### PR TITLE
refactor(Checkbox): :recycle: Remove deprecated children check

### DIFF
--- a/packages/react/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.tsx
@@ -47,16 +47,14 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
           {...omit(['size', 'error'], rest)}
           {...inputProps}
         />
-        {children && (
-          <Label
-            className={classes.label}
-            htmlFor={inputProps.id}
-            size={size}
-            weight='regular'
-          >
-            <span>{children}</span>
-          </Label>
-        )}
+        <Label
+          className={classes.label}
+          htmlFor={inputProps.id}
+          size={size}
+          weight='regular'
+        >
+          <span>{children}</span>
+        </Label>
         {description && (
           <Paragraph
             id={descriptionId}


### PR DESCRIPTION
Removed old code I forgot when refactoring checkbox to CSS in #1373