### PR TITLE
feat(Tag): New Tag design

### DIFF
--- a/packages/react/src/components/Tag/Tag.mdx
+++ b/packages/react/src/components/Tag/Tag.mdx
@@ -41,13 +41,8 @@ import { Tag } from '@digdir/design-system-react';
 
 <Canvas of={TagStories.Sizes} />
 
-## Variants
-
-<Canvas of={TagStories.Variants} />
-
 ## Colors
 
 <Canvas>
   <Story of={TagStories.Colors} />
-  <Story of={TagStories.ColorsOutlined} />
 </Canvas>

--- a/packages/react/src/components/Tag/Tag.module.css
+++ b/packages/react/src/components/Tag/Tag.module.css
@@ -1,5 +1,4 @@
 .tag {
-  --fdsc-tag-border: var(--fds-semantic-border-neutral-default);
   --fdsc-tag-background: var(--fds-semantic-surface-neutral-subtle);
   --fdsc-tag-text: var(--fds-semantic-text-neutral-default);
   --fdsc-tag-padding: var(--fds-spacing-2);
@@ -8,7 +7,6 @@
 
   color: var(--fdsc-tag-text);
   padding: 0 var(--fdsc-tag-padding);
-  border: var(--fds-border_width-default) solid var(--fdsc-tag-border);
   background-color: var(--fdsc-tag-background);
   min-height: var(--fdsc-tag-min-height);
   border-radius: var(--fdsc-tag-border-radius);
@@ -34,98 +32,42 @@
   --fdsc-tag-min-height: var(--fds-sizing-7);
 }
 
-.secondary.neutral {
-  --fdsc-tag-border: var(--fds-semantic-border-neutral-default);
+.neutral {
   --fdsc-tag-background: var(--fds-semantic-surface-neutral-subtle);
   --fdsc-tag-text: var(--fds-semantic-text-neutral-default);
 }
 
-.secondary.info {
-  --fdsc-tag-border: var(--fds-semantic-border-info-default);
+.info {
   --fdsc-tag-background: var(--fds-semantic-surface-info-subtle);
   --fdsc-tag-text: var(--fds-semantic-text-neutral-default);
 }
 
-.secondary.success {
-  --fdsc-tag-border: var(--fds-semantic-border-success-default);
+.success {
   --fdsc-tag-background: var(--fds-semantic-surface-success-subtle);
   --fdsc-tag-text: var(--fds-semantic-text-success-on_success_subtle);
 }
 
-.secondary.warning {
-  --fdsc-tag-border: var(--fds-semantic-border-warning-default);
-  --fdsc-tag-background: var(--fds-semantic-surface-warning-subtle);
-  --fdsc-tag-text: var(--fds-semantic-text-neutral-default);
-}
-
-.secondary.danger {
-  --fdsc-tag-border: var(--fds-semantic-border-danger-default);
-  --fdsc-tag-background: var(--fds-semantic-surface-danger-subtle);
-  --fdsc-tag-text: var(--fds-semantic-text-danger-on_danger_subtle);
-}
-
-.secondary.first {
-  --fdsc-tag-border: var(--fds-semantic-surface-first-dark);
-  --fdsc-tag-background: var(--fds-semantic-surface-first-light);
-  --fdsc-tag-text: var(--fds-semantic-text-neutral-default);
-}
-
-.secondary.second {
-  --fdsc-tag-border: var(--fds-semantic-surface-second-dark);
-  --fdsc-tag-background: var(--fds-semantic-surface-second-light);
-  --fdsc-tag-text: var(--fds-semantic-text-neutral-default);
-}
-
-.secondary.third {
-  --fdsc-tag-border: var(--fds-semantic-surface-third-dark);
-  --fdsc-tag-background: var(--fds-semantic-surface-third-light);
-  --fdsc-tag-text: var(--fds-semantic-text-neutral-default);
-}
-
-.primary.neutral {
-  --fdsc-tag-border: var(--fds-semantic-surface-neutral-dark);
-  --fdsc-tag-background: var(--fds-semantic-surface-neutral-dark);
-  --fdsc-tag-text: var(--fds-semantic-text-neutral-on_inverted);
-}
-
-.primary.info {
-  --fdsc-tag-border: var(--fds-semantic-surface-info-subtle-hover);
-  --fdsc-tag-background: var(--fds-semantic-surface-info-subtle-hover);
-  --fdsc-tag-text: var(--fds-semantic-text-neutral-default);
-}
-
-.primary.success {
-  --fdsc-tag-border: var(--fds-semantic-surface-success-default);
-  --fdsc-tag-background: var(--fds-semantic-surface-success-default);
-  --fdsc-tag-text: var(--fds-semantic-text-success-on_success);
-}
-
-.primary.warning {
-  --fdsc-tag-border: var(--fds-semantic-surface-warning-default);
+.warning {
   --fdsc-tag-background: var(--fds-semantic-surface-warning-default);
   --fdsc-tag-text: var(--fds-semantic-text-neutral-default);
 }
 
-.primary.danger {
-  --fdsc-tag-border: var(--fds-semantic-surface-danger-default);
-  --fdsc-tag-background: var(--fds-semantic-surface-danger-default);
-  --fdsc-tag-text: var(--fds-semantic-text-danger-on_danger);
+.danger {
+  --fdsc-tag-background: var(--fds-semantic-surface-danger-subtle);
+  --fdsc-tag-text: var(--fds-semantic-text-danger-on_danger_subtle);
 }
 
-.primary.first {
-  --fdsc-tag-border: var(--fds-semantic-surface-first-dark);
-  --fdsc-tag-background: var(--fds-semantic-surface-first-dark);
-  --fdsc-tag-text: var(--fds-semantic-text-neutral-on_inverted);
+.first {
+  --fdsc-tag-background: var(--fds-semantic-surface-first-light);
+  --fdsc-tag-text: var(--fds-semantic-text-neutral-default);
 }
 
-.primary.second {
-  --fdsc-tag-border: var(--fds-semantic-surface-second-dark);
-  --fdsc-tag-background: var(--fds-semantic-surface-second-dark);
-  --fdsc-tag-text: var(--fds-semantic-text-neutral-on_inverted);
+.second {
+  --fdsc-tag-background: var(--fds-semantic-surface-second-light);
+  --fdsc-tag-text: var(--fds-semantic-text-neutral-default);
 }
 
-.primary.third {
-  --fdsc-tag-border: var(--fds-semantic-surface-third-dark);
-  --fdsc-tag-background: var(--fds-semantic-surface-third-dark);
-  --fdsc-tag-text: var(--fds-semantic-text-neutral-on_inverted);
+.third {
+  --fdsc-tag-background: var(--fds-semantic-surface-third-light);
+  --fdsc-tag-text: var(--fds-semantic-text-neutral-default);
 }

--- a/packages/react/src/components/Tag/Tag.stories.tsx
+++ b/packages/react/src/components/Tag/Tag.stories.tsx
@@ -24,7 +24,6 @@ export const Preview: Story = {
   args: {
     children: 'New',
     size: 'medium',
-    variant: 'secondary',
     color: 'neutral',
   },
 };
@@ -40,23 +39,6 @@ export const Sizes: StoryFn<typeof Tag> = ({ ...rest }): JSX.Element => {
           {...rest}
         >
           {size}
-        </Tag>
-      ))}
-    </>
-  );
-};
-
-const variants: TagProps['variant'][] = ['primary', 'secondary'];
-export const Variants: StoryFn<typeof Tag> = ({ ...rest }): JSX.Element => {
-  return (
-    <>
-      {variants.map((variant) => (
-        <Tag
-          key={variant}
-          variant={variant}
-          {...rest}
-        >
-          {variant}
         </Tag>
       ))}
     </>
@@ -81,25 +63,6 @@ export const Colors: StoryFn<typeof Tag> = ({ ...rest }): JSX.Element => {
         <Tag
           key={color}
           color={color}
-          {...rest}
-        >
-          {color}
-        </Tag>
-      ))}
-    </>
-  );
-};
-
-export const ColorsOutlined: StoryFn<typeof Tag> = ({
-  ...rest
-}): JSX.Element => {
-  return (
-    <>
-      {colors.map((color) => (
-        <Tag
-          key={color}
-          color={color}
-          variant='secondary'
           {...rest}
         >
           {color}

--- a/packages/react/src/components/Tag/Tag.test.tsx
+++ b/packages/react/src/components/Tag/Tag.test.tsx
@@ -19,22 +19,12 @@ describe('Tag', () => {
       render(<Tag>Beta</Tag>);
       expect(screen.getByText('Beta')).toHaveClass('neutral');
     });
-
-    test('should render variant as primary by default', () => {
-      render(<Tag>Beta</Tag>);
-      expect(screen.getByText('Beta')).toHaveClass('primary');
-    });
   });
 
   describe('Tag With Props Provided', () => {
     test('should render tag as small', (): void => {
       render(<Tag size='small'>Beta</Tag>);
       expect(screen.getByText('Beta')).toHaveClass('small');
-    });
-
-    test('should render as variant outline', (): void => {
-      render(<Tag variant='secondary'>Beta</Tag>);
-      expect(screen.getByText('Beta')).toHaveClass('secondary');
     });
 
     test('should render color first', (): void => {

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -15,7 +15,7 @@ export type TagProps = {
   /** Color of the tag
    * @default neutral
    */
-  color?: BrandColor | VariantColor;
+  color?: VariantColor | BrandColor;
   /** Size of the tag
    * @default medium
    */

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -20,35 +20,18 @@ export type TagProps = {
    * @default medium
    */
   size?: Size;
-  /** Variant of the tag
-   * @default primary
-   */
-  variant?: 'primary' | 'secondary';
 } & HTMLAttributes<HTMLSpanElement>;
 
 export const Tag = forwardRef<HTMLSpanElement, TagProps>(
   (
-    {
-      children,
-      color = 'neutral',
-      size = 'medium',
-      variant = 'primary',
-      className,
-      ...rest
-    },
+    { children, color = 'neutral', size = 'medium', className, ...rest },
     ref,
   ) => {
     return (
       <Paragraph
         as='span'
         size={size}
-        className={cl(
-          classes.tag,
-          classes[color],
-          classes[size],
-          classes[variant],
-          className,
-        )}
+        className={cl(classes.tag, classes[color], classes[size], className)}
         ref={ref}
         {...rest}
       >

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -7,15 +7,21 @@ import { Paragraph } from '../Typography';
 
 import classes from './Tag.module.css';
 
-type BrandColor = 'first' | 'second' | 'third';
-type VariantColor = 'neutral' | 'success' | 'warning' | 'danger' | 'info';
 type Size = Exclude<ParagraphProps['size'], 'xsmall'>;
 
 export type TagProps = {
   /** Color of the tag
    * @default neutral
    */
-  color?: VariantColor | BrandColor;
+  color?:
+    | 'neutral'
+    | 'success'
+    | 'warning'
+    | 'danger'
+    | 'info'
+    | 'first'
+    | 'second'
+    | 'third';
   /** Size of the tag
    * @default medium
    */


### PR DESCRIPTION
**This is a breaking change**

To differentiate `Tag` from `Button`, three things have been changed:

-  Primary (dark) version has been removed, thus removing the variant prop
-  Border on light version has been removed
-  Warning tag now uses token: `surface-warning-default` instead of `surface-warning-subtle`

Resolves #1261 