### PR TITLE
refactor(Checkbox): ♻️ Replace checkbox SVG icon with CSS

### DIFF
--- a/packages/react/src/components/form/Checkbox/Checkbox.module.css
+++ b/packages/react/src/components/form/Checkbox/Checkbox.module.css
@@ -68,7 +68,7 @@
   --fds-checkbox-border-color: var(--fds-semantic-border-input-hover);
 
   background: var(--fds-checkbox-border-color);
-  background-image: url('data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PScwIDAgMjQgMjQnIHhtbG5zPSdodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZycgPjxwYXRoIGZpbGwtcnVsZT0nZXZlbm9kZCcgY2xpcC1ydWxlPSdldmVub2RkJyBkPSdNMTcuNzg3NiA2LjI3ODM4QzE4LjExNzEgNi42MDc4OCAxOC4xMTcxIDcuMTQyMTIgMTcuNzg3NiA3LjQ3MTYyTDkuOTk1OTEgMTUuMjYzM0M5LjY2NjQgMTUuNTkyOCA5LjEzMjE3IDE1LjU5MjggOC44MDI2NyAxNS4yNjMzTDQuNjc3NjcgMTEuMTM4M0M0LjM0ODE2IDEwLjgwODggNC4zNDgxNiAxMC4yNzQ1IDQuNjc3NjcgOS45NDUwNUM1LjAwNzE3IDkuNjE1NTQgNS41NDE0IDkuNjE1NTQgNS44NzA5MSA5Ljk0NTA1TDkuMzk5MjkgMTMuNDczNEwxNi41OTQzIDYuMjc4MzhDMTYuOTIzOCA1Ljk0ODg3IDE3LjQ1ODEgNS45NDg4NyAxNy43ODc2IDYuMjc4MzhaJyBmaWxsPScjZmZmJyAvPjwvc3ZnPgo=');
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='-1 0 24 24' xmlns='http://www.w3.org/2000/svg' %3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M17.7876 6.27838C18.1171 6.60788 18.1171 7.14212 17.7876 7.47162L9.99591 15.2633C9.6664 15.5928 9.13217 15.5928 8.80267 15.2633L4.67767 11.1383C4.34816 10.8088 4.34816 10.2745 4.67767 9.94505C5.00717 9.61554 5.5414 9.61554 5.87091 9.94505L9.39929 13.4734L16.5943 6.27838C16.9238 5.94887 17.4581 5.94887 17.7876 6.27838Z' fill='white' /%3E%3C/svg%3E%0A");
 }
 
 .readonly > .input + .label::before {
@@ -87,7 +87,7 @@
 
 .readonly > .input:checked + .label::before {
   background: var(--fds-checkbox-background);
-  background-image: url('data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PScwIDAgMjQgMjQnIHhtbG5zPSdodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZycgPjxwYXRoIGZpbGwtcnVsZT0nZXZlbm9kZCcgY2xpcC1ydWxlPSdldmVub2RkJyBkPSdNMTcuNzg3NiA2LjI3ODM4QzE4LjExNzEgNi42MDc4OCAxOC4xMTcxIDcuMTQyMTIgMTcuNzg3NiA3LjQ3MTYyTDkuOTk1OTEgMTUuMjYzM0M5LjY2NjQgMTUuNTkyOCA5LjEzMjE3IDE1LjU5MjggOC44MDI2NyAxNS4yNjMzTDQuNjc3NjcgMTEuMTM4M0M0LjM0ODE2IDEwLjgwODggNC4zNDgxNiAxMC4yNzQ1IDQuNjc3NjcgOS45NDUwNUM1LjAwNzE3IDkuNjE1NTQgNS41NDE0IDkuNjE1NTQgNS44NzA5MSA5Ljk0NTA1TDkuMzk5MjkgMTMuNDczNEwxNi41OTQzIDYuMjc4MzhDMTYuOTIzOCA1Ljk0ODg3IDE3LjQ1ODEgNS45NDg4NyAxNy43ODc2IDYuMjc4MzhaJyBmaWxsPScjNjg3MDdjJyAvPjwvc3ZnPgo=');
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='-1 0 24 24' xmlns='http://www.w3.org/2000/svg' %3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M17.7876 6.27838C18.1171 6.60788 18.1171 7.14212 17.7876 7.47162L9.99591 15.2633C9.6664 15.5928 9.13217 15.5928 8.80267 15.2633L4.67767 11.1383C4.34816 10.8088 4.34816 10.2745 4.67767 9.94505C5.00717 9.61554 5.5414 9.61554 5.87091 9.94505L9.39929 13.4734L16.5943 6.27838C16.9238 5.94887 17.4581 5.94887 17.7876 6.27838Z' fill='%2368707c' /%3E%3C/svg%3E%0A");
 }
 
 .error > .input:not(:disabled, :focus-visible) + .label::before {

--- a/packages/react/src/components/form/Checkbox/Checkbox.module.css
+++ b/packages/react/src/components/form/Checkbox/Checkbox.module.css
@@ -1,42 +1,14 @@
 .container {
+  --fds-checkbox-size: 1.75rem;
+  --fds-checkbox-focus-border-width: 3px;
+  --fds-checkbox-background: var(--fds-semantic-background-default);
+  --fds-checkbox-border-color: var(--fds-semantic-border-input-default);
+  --fds-checkbox-border__hover: 0 0 0 6px var(--fds-semantic-surface-info-subtle-hover);
+
   position: relative;
 }
 
-.spacing {
-  padding-left: var(--fds-spacing-8);
-}
-
-.icon {
-  grid-area: input;
-  pointer-events: none;
-  width: var(--fds-sizing-6);
-  height: var(--fds-sizing-6);
-  margin: auto;
-  overflow: visible;
-}
-
-.checkbox,
-.checkbox .icon {
-  border-radius: var(--fds-border_radius-interactive);
-}
-
-.container.small .icon {
-  width: var(--fds-sizing-5);
-  height: var(--fds-sizing-5);
-}
-
-.container.medium .icon {
-  width: var(--fds-sizing-6);
-  height: var(--fds-sizing-6);
-}
-
-.container.large .icon {
-  width: var(--fds-sizing-7);
-  height: var(--fds-sizing-7);
-}
-
 .label {
-  padding-left: 3px;
   min-height: var(--fds-sizing-10);
   min-width: min-content;
   display: inline-flex;
@@ -46,171 +18,153 @@
   cursor: pointer;
 }
 
+/* Checkbox */
+.label::before {
+  content: '';
+  width: var(--fds-checkbox-size);
+  height: var(--fds-checkbox-size);
+  box-shadow: inset 0 0 0 2px var(--fds-checkbox-border-color);
+  background: var(--fds-checkbox-background);
+  flex-shrink: 0;
+  margin-inline: 6px;
+  margin-block: 6px;
+  border-radius: var(--fds-border_radius-medium);
+}
+
 .description {
-  padding-left: 3px;
+  padding-left: calc(var(--fds-checkbox-size) + 12px + var(--fds-spacing-1));
   margin-top: calc(var(--fds-spacing-2) * -1);
   color: var(--fds-semantic-text-neutral-subtle);
 }
 
-.control {
-  --fds-inner-focus-border-color: var(--fds-semantic-border-focus-boxshadow);
-  --fds-outer-focus-border-color: var(--fds-semantic-border-focus-outline);
-  --fds-focus-border-width: 3px;
-
-  position: absolute;
-  left: 0;
-  top: 0;
-  width: 2.5em;
-  height: 2.5em;
-  display: inline-grid;
-  grid: [input] 1fr / [input] 1fr;
-  gap: var(--fds-spacing-2);
-  grid-auto-flow: column;
-}
-
 .input {
-  height: 100%;
-  width: 100%;
+  position: absolute;
+  width: 2.75rem;
+  height: 2.75rem;
+  z-index: 1;
   opacity: 0;
-  margin: 0;
-  grid-area: input;
   cursor: pointer;
+  margin: 0;
 }
 
-.readonly > .control > .input,
+.disabled > .input,
+.disabled > .label,
+.disabled > .label::before {
+  cursor: not-allowed;
+}
+
+.disabled > .label,
+.disabled > .label::before,
+.disabled > .description {
+  opacity: var(--fds-opacity-disabled);
+}
+
+.input:focus-visible + .label::before {
+  outline: var(--fds-checkbox-focus-border-width) solid var(--fds-semantic-border-focus-outline);
+  box-shadow: inset 0 0 0 var(--fds-checkbox-focus-border-width) var(--fds-semantic-border-focus-boxshadow);
+}
+
+.input:checked + .label::before {
+  --fds-checkbox-border-color: var(--fds-semantic-border-input-hover);
+
+  background: var(--fds-checkbox-border-color);
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PScwIDAgMjQgMjQnIHhtbG5zPSdodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZycgPjxwYXRoIGZpbGwtcnVsZT0nZXZlbm9kZCcgY2xpcC1ydWxlPSdldmVub2RkJyBkPSdNMTcuNzg3NiA2LjI3ODM4QzE4LjExNzEgNi42MDc4OCAxOC4xMTcxIDcuMTQyMTIgMTcuNzg3NiA3LjQ3MTYyTDkuOTk1OTEgMTUuMjYzM0M5LjY2NjQgMTUuNTkyOCA5LjEzMjE3IDE1LjU5MjggOC44MDI2NyAxNS4yNjMzTDQuNjc3NjcgMTEuMTM4M0M0LjM0ODE2IDEwLjgwODggNC4zNDgxNiAxMC4yNzQ1IDQuNjc3NjcgOS45NDUwNUM1LjAwNzE3IDkuNjE1NTQgNS41NDE0IDkuNjE1NTQgNS44NzA5MSA5Ljk0NTA1TDkuMzk5MjkgMTMuNDczNEwxNi41OTQzIDYuMjc4MzhDMTYuOTIzOCA1Ljk0ODg3IDE3LjQ1ODEgNS45NDg4NyAxNy43ODc2IDYuMjc4MzhaJyBmaWxsPScjZmZmJyAvPjwvc3ZnPgo=');
+}
+
+.readonly > .input + .label::before {
+  --fds-checkbox-border-color: var(--fds-semantic-border-neutral-subtle);
+  --fds-checkbox-background: var(--fds-semantic-surface-neutral-subtle);
+}
+
+.input:checked:not(:focus-visible) + .label::before {
+  box-shadow: inset 0 0 0 2px var(--fds-checkbox-border-color);
+}
+
+.readonly > .input,
 .readonly > .label {
   cursor: default;
 }
 
-.disabled > .control .input,
-.disabled > .label {
-  cursor: not-allowed;
-  color: var(--fds-semantic-border-neutral-subtle);
+.readonly > .input:checked + .label::before {
+  background: var(--fds-checkbox-background);
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PScwIDAgMjQgMjQnIHhtbG5zPSdodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZycgPjxwYXRoIGZpbGwtcnVsZT0nZXZlbm9kZCcgY2xpcC1ydWxlPSdldmVub2RkJyBkPSdNMTcuNzg3NiA2LjI3ODM4QzE4LjExNzEgNi42MDc4OCAxOC4xMTcxIDcuMTQyMTIgMTcuNzg3NiA3LjQ3MTYyTDkuOTk1OTEgMTUuMjYzM0M5LjY2NjQgMTUuNTkyOCA5LjEzMjE3IDE1LjU5MjggOC44MDI2NyAxNS4yNjMzTDQuNjc3NjcgMTEuMTM4M0M0LjM0ODE2IDEwLjgwODggNC4zNDgxNiAxMC4yNzQ1IDQuNjc3NjcgOS45NDUwNUM1LjAwNzE3IDkuNjE1NTQgNS41NDE0IDkuNjE1NTQgNS44NzA5MSA5Ljk0NTA1TDkuMzk5MjkgMTMuNDczNEwxNi41OTQzIDYuMjc4MzhDMTYuOTIzOCA1Ljk0ODg3IDE3LjQ1ODEgNS45NDg4NyAxNy43ODc2IDYuMjc4MzhaJyBmaWxsPScjNjg3MDdjJyAvPjwvc3ZnPgo=');
 }
 
-.disabled > .description {
-  color: var(--fds-semantic-border-neutral-subtle);
+.error > .input:not(:disabled, :focus-visible) + .label::before {
+  --fds-checkbox-border-color: var(--fds-semantic-border-danger-default);
 }
 
-.input:not(:checked) ~ .icon .checked {
-  display: none;
-}
-
-.input:checked ~ .icon .checked {
-  display: inline;
-}
-
-.input:not(:checked) ~ .icon .box {
-  stroke: var(--fds-semantic-border-input-default);
-}
-
-.input:disabled ~ .icon .box {
-  stroke: var(--fds-semantic-border-neutral-subtle);
-  fill: white;
-}
-
-.input:checked:not(:disabled) ~ .icon .box {
-  stroke: var(--fds-semantic-border-input-hover);
-  fill: var(--fds-semantic-border-input-hover);
-}
-
-.input:focus-visible ~ .icon {
-  outline: var(--fds-focus-border-width) solid var(--fds-outer-focus-border-color);
-  outline-offset: 0;
-}
-
-.input:focus-visible:not(:disabled) ~ .icon .box {
-  stroke: var(--fds-semantic-border-focus-boxshadow);
-  stroke-width: var(--fds-focus-border-width);
-}
-
-.input:disabled ~ .icon .checked {
-  fill: var(--fds-semantic-border-neutral-subtle);
-}
-
-.error .input:not(:disabled, :focus-visible, :checked) ~ .icon .box {
-  stroke: var(--fds-semantic-border-danger-default);
-}
-
-.readonly .input:read-only:not(:focus-visible) ~ .icon .box {
-  stroke: var(--fds-semantic-border-neutral-subtle);
-  fill: var(--fds-semantic-background-subtle);
-}
-
-.readonly .input:read-only:not(:focus-visible):is(:checked) ~ .icon .checked {
-  fill: var(--fds-semantic-border-neutral-default);
-}
-
-/* Only use hover for non-touch devices to prevent sticky-hovering */
+/* Only use hover for non-touch devices to prevent sticky-hovering
+  "input:not(:read-only)" does not work so using ".container:not(.readonly) >" instead */
 @media (hover: hover) and (pointer: fine) {
-  .container:not(.disabled, .readonly) > .control:hover,
-  .container:not(.disabled, .readonly):has(.label:hover) > .control {
-    background: var(--fds-semantic-surface-info-subtle-hover);
+  .container:not(.readonly, .disabled) > .label:hover,
+  .container:not(.readonly, .disabled) > .input:hover + .label {
+    color: var(--fds-semantic-text-action-hover);
   }
 
-  .container:not(.disabled, .readonly) > .label:hover,
-  .container:not(.disabled, .readonly) > .control:hover ~ .label {
-    color: var(--fds-semantic-border-input-hover);
+  .container:not(.readonly, .disabled) > .input:hover:not(:checked) + .label::before {
+    --fds-checkbox-border-color: var(--fds-semantic-border-input-hover);
+
+    box-shadow: var(--fds-checkbox-border__hover), inset 0 0 0 2px var(--fds-checkbox-border-color);
   }
 
-  .container:not(.disabled, .readonly) > .control:hover > .icon > .box,
-  .container:not(.disabled, .readonly):has(.label:hover) > .control > .icon > .box {
-    stroke: var(--fds-semantic-border-input-hover);
+  .container:not(.readonly, .disabled) > .input:hover:checked + .label::before {
+    --fds-checkbox-border-color: var(--fds-semantic-border-input-hover);
+
+    box-shadow: var(--fds-checkbox-border__hover), inset 0 0 0 2px var(--fds-checkbox-border-color);
+  }
+
+  .container:not(.readonly, .disabled) > .input:hover:checked:focus-visible + .label::before {
+    box-shadow: var(--fds-checkbox-border__hover), inset 0 0 0 var(--fds-checkbox-focus-border-width) var(--fds-semantic-border-focus-boxshadow);
   }
 }
 
-/** Sizing mess for now... */
+/** Sizing */
 
-.container.small.spacing {
-  padding-left: calc(var(--fds-spacing-8));
-}
-
-.container.medium.spacing {
-  padding-left: var(--fds-spacing-10);
-}
-
-.container.large.spacing {
-  padding-left: calc(var(--fds-spacing-12));
-}
-
-.container.small {
-  min-width: var(--fds-sizing-8);
-}
-
-.container.medium {
-  min-width: var(--fds-sizing-10);
-}
-
-.container.large {
-  min-width: var(--fds-sizing-12);
-}
-
-.container.small,
-.container.small .label {
+.small,
+.small .label {
   min-height: var(--fds-sizing-8);
 }
 
-.container.medium,
-.container.medium .label {
+.medium,
+.medium .label {
   min-height: var(--fds-sizing-10);
 }
 
-.container.large,
-.container.large .label {
+.large,
+.large .label {
   min-height: var(--fds-sizing-12);
 }
 
-.container.small .control {
-  width: var(--fds-sizing-8);
-  height: var(--fds-sizing-8);
+.small {
+  --fds-checkbox-size: 1.5rem;
+
+  min-width: var(--fds-sizing-8);
 }
 
-.container.medium .control {
-  width: var(--fds-sizing-10);
-  height: var(--fds-sizing-10);
+.small .input {
+  left: -0.25rem;
+  top: -0.25rem;
 }
 
-.container.large .control {
-  width: var(--fds-sizing-12);
-  height: var(--fds-sizing-12);
+.medium {
+  --fds-checkbox-size: 1.75rem;
+
+  min-width: var(--fds-sizing-10);
+}
+
+.medium .input {
+  left: 0;
+  top: 0;
+}
+
+.large {
+  --fds-checkbox-size: 2rem;
+
+  min-width: var(--fds-sizing-12);
+}
+
+.large .input {
+  left: 0;
+  top: 0.25rem;
 }

--- a/packages/react/src/components/form/Checkbox/Checkbox.module.css
+++ b/packages/react/src/components/form/Checkbox/Checkbox.module.css
@@ -68,7 +68,7 @@
   --fds-checkbox-border-color: var(--fds-semantic-border-input-hover);
 
   background: var(--fds-checkbox-border-color);
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 27 27' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M21.8732 7.37684C22.4589 7.96263 22.4589 8.91237 21.8732 9.49816L12.3107 19.0607C11.7249 19.6464 10.7751 19.6464 10.1893 19.0607L5.12684 13.9982C4.54105 13.4124 4.54105 12.4626 5.12684 11.8768C5.71263 11.2911 6.66237 11.2911 7.24816 11.8768L11.25 15.8787L19.7518 7.37684C20.3376 6.79105 21.2874 6.79105 21.8732 7.37684Z' fill='white'/%3E%3C/svg%3E%0A");
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 23 23' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M18.5509 6.32414C18.9414 6.71467 18.9414 7.34783 18.5509 7.73836L10.5821 15.7071C10.1916 16.0976 9.55842 16.0976 9.16789 15.7071L4.94914 11.4884C4.55862 11.0978 4.55862 10.4647 4.94914 10.0741C5.33967 9.68362 5.97283 9.68362 6.36336 10.0741L9.875 13.5858L17.1366 6.32414C17.5272 5.93362 18.1603 5.93362 18.5509 6.32414Z' fill='white'/%3E%3C/svg%3E%0A");
 }
 
 .readonly > .input + .label::before {
@@ -87,7 +87,7 @@
 
 .readonly > .input:checked + .label::before {
   background: var(--fds-checkbox-background);
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 27 27' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M21.8732 7.37684C22.4589 7.96263 22.4589 8.91237 21.8732 9.49816L12.3107 19.0607C11.7249 19.6464 10.7751 19.6464 10.1893 19.0607L5.12684 13.9982C4.54105 13.4124 4.54105 12.4626 5.12684 11.8768C5.71263 11.2911 6.66237 11.2911 7.24816 11.8768L11.25 15.8787L19.7518 7.37684C20.3376 6.79105 21.2874 6.79105 21.8732 7.37684Z' fill='%2368707c'/%3E%3C/svg%3E%0A");
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 23 23' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M18.5509 6.32414C18.9414 6.71467 18.9414 7.34783 18.5509 7.73836L10.5821 15.7071C10.1916 16.0976 9.55842 16.0976 9.16789 15.7071L4.94914 11.4884C4.55862 11.0978 4.55862 10.4647 4.94914 10.0741C5.33967 9.68362 5.97283 9.68362 6.36336 10.0741L9.875 13.5858L17.1366 6.32414C17.5272 5.93362 18.1603 5.93362 18.5509 6.32414Z' fill='%2368707c'/%3E%3C/svg%3E%0A");
 }
 
 .error > .input:not(:disabled, :focus-visible) + .label::before {

--- a/packages/react/src/components/form/Checkbox/Checkbox.module.css
+++ b/packages/react/src/components/form/Checkbox/Checkbox.module.css
@@ -68,7 +68,7 @@
   --fds-checkbox-border-color: var(--fds-semantic-border-input-hover);
 
   background: var(--fds-checkbox-border-color);
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='-1 0 24 24' xmlns='http://www.w3.org/2000/svg' %3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M17.7876 6.27838C18.1171 6.60788 18.1171 7.14212 17.7876 7.47162L9.99591 15.2633C9.6664 15.5928 9.13217 15.5928 8.80267 15.2633L4.67767 11.1383C4.34816 10.8088 4.34816 10.2745 4.67767 9.94505C5.00717 9.61554 5.5414 9.61554 5.87091 9.94505L9.39929 13.4734L16.5943 6.27838C16.9238 5.94887 17.4581 5.94887 17.7876 6.27838Z' fill='white' /%3E%3C/svg%3E%0A");
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='-1 -1 24 24' xmlns='http://www.w3.org/2000/svg' %3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M17.7876 6.27838C18.1171 6.60788 18.1171 7.14212 17.7876 7.47162L9.99591 15.2633C9.6664 15.5928 9.13217 15.5928 8.80267 15.2633L4.67767 11.1383C4.34816 10.8088 4.34816 10.2745 4.67767 9.94505C5.00717 9.61554 5.5414 9.61554 5.87091 9.94505L9.39929 13.4734L16.5943 6.27838C16.9238 5.94887 17.4581 5.94887 17.7876 6.27838Z' fill='white' /%3E%3C/svg%3E%0A");
 }
 
 .readonly > .input + .label::before {
@@ -87,7 +87,7 @@
 
 .readonly > .input:checked + .label::before {
   background: var(--fds-checkbox-background);
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='-1 0 24 24' xmlns='http://www.w3.org/2000/svg' %3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M17.7876 6.27838C18.1171 6.60788 18.1171 7.14212 17.7876 7.47162L9.99591 15.2633C9.6664 15.5928 9.13217 15.5928 8.80267 15.2633L4.67767 11.1383C4.34816 10.8088 4.34816 10.2745 4.67767 9.94505C5.00717 9.61554 5.5414 9.61554 5.87091 9.94505L9.39929 13.4734L16.5943 6.27838C16.9238 5.94887 17.4581 5.94887 17.7876 6.27838Z' fill='%2368707c' /%3E%3C/svg%3E%0A");
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='-1 -1 24 24' xmlns='http://www.w3.org/2000/svg' %3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M17.7876 6.27838C18.1171 6.60788 18.1171 7.14212 17.7876 7.47162L9.99591 15.2633C9.6664 15.5928 9.13217 15.5928 8.80267 15.2633L4.67767 11.1383C4.34816 10.8088 4.34816 10.2745 4.67767 9.94505C5.00717 9.61554 5.5414 9.61554 5.87091 9.94505L9.39929 13.4734L16.5943 6.27838C16.9238 5.94887 17.4581 5.94887 17.7876 6.27838Z' fill='%2368707c' /%3E%3C/svg%3E%0A");
 }
 
 .error > .input:not(:disabled, :focus-visible) + .label::before {

--- a/packages/react/src/components/form/Checkbox/Checkbox.module.css
+++ b/packages/react/src/components/form/Checkbox/Checkbox.module.css
@@ -68,7 +68,7 @@
   --fds-checkbox-border-color: var(--fds-semantic-border-input-hover);
 
   background: var(--fds-checkbox-border-color);
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='-1 -1 24 24' xmlns='http://www.w3.org/2000/svg' %3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M17.7876 6.27838C18.1171 6.60788 18.1171 7.14212 17.7876 7.47162L9.99591 15.2633C9.6664 15.5928 9.13217 15.5928 8.80267 15.2633L4.67767 11.1383C4.34816 10.8088 4.34816 10.2745 4.67767 9.94505C5.00717 9.61554 5.5414 9.61554 5.87091 9.94505L9.39929 13.4734L16.5943 6.27838C16.9238 5.94887 17.4581 5.94887 17.7876 6.27838Z' fill='white' /%3E%3C/svg%3E%0A");
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 27 27' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M21.8732 7.37684C22.4589 7.96263 22.4589 8.91237 21.8732 9.49816L12.3107 19.0607C11.7249 19.6464 10.7751 19.6464 10.1893 19.0607L5.12684 13.9982C4.54105 13.4124 4.54105 12.4626 5.12684 11.8768C5.71263 11.2911 6.66237 11.2911 7.24816 11.8768L11.25 15.8787L19.7518 7.37684C20.3376 6.79105 21.2874 6.79105 21.8732 7.37684Z' fill='white'/%3E%3C/svg%3E%0A");
 }
 
 .readonly > .input + .label::before {
@@ -87,7 +87,7 @@
 
 .readonly > .input:checked + .label::before {
   background: var(--fds-checkbox-background);
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='-1 -1 24 24' xmlns='http://www.w3.org/2000/svg' %3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M17.7876 6.27838C18.1171 6.60788 18.1171 7.14212 17.7876 7.47162L9.99591 15.2633C9.6664 15.5928 9.13217 15.5928 8.80267 15.2633L4.67767 11.1383C4.34816 10.8088 4.34816 10.2745 4.67767 9.94505C5.00717 9.61554 5.5414 9.61554 5.87091 9.94505L9.39929 13.4734L16.5943 6.27838C16.9238 5.94887 17.4581 5.94887 17.7876 6.27838Z' fill='%2368707c' /%3E%3C/svg%3E%0A");
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 27 27' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M21.8732 7.37684C22.4589 7.96263 22.4589 8.91237 21.8732 9.49816L12.3107 19.0607C11.7249 19.6464 10.7751 19.6464 10.1893 19.0607L5.12684 13.9982C4.54105 13.4124 4.54105 12.4626 5.12684 11.8768C5.71263 11.2911 6.66237 11.2911 7.24816 11.8768L11.25 15.8787L19.7518 7.37684C20.3376 6.79105 21.2874 6.79105 21.8732 7.37684Z' fill='%2368707c'/%3E%3C/svg%3E%0A");
 }
 
 .error > .input:not(:disabled, :focus-visible) + .label::before {

--- a/packages/react/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import type { InputHTMLAttributes, ReactNode, SVGAttributes } from 'react';
+import type { InputHTMLAttributes, ReactNode } from 'react';
 import React, { forwardRef } from 'react';
 import cl from 'clsx';
 
@@ -8,37 +8,6 @@ import type { FormFieldProps } from '../useFormField';
 
 import classes from './Checkbox.module.css';
 import { useCheckbox } from './useCheckbox';
-
-export const CheckboxIcon = (props: SVGAttributes<SVGElement>) => (
-  <svg
-    width='22'
-    height='22'
-    viewBox='0 0 22 22'
-    fill='none'
-    xmlns='http://www.w3.org/2000/svg'
-    {...props}
-  >
-    <rect
-      x='1'
-      y='1'
-      width='20'
-      height='20'
-      rx='2px'
-      ry='2px'
-      fill='white'
-      strokeWidth='2'
-      strokeLinejoin='round'
-      className={classes.box}
-    />
-    <path
-      fillRule='evenodd'
-      clipRule='evenodd'
-      d='M17.7876 6.27838C18.1171 6.60788 18.1171 7.14212 17.7876 7.47162L9.99591 15.2633C9.6664 15.5928 9.13217 15.5928 8.80267 15.2633L4.67767 11.1383C4.34816 10.8088 4.34816 10.2745 4.67767 9.94505C5.00717 9.61554 5.5414 9.61554 5.87091 9.94505L9.39929 13.4734L16.5943 6.27838C16.9238 5.94887 17.4581 5.94887 17.7876 6.27838Z'
-      fill='white'
-      className={classes.checked}
-    />
-  </svg>
-);
 
 export type CheckboxProps = {
   /** Checkbox label */
@@ -66,23 +35,18 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
         className={cl(
           classes.container,
           classes[size],
-          children && classes.spacing,
           inputProps.disabled && classes.disabled,
           hasError && classes.error,
           readOnly && classes.readonly,
           className,
         )}
       >
-        <span className={cl(classes.control, classes.checkbox)}>
-          <input
-            className={classes.input}
-            ref={ref}
-            {...omit(['size', 'error'], rest)}
-            {...inputProps}
-          />
-          <CheckboxIcon className={classes.icon} />
-        </span>
-
+        <input
+          className={classes.input}
+          ref={ref}
+          {...omit(['size', 'error'], rest)}
+          {...inputProps}
+        />
         {children && (
           <Label
             className={classes.label}

--- a/packages/react/src/components/form/Checkbox/Group/Group.module.css
+++ b/packages/react/src/components/form/Checkbox/Group/Group.module.css
@@ -1,3 +1,0 @@
-.alignToLegend {
-  margin-left: calc(var(--fds-spacing-2) * -1);
-}

--- a/packages/react/src/components/form/Checkbox/Group/Group.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.tsx
@@ -1,11 +1,8 @@
 import type { ReactNode } from 'react';
 import React, { useState, forwardRef, createContext } from 'react';
-import cl from 'clsx';
 
 import type { FieldsetProps } from '../../Fieldset';
 import { Fieldset } from '../../Fieldset';
-
-import classes from './Group.module.css';
 
 export type CheckboxGroupContextProps = {
   value?: string[];
@@ -75,9 +72,7 @@ export const CheckboxGroup = forwardRef<
             toggleValue,
           }}
         >
-          <div className={cl(!rest.hideLegend && classes.alignToLegend)}>
-            {children}
-          </div>
+          <div>{children}</div>
         </CheckboxGroupContext.Provider>
       </Fieldset>
     );


### PR DESCRIPTION
resolves #1223

- Mostly just copied css from `Radio`. 
- Changed border-radius and added background-image with encoded svg for "checked" mark.
- Updated with thicker checkmark icon after discussions on slack: https://designsystemet.slack.com/archives/C05U1MNKYCX/p1704983538260269

Did not base64 encode the svg due to: https://css-tricks.com/probably-dont-base64-svg/ and testing locally, the url encoded svg was about smaller. This will also make it easier to adjust in the future.