### PR TITLE
refactor(Radio): :recycle: Replace radio SVG icon with CSS

### DIFF
--- a/packages/react/src/components/form/Radio/Group/Group.module.css
+++ b/packages/react/src/components/form/Radio/Group/Group.module.css
@@ -1,7 +1,3 @@
-.alignToLegend {
-  margin-left: calc(var(--fds-spacing-2) * -1);
-}
-
 .inline {
   display: flex;
   flex-direction: row;

--- a/packages/react/src/components/form/Radio/Group/Group.tsx
+++ b/packages/react/src/components/form/Radio/Group/Group.tsx
@@ -72,14 +72,7 @@ export const RadioGroup = forwardRef<HTMLFieldSetElement, RadioGroupProps>(
             required,
           }}
         >
-          <div
-            className={cl(
-              !rest.hideLegend && classes.alignToLegend,
-              inline && classes.inline,
-            )}
-          >
-            {children}
-          </div>
+          <div className={cl(inline && classes.inline)}>{children}</div>
         </RadioGroupContext.Provider>
       </Fieldset>
     );

--- a/packages/react/src/components/form/Radio/Radio.module.css
+++ b/packages/react/src/components/form/Radio/Radio.module.css
@@ -1,4 +1,5 @@
 .container {
+  --fds-radio-icon-size: 1.75rem;
   --fds-radio-focus-border-width: 3px;
   --fds-radio-background: var(--fds-semantic-background-default);
   --fds-radio-hover-color: var(--fds-semantic-surface-info-subtle-hover);
@@ -22,8 +23,8 @@
 /* Radio */
 .label::before {
   content: '';
-  width: 1.75rem;
-  height: 1.75rem;
+  width: var(--fds-radio-icon-size);
+  height: var(--fds-radio-icon-size);
   box-shadow: inset 0 0 0 2px var(--fds-radio-border-color);
   background: var(--fds-radio-background);
   border-radius: 50%;
@@ -33,7 +34,7 @@
 }
 
 .description {
-  padding-left: calc(1.75rem + 12px + var(--fds-spacing-1));
+  padding-left: calc(var(--fds-radio-icon-size) + 12px + var(--fds-spacing-1));
   margin-top: calc(var(--fds-spacing-2) * -1);
   color: var(--fds-semantic-text-neutral-subtle);
 }
@@ -58,48 +59,6 @@
 .disabled > .label::before,
 .disabled > .description {
   opacity: var(--fds-opacity-disabled);
-}
-
-.small .label::before {
-  height: 1.5rem;
-  width: 1.5rem;
-}
-
-.small .input {
-  left: -0.25rem;
-  top: -0.25rem;
-}
-
-.small .description {
-  padding-left: calc(1.5rem + 12px + var(--fds-spacing-1));
-}
-
-.medium .label::before {
-  width: 1.75rem;
-  height: 1.75rem;
-}
-
-.medium .input {
-  left: 0;
-  top: 0;
-}
-
-.medium .description {
-  padding-left: calc(1.75rem + 12px + var(--fds-spacing-1));
-}
-
-.large .label::before {
-  width: 2rem;
-  height: 2rem;
-}
-
-.large .input {
-  left: 0;
-  top: 0.25rem;
-}
-
-.large .description {
-  padding-left: calc(2rem + 12px + var(--fds-spacing-1));
 }
 
 .input:focus-visible + .label::before {
@@ -161,31 +120,52 @@
   }
 }
 
-/** Sizing mess for now... */
+/** Sizing */
 
-.container.small {
-  min-width: var(--fds-sizing-8);
-}
-
-.container.medium {
-  min-width: var(--fds-sizing-10);
-}
-
-.container.large {
-  min-width: var(--fds-sizing-12);
-}
-
-.container.small,
-.container.small .label {
+.small,
+.small .label {
   min-height: var(--fds-sizing-8);
 }
 
-.container.medium,
-.container.medium .label {
+.medium,
+.medium .label {
   min-height: var(--fds-sizing-10);
 }
 
-.container.large,
-.container.large .label {
+.large,
+.large .label {
   min-height: var(--fds-sizing-12);
+}
+
+.small {
+  --fds-radio-icon-size: 1.5rem;
+
+  min-width: var(--fds-sizing-8);
+}
+
+.small .input {
+  left: -0.25rem;
+  top: -0.25rem;
+}
+
+.medium {
+  --fds-radio-icon-size: 1.75rem;
+
+  min-width: var(--fds-sizing-10);
+}
+
+.medium .input {
+  left: 0;
+  top: 0;
+}
+
+.large {
+  --fds-radio-icon-size: 2rem;
+
+  min-width: var(--fds-sizing-12);
+}
+
+.large .input {
+  left: 0;
+  top: 0.25rem;
 }

--- a/packages/react/src/components/form/Radio/Radio.module.css
+++ b/packages/react/src/components/form/Radio/Radio.module.css
@@ -63,14 +63,18 @@
   background: var(--fds-radio-circle-color);
 }
 
-.input:checked:not(:focus-visible) + .label::before {
+.input:checked:not(:disabled, :focus-visible) + .label::before {
   box-shadow: inset 0 0 0 2px var(--fds-radio-circle-color), inset 0 0 0 6px #fff;
+}
+
+.error > .input:not(:disabled, :focus-visible) + .label::before {
+  --fds-radio-circle-color: var(--fds-semantic-border-danger-default);
 }
 
 /* Only use hover for non-touch devices to prevent sticky-hovering */
 @media (hover: hover) and (pointer: fine) {
   .input:hover:not(:checked) + .label::before {
-    --fds-radio-circle-color: var(--fds-semantic-border-input-default);
+    --fds-radio-circle-color: var(--fds-semantic-border-input-hover);
 
     box-shadow: 0 0 0 6px var(--fds-semantic-surface-info-subtle-hover), inset 0 0 0 2px var(--fds-radio-circle-color);
   }

--- a/packages/react/src/components/form/Radio/Radio.module.css
+++ b/packages/react/src/components/form/Radio/Radio.module.css
@@ -95,24 +95,24 @@
 /* Only use hover for non-touch devices to prevent sticky-hovering
   "input:not(:read-only)" does not work so using ".container:not(.readonly) >" instead */
 @media (hover: hover) and (pointer: fine) {
-  .container:not(.readonly) > .label:hover,
-  .container:not(.readonly) > .input:hover + .label {
+  .container:not(.readonly, .disabled) > .label:hover,
+  .container:not(.readonly, .disabled) > .input:hover + .label {
     color: var(--fds-semantic-text-action-hover);
   }
 
-  .container:not(.readonly) > .input:hover:not(:checked) + .label::before {
+  .container:not(.readonly, .disabled) > .input:hover:not(:checked) + .label::before {
     --fds-radio-border-color: var(--fds-semantic-border-input-hover);
 
     box-shadow: var(--fds-radio-border__hover), inset 0 0 0 2px var(--fds-radio-border-color);
   }
 
-  .container:not(.readonly) > .input:hover:checked + .label::before {
+  .container:not(.readonly, .disabled) > .input:hover:checked + .label::before {
     --fds-radio-border-color: var(--fds-semantic-border-input-hover);
 
     box-shadow: var(--fds-radio-border__hover), inset 0 0 0 2px var(--fds-radio-border-color), inset 0 0 0 6px var(--fds-radio-background);
   }
 
-  .container:not(.readonly) > .input:hover:checked:focus-visible + .label::before {
+  .container:not(.readonly, .disabled) > .input:hover:checked:focus-visible + .label::before {
     box-shadow: var(--fds-radio-border__hover), inset 0 0 0 var(--fds-radio-focus-border-width) var(--fds-semantic-border-focus-boxshadow),
       inset 0 0 0 6px var(--fds-radio-background);
   }

--- a/packages/react/src/components/form/Radio/Radio.module.css
+++ b/packages/react/src/components/form/Radio/Radio.module.css
@@ -46,6 +46,32 @@
   cursor: pointer;
 }
 
+.label::before {
+  content: '';
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 40px;
+  height: 40px;
+  border: 2px solid;
+  border-radius: 50%;
+  background: #0000;
+}
+
+.label::after {
+  content: '';
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  width: 0;
+  height: 0;
+  border: 10px solid;
+  border-radius: 50%;
+  opacity: 0;
+  background: currentcolor;
+}
+
 .description {
   padding-left: 3px;
   margin-top: calc(var(--fds-spacing-2) * -1);

--- a/packages/react/src/components/form/Radio/Radio.module.css
+++ b/packages/react/src/components/form/Radio/Radio.module.css
@@ -46,6 +46,7 @@
   cursor: pointer;
 }
 
+/* Circle */
 .label::before {
   content: '';
   box-sizing: border-box;
@@ -59,17 +60,32 @@
   background: #0000;
 }
 
+.input:focus-visible + .label::before {
+  --fds-focus-border-width: 3px;
+
+  outline: var(--fds-focus-border-width) solid var(--fds-semantic-border-focus-outline);
+  outline-offset: var(--fds-focus-border-width);
+  box-shadow: 0 0 0 var(--fds-focus-border-width) var(--fds-semantic-border-focus-boxshadow);
+}
+
+/* Dot */
 .label::after {
+  --fdsc-radio__dot-size: calc(var(--fds-sizing-6) / 4);
+
   content: '';
   position: absolute;
-  top: 10px;
-  left: 10px;
+  top: var(--fdsc-radio__dot-size);
+  left: var(--fdsc-radio__dot-size);
   width: 0;
   height: 0;
-  border: 10px solid;
+  border: var(--fdsc-radio__dot-size) solid;
   border-radius: 50%;
   opacity: 0;
   background: currentcolor;
+}
+
+.input:checked + .label::after {
+  opacity: 1;
 }
 
 .description {
@@ -229,17 +245,17 @@
   min-height: var(--fds-sizing-12);
 }
 
-.container.small .control {
-  width: var(--fds-sizing-8);
-  height: var(--fds-sizing-8);
+.container.small .label::before {
+  width: var(--fds-sizing-5);
+  height: var(--fds-sizing-5);
 }
 
-.container.medium .control {
-  width: var(--fds-sizing-10);
-  height: var(--fds-sizing-10);
+.container.medium .label::before {
+  width: var(--fds-sizing-6);
+  height: var(--fds-sizing-6);
 }
 
-.container.large .control {
-  width: var(--fds-sizing-12);
-  height: var(--fds-sizing-12);
+.container.large .label::before {
+  width: var(--fds-sizing-7);
+  height: var(--fds-sizing-7);
 }

--- a/packages/react/src/components/form/Radio/Radio.module.css
+++ b/packages/react/src/components/form/Radio/Radio.module.css
@@ -22,13 +22,14 @@
 /* Radio */
 .label::before {
   content: '';
-  box-sizing: border-box;
   width: var(--fds-sizing-6);
   height: var(--fds-sizing-6);
   box-shadow: inset 0 0 0 2px var(--fds-radio-border-color);
   background: var(--fds-radio-background);
   border-radius: 50%;
   flex-shrink: 0;
+  margin-inline: 6px;
+  margin-block: 6px;
 }
 
 .description {
@@ -46,6 +47,7 @@
   z-index: 1;
   opacity: 0;
   cursor: pointer;
+  margin: 0;
 }
 
 .disabled > .input,
@@ -66,8 +68,13 @@
   width: var(--fds-sizing-5);
 }
 
+.small .input {
+  left: calc(var(--fds-spacing-1) * -1);
+  top: calc(var(--fds-spacing-1) * -1);
+}
+
 .small .description {
-  padding-left: var(--fds-sizing-6);
+  padding-left: calc(var(--fds-sizing-6) + 12px);
 }
 
 .medium .label::before {
@@ -76,8 +83,13 @@
   width: var(--fds-sizing-6);
 }
 
+.medium .input {
+  left: calc(var(--fds-spacing-1) + 6px * -1);
+  top: 0;
+}
+
 .medium .description {
-  padding-left: var(--fds-sizing-7);
+  padding-left: calc(var(--fds-sizing-7) + 12px);
 }
 
 .large .label::before {
@@ -86,8 +98,13 @@
   width: var(--fds-sizing-7);
 }
 
+.large .input {
+  left: 0;
+  top: var(--fds-spacing-1);
+}
+
 .large .description {
-  padding-left: var(--fds-sizing-8);
+  padding-left: calc(var(--fds-sizing-8) + 12px);
 }
 
 .input:focus-visible + .label::before {

--- a/packages/react/src/components/form/Radio/Radio.module.css
+++ b/packages/react/src/components/form/Radio/Radio.module.css
@@ -4,7 +4,7 @@
   --fds-radio-hover-color: var(--fds-semantic-surface-info-subtle-hover);
   --fds-radio-border-color: var(--fds-semantic-border-input-default);
   --fds-radio-border-inner__checked: inset 0 0 0 6px var(--fds-radio-background); /** Adjust for dot size */
-  --fds-radio-border__hover: 0 0 6px var(--fds-semantic-surface-info-subtle-hover);
+  --fds-radio-border__hover: 0 0 0 6px var(--fds-semantic-surface-info-subtle-hover);
 
   position: relative;
 }
@@ -146,11 +146,11 @@
   .input:hover:not(:checked) + .label::before {
     --fds-radio-border-color: var(--fds-semantic-border-input-hover);
 
-    box-shadow: 0 var(--fds-radio-border__hover), inset 0 0 0 2px var(--fds-radio-border-color);
+    box-shadow: var(--fds-radio-border__hover), inset 0 0 0 2px var(--fds-radio-border-color);
   }
 
   .input:hover:checked:not(:focus-visible, :read-only) + .label::before {
-    box-shadow: 0 var(--fds-radio-border__hover), inset 0 0 0 2px var(--fds-radio-border-color), var(--fds-radio-border-inner__checked);
+    box-shadow: var(--fds-radio-border__hover), inset 0 0 0 2px var(--fds-radio-border-color), var(--fds-radio-border-inner__checked);
   }
 
   .input:hover:checked:focus-visible + .label::before {

--- a/packages/react/src/components/form/Radio/Radio.module.css
+++ b/packages/react/src/components/form/Radio/Radio.module.css
@@ -50,26 +50,35 @@
 .label::before {
   content: '';
   box-sizing: border-box;
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 40px;
-  height: 40px;
-  border: 2px solid;
+  width: var(--fds-sizing-6);
+  height: var(--fds-sizing-6);
+  box-shadow: inset 0 0 0 2px var(--fds-semantic-border-input-default);
+  /* border: 2px solid var(--fds-semantic-border-input-default); */
   border-radius: 50%;
   background: #0000;
+  flex-shrink: 0;
+  margin-block: 2px;
+  margin-inline: 2px;
 }
 
 .input:focus-visible + .label::before {
   --fds-focus-border-width: 3px;
 
   outline: var(--fds-focus-border-width) solid var(--fds-semantic-border-focus-outline);
-  outline-offset: var(--fds-focus-border-width);
-  box-shadow: 0 0 0 var(--fds-focus-border-width) var(--fds-semantic-border-focus-boxshadow);
+  /* outline-offset: var(--fds-focus-border-width); */
+  box-shadow: inset 0 0 0 var(--fds-focus-border-width) var(--fds-semantic-border-focus-boxshadow);
+}
+
+.input:checked + .label::before {
+  background: var(--fds-semantic-border-input-hover);
+}
+
+.input:checked:not(:focus-visible) + .label::before {
+  box-shadow: inset 0 0 0 3px #fff;
 }
 
 /* Dot */
-.label::after {
+/* .label::after {
   --fdsc-radio__dot-size: calc(var(--fds-sizing-6) / 4);
 
   content: '';
@@ -86,7 +95,7 @@
 
 .input:checked + .label::after {
   opacity: 1;
-}
+} */
 
 .description {
   padding-left: 3px;

--- a/packages/react/src/components/form/Radio/Radio.module.css
+++ b/packages/react/src/components/form/Radio/Radio.module.css
@@ -1,13 +1,16 @@
 .container {
+  --fds-radio-focus-border-width: 3px;
+  --fds-radio-background: var(--fds-semantic-background-default);
+  --fds-radio-hover-color: var(--fds-semantic-surface-info-subtle-hover);
+  --fds-radio-border-color: var(--fds-semantic-border-input-default);
+  --fds-radio-border: inset 0 0 0 2px var(--fds-radio-border-color);
+  --fds-radio-border-inner__checked: inset 0 0 0 6px var(--fds-radio-background); /** Adjust for dot size */
+  --fds-radio-border__hover: 0 0 6px var(--fds-semantic-surface-info-subtle-hover);
+
   position: relative;
 }
 
-.spacing {
-  padding-left: var(--fds-sizing-8);
-}
-
 .label {
-  padding-left: 3px;
   min-height: var(--fds-sizing-10);
   min-width: min-content;
   display: inline-flex;
@@ -19,14 +22,6 @@
 
 /* Radio */
 .label::before {
-  --fds-radio-focus-border-width: 3px;
-  --fds-radio-background: var(--fds-semantic-background-default);
-  --fds-radio-hover-color: var(--fds-semantic-surface-info-subtle-hover);
-  --fds-radio-border-color: var(--fds-semantic-border-input-default);
-  --fds-radio-border: inset 0 0 0 2px var(--fds-radio-border-color);
-  --fds-radio-border-inner__checked: inset 0 0 0 6px var(--fds-radio-background); /** Adjust for dot size */
-  --fds-radio-border__hover: 0 0 6px var(--fds-semantic-surface-info-subtle-hover);
-
   content: '';
   box-sizing: border-box;
   width: var(--fds-sizing-6);
@@ -37,12 +32,20 @@
   flex-shrink: 0;
 }
 
+.description {
+  padding-left: var(--fds-sizing-7);
+  margin-top: calc(var(--fds-spacing-2) * -1);
+  color: var(--fds-semantic-text-neutral-subtle);
+}
+
 .input {
-  height: 44px;
-  width: 44px;
+  position: absolute;
+  width: 2.75rem;
+  height: 2.75rem;
+  top: 0;
+  left: -0.75rem;
+  z-index: 1;
   opacity: 0;
-  margin: 0;
-  grid-area: input;
   cursor: pointer;
 }
 
@@ -58,21 +61,33 @@
 }
 
 .small .label::before {
-  aspect-ratio: 1/1;
+  aspect-ratio: 1;
   height: auto;
   width: var(--fds-sizing-5);
 }
 
+.small .description {
+  padding-left: var(--fds-sizing-6);
+}
+
 .medium .label::before {
-  aspect-ratio: 1/1;
+  aspect-ratio: 1;
   height: auto;
   width: var(--fds-sizing-6);
 }
 
+.medium .description {
+  padding-left: var(--fds-sizing-7);
+}
+
 .large .label::before {
-  aspect-ratio: 1/1;
+  aspect-ratio: 1;
   height: auto;
   width: var(--fds-sizing-7);
+}
+
+.large .description {
+  padding-left: var(--fds-sizing-8);
 }
 
 .input:focus-visible + .label::before {
@@ -127,25 +142,7 @@
   }
 }
 
-.description {
-  padding-left: 3px;
-  margin-top: calc(var(--fds-spacing-2) * -1);
-  color: var(--fds-semantic-text-neutral-subtle);
-}
-
 /** Sizing mess for now... */
-
-.container.small.spacing {
-  padding-left: calc(var(--fds-spacing-8));
-}
-
-.container.medium.spacing {
-  padding-left: var(--fds-spacing-10);
-}
-
-.container.large.spacing {
-  padding-left: calc(var(--fds-spacing-12));
-}
 
 .container.small {
   min-width: var(--fds-sizing-8);

--- a/packages/react/src/components/form/Radio/Radio.module.css
+++ b/packages/react/src/components/form/Radio/Radio.module.css
@@ -1,5 +1,5 @@
 .container {
-  --fds-radio-icon-size: 1.75rem;
+  --fds-radio-size: 1.75rem;
   --fds-radio-focus-border-width: 3px;
   --fds-radio-background: var(--fds-semantic-background-default);
   --fds-radio-border-color: var(--fds-semantic-border-input-default);
@@ -21,8 +21,8 @@
 /* Radio */
 .label::before {
   content: '';
-  width: var(--fds-radio-icon-size);
-  height: var(--fds-radio-icon-size);
+  width: var(--fds-radio-size);
+  height: var(--fds-radio-size);
   box-shadow: inset 0 0 0 2px var(--fds-radio-border-color);
   background: var(--fds-radio-background);
   border-radius: 50%;
@@ -32,7 +32,7 @@
 }
 
 .description {
-  padding-left: calc(var(--fds-radio-icon-size) + 12px + var(--fds-spacing-1));
+  padding-left: calc(var(--fds-radio-size) + 12px + var(--fds-spacing-1));
   margin-top: calc(var(--fds-spacing-2) * -1);
   color: var(--fds-semantic-text-neutral-subtle);
 }
@@ -136,7 +136,7 @@
 }
 
 .small {
-  --fds-radio-icon-size: 1.5rem;
+  --fds-radio-size: 1.5rem;
 
   min-width: var(--fds-sizing-8);
 }
@@ -147,7 +147,7 @@
 }
 
 .medium {
-  --fds-radio-icon-size: 1.75rem;
+  --fds-radio-size: 1.75rem;
 
   min-width: var(--fds-sizing-10);
 }
@@ -158,7 +158,7 @@
 }
 
 .large {
-  --fds-radio-icon-size: 2rem;
+  --fds-radio-size: 2rem;
 
   min-width: var(--fds-sizing-12);
 }

--- a/packages/react/src/components/form/Radio/Radio.module.css
+++ b/packages/react/src/components/form/Radio/Radio.module.css
@@ -143,13 +143,20 @@
 
 /* Only use hover for non-touch devices to prevent sticky-hovering */
 @media (hover: hover) and (pointer: fine) {
+  .label:hover,
+  .input:hover + .label {
+    color: var(--fds-semantic-text-action-hover);
+  }
+
   .input:hover:not(:checked) + .label::before {
     --fds-radio-border-color: var(--fds-semantic-border-input-hover);
 
     box-shadow: var(--fds-radio-border__hover), inset 0 0 0 2px var(--fds-radio-border-color);
   }
 
-  .input:hover:checked:not(:focus-visible, :read-only) + .label::before {
+  .input:hover:checked + .label::before {
+    --fds-radio-border-color: var(--fds-semantic-border-input-hover);
+
     box-shadow: var(--fds-radio-border__hover), inset 0 0 0 2px var(--fds-radio-border-color), var(--fds-radio-border-inner__checked);
   }
 

--- a/packages/react/src/components/form/Radio/Radio.module.css
+++ b/packages/react/src/components/form/Radio/Radio.module.css
@@ -22,8 +22,8 @@
 /* Radio */
 .label::before {
   content: '';
-  width: var(--fds-sizing-6);
-  height: var(--fds-sizing-6);
+  width: 1.75rem;
+  height: 1.75rem;
   box-shadow: inset 0 0 0 2px var(--fds-radio-border-color);
   background: var(--fds-radio-background);
   border-radius: 50%;
@@ -33,7 +33,7 @@
 }
 
 .description {
-  padding-left: var(--fds-sizing-7);
+  padding-left: calc(1.75rem + 12px + var(--fds-spacing-1));
   margin-top: calc(var(--fds-spacing-2) * -1);
   color: var(--fds-semantic-text-neutral-subtle);
 }
@@ -42,8 +42,6 @@
   position: absolute;
   width: 2.75rem;
   height: 2.75rem;
-  top: 0;
-  left: -0.75rem;
   z-index: 1;
   opacity: 0;
   cursor: pointer;
@@ -63,48 +61,45 @@
 }
 
 .small .label::before {
-  aspect-ratio: 1;
-  height: auto;
-  width: var(--fds-sizing-5);
+  height: 1.5rem;
+  width: 1.5rem;
 }
 
 .small .input {
-  left: calc(var(--fds-spacing-1) * -1);
-  top: calc(var(--fds-spacing-1) * -1);
+  left: -0.25rem;
+  top: -0.25rem;
 }
 
 .small .description {
-  padding-left: calc(var(--fds-sizing-6) + 12px);
+  padding-left: calc(1.5rem + 12px + var(--fds-spacing-1));
 }
 
 .medium .label::before {
-  aspect-ratio: 1;
-  height: auto;
-  width: var(--fds-sizing-6);
+  width: 1.75rem;
+  height: 1.75rem;
 }
 
 .medium .input {
-  left: calc(var(--fds-spacing-1) + 6px * -1);
+  left: 0;
   top: 0;
 }
 
 .medium .description {
-  padding-left: calc(var(--fds-sizing-7) + 12px);
+  padding-left: calc(1.75rem + 12px + var(--fds-spacing-1));
 }
 
 .large .label::before {
-  aspect-ratio: 1;
-  height: auto;
-  width: var(--fds-sizing-7);
+  width: 2rem;
+  height: 2rem;
 }
 
 .large .input {
   left: 0;
-  top: var(--fds-spacing-1);
+  top: 0.25rem;
 }
 
 .large .description {
-  padding-left: calc(var(--fds-sizing-8) + 12px);
+  padding-left: calc(2rem + 12px + var(--fds-spacing-1));
 }
 
 .input:focus-visible + .label::before {

--- a/packages/react/src/components/form/Radio/Radio.module.css
+++ b/packages/react/src/components/form/Radio/Radio.module.css
@@ -6,35 +6,6 @@
   padding-left: var(--fds-sizing-8);
 }
 
-.icon {
-  grid-area: input;
-  pointer-events: none;
-  width: var(--fds-sizing-6);
-  height: var(--fds-sizing-6);
-  margin: auto;
-  overflow: visible;
-}
-
-.radio,
-.radio .icon {
-  border-radius: var(--fds-border_radius-full);
-}
-
-.container.small .icon {
-  width: var(--fds-sizing-5);
-  height: var(--fds-sizing-5);
-}
-
-.container.medium .icon {
-  width: var(--fds-sizing-6);
-  height: var(--fds-sizing-6);
-}
-
-.container.large .icon {
-  width: var(--fds-sizing-7);
-  height: var(--fds-sizing-7);
-}
-
 .label {
   padding-left: 3px;
   min-height: var(--fds-sizing-10);
@@ -46,56 +17,73 @@
   cursor: pointer;
 }
 
-/* Circle */
+/* Radio */
 .label::before {
+  --fds-focus-border-width: 3px;
+  --fds-radio-circle-color: var(--fds-semantic-border-input-default);
+  --fds-radio-hover-color: var(--fds-semantic-surface-info-subtle-hover);
+  --fds-radio-color-background: #fff;
+
   content: '';
   box-sizing: border-box;
   width: var(--fds-sizing-6);
   height: var(--fds-sizing-6);
-  box-shadow: inset 0 0 0 2px var(--fds-semantic-border-input-default);
-  /* border: 2px solid var(--fds-semantic-border-input-default); */
+  box-shadow: inset 0 0 0 2px var(--fds-radio-circle-color);
+  background: var(--fds-radio-color-background);
   border-radius: 50%;
-  background: #0000;
   flex-shrink: 0;
-  margin-block: 2px;
-  margin-inline: 2px;
+}
+
+.container.small .label::before {
+  aspect-ratio: 1/1;
+  height: auto;
+  width: var(--fds-sizing-5);
+}
+
+.container.medium .label::before {
+  aspect-ratio: 1/1;
+  height: auto;
+  width: var(--fds-sizing-6);
+}
+
+.container.large .label::before {
+  aspect-ratio: 1/1;
+  height: auto;
+  width: var(--fds-sizing-7);
 }
 
 .input:focus-visible + .label::before {
-  --fds-focus-border-width: 3px;
-
   outline: var(--fds-focus-border-width) solid var(--fds-semantic-border-focus-outline);
-  /* outline-offset: var(--fds-focus-border-width); */
-  box-shadow: inset 0 0 0 var(--fds-focus-border-width) var(--fds-semantic-border-focus-boxshadow);
+  box-shadow: inset 0 0 0 var(--fds-focus-border-width) var(--fds-semantic-border-focus-boxshadow), inset 0 0 0 6px #fff;
 }
 
 .input:checked + .label::before {
-  background: var(--fds-semantic-border-input-hover);
+  --fds-radio-circle-color: var(--fds-semantic-border-input-hover);
+
+  background: var(--fds-radio-circle-color);
 }
 
 .input:checked:not(:focus-visible) + .label::before {
-  box-shadow: inset 0 0 0 3px #fff;
+  box-shadow: inset 0 0 0 2px var(--fds-radio-circle-color), inset 0 0 0 6px #fff;
 }
 
-/* Dot */
-/* .label::after {
-  --fdsc-radio__dot-size: calc(var(--fds-sizing-6) / 4);
+/* Only use hover for non-touch devices to prevent sticky-hovering */
+@media (hover: hover) and (pointer: fine) {
+  .input:hover:not(:checked) + .label::before {
+    --fds-radio-circle-color: var(--fds-semantic-border-input-default);
 
-  content: '';
-  position: absolute;
-  top: var(--fdsc-radio__dot-size);
-  left: var(--fdsc-radio__dot-size);
-  width: 0;
-  height: 0;
-  border: var(--fdsc-radio__dot-size) solid;
-  border-radius: 50%;
-  opacity: 0;
-  background: currentcolor;
+    box-shadow: 0 0 0 6px var(--fds-semantic-surface-info-subtle-hover), inset 0 0 0 2px var(--fds-radio-circle-color);
+  }
+
+  .input:hover:checked:not(:focus-visible) + .label::before {
+    box-shadow: 0 0 0 6px var(--fds-semantic-surface-info-subtle-hover), inset 0 0 0 2px var(--fds-radio-circle-color), inset 0 0 0 6px #fff;
+  }
+
+  .input:hover:checked:focus-visible + .label::before {
+    box-shadow: 0 0 6px var(--fds-semantic-surface-info-subtle-hover), inset 0 0 0 var(--fds-focus-border-width) var(--fds-semantic-border-focus-boxshadow),
+      inset 0 0 0 6px #fff;
+  }
 }
-
-.input:checked + .label::after {
-  opacity: 1;
-} */
 
 .description {
   padding-left: 3px;
@@ -103,37 +91,21 @@
   color: var(--fds-semantic-text-neutral-subtle);
 }
 
-.control {
-  --fds-inner-focus-border-color: var(--fds-semantic-border-focus-boxshadow);
-  --fds-outer-focus-border-color: var(--fds-semantic-border-focus-outline);
-  --fds-focus-border-width: 3px;
-
-  position: absolute;
-  left: 0;
-  top: 0;
-  width: var(--fds-sizing-10);
-  height: var(--fds-sizing-10);
-  display: inline-grid;
-  grid: [input] 1fr / [input] 1fr;
-  gap: var(--fds-spacing-2);
-  grid-auto-flow: column;
-}
-
 .input {
-  height: 100%;
-  width: 100%;
+  height: 44px;
+  width: 44px;
   opacity: 0;
   margin: 0;
   grid-area: input;
   cursor: pointer;
 }
 
-.readonly > .control > .input,
+.readonly > .input,
 .readonly > .label {
   cursor: default;
 }
 
-.disabled > .control .input,
+.disabled > .input,
 .disabled > .label {
   cursor: not-allowed;
   color: var(--fds-semantic-border-neutral-subtle);
@@ -195,24 +167,6 @@
   fill: var(--fds-semantic-border-neutral-default);
 }
 
-/* Only use hover for non-touch devices to prevent sticky-hovering */
-@media (hover: hover) and (pointer: fine) {
-  .container:not(.disabled, .readonly) > .control:hover,
-  .container:not(.disabled, .readonly):has(.label:hover) > .control {
-    background: var(--fds-semantic-surface-info-subtle-hover);
-  }
-
-  .container:not(.disabled, .readonly) > .label:hover,
-  .container:not(.disabled, .readonly) > .control:hover ~ .label {
-    color: var(--fds-semantic-border-input-hover);
-  }
-
-  .container:not(.disabled, .readonly) > .control:hover > .icon > .box,
-  .container:not(.disabled, .readonly):has(.label:hover) > .control > .icon > .box {
-    stroke: var(--fds-semantic-border-input-hover);
-  }
-}
-
 /** Sizing mess for now... */
 
 .container.small.spacing {
@@ -252,19 +206,4 @@
 .container.large,
 .container.large .label {
   min-height: var(--fds-sizing-12);
-}
-
-.container.small .label::before {
-  width: var(--fds-sizing-5);
-  height: var(--fds-sizing-5);
-}
-
-.container.medium .label::before {
-  width: var(--fds-sizing-6);
-  height: var(--fds-sizing-6);
-}
-
-.container.large .label::before {
-  width: var(--fds-sizing-7);
-  height: var(--fds-sizing-7);
 }

--- a/packages/react/src/components/form/Radio/Radio.module.css
+++ b/packages/react/src/components/form/Radio/Radio.module.css
@@ -19,80 +19,22 @@
 
 /* Radio */
 .label::before {
-  --fds-focus-border-width: 3px;
-  --fds-radio-circle-color: var(--fds-semantic-border-input-default);
+  --fds-radio-focus-border-width: 3px;
+  --fds-radio-background: var(--fds-semantic-background-default);
   --fds-radio-hover-color: var(--fds-semantic-surface-info-subtle-hover);
-  --fds-radio-color-background: #fff;
+  --fds-radio-border-color: var(--fds-semantic-border-input-default);
+  --fds-radio-border: inset 0 0 0 2px var(--fds-radio-border-color);
+  --fds-radio-border-inner__checked: inset 0 0 0 6px var(--fds-radio-background); /** Adjust for dot size */
+  --fds-radio-border__hover: 0 0 6px var(--fds-semantic-surface-info-subtle-hover);
 
   content: '';
   box-sizing: border-box;
   width: var(--fds-sizing-6);
   height: var(--fds-sizing-6);
-  box-shadow: inset 0 0 0 2px var(--fds-radio-circle-color);
-  background: var(--fds-radio-color-background);
+  box-shadow: var(--fds-radio-border);
+  background: var(--fds-radio-background);
   border-radius: 50%;
   flex-shrink: 0;
-}
-
-.container.small .label::before {
-  aspect-ratio: 1/1;
-  height: auto;
-  width: var(--fds-sizing-5);
-}
-
-.container.medium .label::before {
-  aspect-ratio: 1/1;
-  height: auto;
-  width: var(--fds-sizing-6);
-}
-
-.container.large .label::before {
-  aspect-ratio: 1/1;
-  height: auto;
-  width: var(--fds-sizing-7);
-}
-
-.input:focus-visible + .label::before {
-  outline: var(--fds-focus-border-width) solid var(--fds-semantic-border-focus-outline);
-  box-shadow: inset 0 0 0 var(--fds-focus-border-width) var(--fds-semantic-border-focus-boxshadow), inset 0 0 0 6px #fff;
-}
-
-.input:checked + .label::before {
-  --fds-radio-circle-color: var(--fds-semantic-border-input-hover);
-
-  background: var(--fds-radio-circle-color);
-}
-
-.input:checked:not(:disabled, :focus-visible) + .label::before {
-  box-shadow: inset 0 0 0 2px var(--fds-radio-circle-color), inset 0 0 0 6px #fff;
-}
-
-.error > .input:not(:disabled, :focus-visible) + .label::before {
-  --fds-radio-circle-color: var(--fds-semantic-border-danger-default);
-}
-
-/* Only use hover for non-touch devices to prevent sticky-hovering */
-@media (hover: hover) and (pointer: fine) {
-  .input:hover:not(:checked) + .label::before {
-    --fds-radio-circle-color: var(--fds-semantic-border-input-hover);
-
-    box-shadow: 0 0 0 6px var(--fds-semantic-surface-info-subtle-hover), inset 0 0 0 2px var(--fds-radio-circle-color);
-  }
-
-  .input:hover:checked:not(:focus-visible) + .label::before {
-    box-shadow: 0 0 0 6px var(--fds-semantic-surface-info-subtle-hover), inset 0 0 0 2px var(--fds-radio-circle-color), inset 0 0 0 6px #fff;
-  }
-
-  .input:hover:checked:focus-visible + .label::before {
-    box-shadow: 0 0 6px var(--fds-semantic-surface-info-subtle-hover), inset 0 0 0 var(--fds-focus-border-width) var(--fds-semantic-border-focus-boxshadow),
-      inset 0 0 0 6px #fff;
-  }
-}
-
-.description {
-  padding-left: 3px;
-  margin-top: calc(var(--fds-spacing-2) * -1);
-  color: var(--fds-semantic-text-neutral-subtle);
 }
 
 .input {
@@ -104,71 +46,91 @@
   cursor: pointer;
 }
 
+.disabled > .input,
+.disabled > .label,
+.disabled > .label::before {
+  cursor: not-allowed;
+}
+
+.disabled > .label,
+.disabled > .label::before {
+  opacity: var(--fds-opacity-disabled);
+}
+
+.small .label::before {
+  aspect-ratio: 1/1;
+  height: auto;
+  width: var(--fds-sizing-5);
+}
+
+.medium .label::before {
+  aspect-ratio: 1/1;
+  height: auto;
+  width: var(--fds-sizing-6);
+}
+
+.large .label::before {
+  aspect-ratio: 1/1;
+  height: auto;
+  width: var(--fds-sizing-7);
+}
+
+.input:focus-visible + .label::before {
+  outline: var(--fds-radio-focus-border-width) solid var(--fds-semantic-border-focus-outline);
+  box-shadow: inset 0 0 0 var(--fds-radio-focus-border-width) var(--fds-semantic-border-focus-boxshadow), var(--fds-radio-border-inner__checked);
+}
+
+.input:checked + .label::before {
+  --fds-radio-border-color: var(--fds-semantic-border-input-hover);
+
+  background: var(--fds-radio-border-color);
+}
+
+.readonly > .input + .label::before {
+  --fds-radio-border-color: var(--fds-semantic-border-neutral-subtle);
+}
+
+.input:checked:not(:focus-visible) + .label::before {
+  box-shadow: var(--fds-radio-border), var(--fds-radio-border-inner__checked);
+}
+
 .readonly > .input,
 .readonly > .label {
   cursor: default;
 }
 
-.disabled > .input,
-.disabled > .label {
-  cursor: not-allowed;
-  color: var(--fds-semantic-border-neutral-subtle);
+.readonly > .input:checked + .label::before {
+  --fds-radio-background: var(--fds-semantic-surface-neutral-subtle);
+
+  background: var(--fds-semantic-border-neutral-default);
 }
 
-.disabled > .description {
-  color: var(--fds-semantic-border-neutral-subtle);
+.error > .input:not(:disabled, :focus-visible) + .label::before {
+  --fds-radio-border-color: var(--fds-semantic-border-danger-default);
 }
 
-.input:not(:checked) ~ .icon .checked {
-  display: none;
+/* Only use hover for non-touch devices to prevent sticky-hovering */
+@media (hover: hover) and (pointer: fine) {
+  .input:hover:not(:checked) + .label::before {
+    --fds-radio-border-color: var(--fds-semantic-border-input-hover);
+
+    box-shadow: 0 var(--fds-radio-border__hover), var(--fds-radio-border);
+  }
+
+  .input:hover:checked:not(:focus-visible, :read-only) + .label::before {
+    box-shadow: 0 var(--fds-radio-border__hover), var(--fds-radio-border), var(--fds-radio-border-inner__checked);
+  }
+
+  .input:hover:checked:focus-visible + .label::before {
+    box-shadow: var(--fds-radio-border__hover), inset 0 0 0 var(--fds-radio-focus-border-width) var(--fds-semantic-border-focus-boxshadow),
+      var(--fds-radio-border-inner__checked);
+  }
 }
 
-.input:checked ~ .icon .checked {
-  display: inline;
-  fill: var(--fds-semantic-border-input-hover);
-}
-
-.input:not(:checked) ~ .icon .box {
-  stroke: var(--fds-semantic-border-input-default);
-}
-
-.input:checked ~ .icon .box {
-  stroke: var(--fds-semantic-border-input-hover);
-}
-
-.input:disabled ~ .icon .box {
-  stroke: var(--fds-semantic-border-neutral-subtle);
-}
-
-.input:focus-visible ~ .icon {
-  outline: var(--fds-focus-border-width) solid var(--fds-outer-focus-border-color);
-  outline-offset: 0;
-}
-
-.input:focus-visible ~ .icon .box {
-  stroke: var(--fds-semantic-border-focus-boxshadow);
-  stroke-width: var(--fds-focus-border-width);
-}
-
-.input:disabled ~ .icon .checked {
-  fill: var(--fds-semantic-border-neutral-subtle);
-}
-
-.error .input:not(:disabled, :focus-visible) ~ .icon .box {
-  stroke: var(--fds-semantic-border-danger-default);
-}
-
-.error .input:not(:disabled, :focus-visible) ~ .icon .checked {
-  fill: var(--fds-semantic-border-danger-default);
-}
-
-.readonly .input:read-only:not(:focus-visible) ~ .icon .box {
-  stroke: var(--fds-semantic-border-neutral-subtle);
-  fill: var(--fds-semantic-background-subtle);
-}
-
-.readonly .input:read-only:not(:focus-visible):is(:checked) ~ .icon .checked {
-  fill: var(--fds-semantic-border-neutral-default);
+.description {
+  padding-left: 3px;
+  margin-top: calc(var(--fds-spacing-2) * -1);
+  color: var(--fds-semantic-text-neutral-subtle);
 }
 
 /** Sizing mess for now... */

--- a/packages/react/src/components/form/Radio/Radio.module.css
+++ b/packages/react/src/components/form/Radio/Radio.module.css
@@ -2,9 +2,7 @@
   --fds-radio-icon-size: 1.75rem;
   --fds-radio-focus-border-width: 3px;
   --fds-radio-background: var(--fds-semantic-background-default);
-  --fds-radio-hover-color: var(--fds-semantic-surface-info-subtle-hover);
   --fds-radio-border-color: var(--fds-semantic-border-input-default);
-  --fds-radio-border-inner__checked: inset 0 0 0 6px var(--fds-radio-background); /** Adjust for dot size */
   --fds-radio-border__hover: 0 0 0 6px var(--fds-semantic-surface-info-subtle-hover);
 
   position: relative;
@@ -63,7 +61,7 @@
 
 .input:focus-visible + .label::before {
   outline: var(--fds-radio-focus-border-width) solid var(--fds-semantic-border-focus-outline);
-  box-shadow: inset 0 0 0 var(--fds-radio-focus-border-width) var(--fds-semantic-border-focus-boxshadow), var(--fds-radio-border-inner__checked);
+  box-shadow: inset 0 0 0 var(--fds-radio-focus-border-width) var(--fds-semantic-border-focus-boxshadow), inset 0 0 0 6px var(--fds-radio-background);
 }
 
 .input:checked + .label::before {
@@ -74,10 +72,11 @@
 
 .readonly > .input + .label::before {
   --fds-radio-border-color: var(--fds-semantic-border-neutral-subtle);
+  --fds-radio-background: var(--fds-semantic-surface-neutral-subtle);
 }
 
 .input:checked:not(:focus-visible) + .label::before {
-  box-shadow: inset 0 0 0 2px var(--fds-radio-border-color), var(--fds-radio-border-inner__checked);
+  box-shadow: inset 0 0 0 2px var(--fds-radio-border-color), inset 0 0 0 6px var(--fds-radio-background);
 }
 
 .readonly > .input,
@@ -86,8 +85,6 @@
 }
 
 .readonly > .input:checked + .label::before {
-  --fds-radio-background: var(--fds-semantic-surface-neutral-subtle);
-
   background: var(--fds-semantic-border-neutral-default);
 }
 
@@ -95,28 +92,29 @@
   --fds-radio-border-color: var(--fds-semantic-border-danger-default);
 }
 
-/* Only use hover for non-touch devices to prevent sticky-hovering */
+/* Only use hover for non-touch devices to prevent sticky-hovering
+  "input:not(:read-only)" does not work so using ".container:not(.readonly) >" instead */
 @media (hover: hover) and (pointer: fine) {
-  .label:hover,
-  .input:hover + .label {
+  .container:not(.readonly) > .label:hover,
+  .container:not(.readonly) > .input:hover + .label {
     color: var(--fds-semantic-text-action-hover);
   }
 
-  .input:hover:not(:checked) + .label::before {
+  .container:not(.readonly) > .input:hover:not(:checked) + .label::before {
     --fds-radio-border-color: var(--fds-semantic-border-input-hover);
 
     box-shadow: var(--fds-radio-border__hover), inset 0 0 0 2px var(--fds-radio-border-color);
   }
 
-  .input:hover:checked + .label::before {
+  .container:not(.readonly) > .input:hover:checked + .label::before {
     --fds-radio-border-color: var(--fds-semantic-border-input-hover);
 
-    box-shadow: var(--fds-radio-border__hover), inset 0 0 0 2px var(--fds-radio-border-color), var(--fds-radio-border-inner__checked);
+    box-shadow: var(--fds-radio-border__hover), inset 0 0 0 2px var(--fds-radio-border-color), inset 0 0 0 6px var(--fds-radio-background);
   }
 
-  .input:hover:checked:focus-visible + .label::before {
+  .container:not(.readonly) > .input:hover:checked:focus-visible + .label::before {
     box-shadow: var(--fds-radio-border__hover), inset 0 0 0 var(--fds-radio-focus-border-width) var(--fds-semantic-border-focus-boxshadow),
-      var(--fds-radio-border-inner__checked);
+      inset 0 0 0 6px var(--fds-radio-background);
   }
 }
 

--- a/packages/react/src/components/form/Radio/Radio.module.css
+++ b/packages/react/src/components/form/Radio/Radio.module.css
@@ -3,7 +3,6 @@
   --fds-radio-background: var(--fds-semantic-background-default);
   --fds-radio-hover-color: var(--fds-semantic-surface-info-subtle-hover);
   --fds-radio-border-color: var(--fds-semantic-border-input-default);
-  --fds-radio-border: inset 0 0 0 2px var(--fds-radio-border-color);
   --fds-radio-border-inner__checked: inset 0 0 0 6px var(--fds-radio-background); /** Adjust for dot size */
   --fds-radio-border__hover: 0 0 6px var(--fds-semantic-surface-info-subtle-hover);
 
@@ -26,7 +25,7 @@
   box-sizing: border-box;
   width: var(--fds-sizing-6);
   height: var(--fds-sizing-6);
-  box-shadow: var(--fds-radio-border);
+  box-shadow: inset 0 0 0 2px var(--fds-radio-border-color);
   background: var(--fds-radio-background);
   border-radius: 50%;
   flex-shrink: 0;
@@ -56,7 +55,8 @@
 }
 
 .disabled > .label,
-.disabled > .label::before {
+.disabled > .label::before,
+.disabled > .description {
   opacity: var(--fds-opacity-disabled);
 }
 
@@ -106,7 +106,7 @@
 }
 
 .input:checked:not(:focus-visible) + .label::before {
-  box-shadow: var(--fds-radio-border), var(--fds-radio-border-inner__checked);
+  box-shadow: inset 0 0 0 2px var(--fds-radio-border-color), var(--fds-radio-border-inner__checked);
 }
 
 .readonly > .input,
@@ -129,11 +129,11 @@
   .input:hover:not(:checked) + .label::before {
     --fds-radio-border-color: var(--fds-semantic-border-input-hover);
 
-    box-shadow: 0 var(--fds-radio-border__hover), var(--fds-radio-border);
+    box-shadow: 0 var(--fds-radio-border__hover), inset 0 0 0 2px var(--fds-radio-border-color);
   }
 
   .input:hover:checked:not(:focus-visible, :read-only) + .label::before {
-    box-shadow: 0 var(--fds-radio-border__hover), var(--fds-radio-border), var(--fds-radio-border-inner__checked);
+    box-shadow: 0 var(--fds-radio-border__hover), inset 0 0 0 2px var(--fds-radio-border-color), var(--fds-radio-border-inner__checked);
   }
 
   .input:hover:checked:focus-visible + .label::before {

--- a/packages/react/src/components/form/Radio/Radio.tsx
+++ b/packages/react/src/components/form/Radio/Radio.tsx
@@ -82,16 +82,14 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
       {/* <RadioIcon className={classes.icon} /> */}
       {/* </span> */}
 
-      {children && (
-        <Label
-          className={classes.label}
-          htmlFor={inputProps.id}
-          size={size}
-          weight='regular'
-        >
-          <span>{children}</span>
-        </Label>
-      )}
+      <Label
+        className={classes.label}
+        htmlFor={inputProps.id}
+        size={size}
+        weight='regular'
+      >
+        <span>{children}</span>
+      </Label>
       {description && (
         <Paragraph
           id={descriptionId}

--- a/packages/react/src/components/form/Radio/Radio.tsx
+++ b/packages/react/src/components/form/Radio/Radio.tsx
@@ -72,15 +72,15 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
         className,
       )}
     >
-      <span className={cl(classes.control, classes.radio)}>
-        <input
-          className={classes.input}
-          ref={ref}
-          {...omit(['size', 'error'], rest)}
-          {...inputProps}
-        />
-        {/* <RadioIcon className={classes.icon} /> */}
-      </span>
+      {/* <span className={cl(classes.control, classes.radio)}> */}
+      <input
+        className={classes.input}
+        ref={ref}
+        {...omit(['size', 'error'], rest)}
+        {...inputProps}
+      />
+      {/* <RadioIcon className={classes.icon} /> */}
+      {/* </span> */}
 
       {children && (
         <Label

--- a/packages/react/src/components/form/Radio/Radio.tsx
+++ b/packages/react/src/components/form/Radio/Radio.tsx
@@ -34,23 +34,18 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
       className={cl(
         classes.container,
         classes[size],
-        children && classes.spacing,
         inputProps.disabled && classes.disabled,
         hasError && classes.error,
         readOnly && classes.readonly,
         className,
       )}
     >
-      {/* <span className={cl(classes.control, classes.radio)}> */}
       <input
         className={classes.input}
         ref={ref}
         {...omit(['size', 'error'], rest)}
         {...inputProps}
       />
-      {/* <RadioIcon className={classes.icon} /> */}
-      {/* </span> */}
-
       <Label
         className={classes.label}
         htmlFor={inputProps.id}

--- a/packages/react/src/components/form/Radio/Radio.tsx
+++ b/packages/react/src/components/form/Radio/Radio.tsx
@@ -1,4 +1,4 @@
-import type { InputHTMLAttributes, ReactNode, SVGAttributes } from 'react';
+import type { InputHTMLAttributes, ReactNode } from 'react';
 import React, { forwardRef } from 'react';
 import cl from 'clsx';
 

--- a/packages/react/src/components/form/Radio/Radio.tsx
+++ b/packages/react/src/components/form/Radio/Radio.tsx
@@ -79,7 +79,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
           {...omit(['size', 'error'], rest)}
           {...inputProps}
         />
-        <RadioIcon className={classes.icon} />
+        {/* <RadioIcon className={classes.icon} /> */}
       </span>
 
       {children && (

--- a/packages/react/src/components/form/Radio/Radio.tsx
+++ b/packages/react/src/components/form/Radio/Radio.tsx
@@ -9,37 +9,6 @@ import type { FormFieldProps } from '../useFormField';
 import classes from './Radio.module.css';
 import { useRadio } from './useRadio';
 
-const RadioIcon = (props: SVGAttributes<SVGElement>) => (
-  <svg
-    width='22'
-    height='22'
-    viewBox='0 0 22 22'
-    fill='none'
-    xmlns='http://www.w3.org/2000/svg'
-    aria-hidden
-    {...props}
-  >
-    <circle
-      className={classes.box}
-      name='circle'
-      cx='11'
-      cy='11'
-      r='10'
-      fill='white'
-      stroke='#00315D'
-      strokeWidth='2'
-    />
-    <circle
-      className={classes.checked}
-      name='checked'
-      cx='11'
-      cy='11'
-      r='4.88889'
-      fill='#0062BA'
-    />
-  </svg>
-);
-
 export type RadioProps = {
   /** Radio label */
   children?: ReactNode;


### PR DESCRIPTION
resolves #1222

- Much simpler html and css than previous
- Still some trickery with box-shadows used for hover, border and background when checked.
- Some updates to match Figma design better
- Using `rem` instead of our fluid sizing tokens as browsers handle rounding half pixels different making skewed circles.
  - Its still possible to get skewed circles if user has changed root font-size but we hope it happens less this way.