### PR TITLE
feat(Link): Add `asChild` support to `Link`

### DIFF
--- a/packages/react/src/components/Link/Link.tsx
+++ b/packages/react/src/components/Link/Link.tsx
@@ -1,6 +1,7 @@
 import type { AnchorHTMLAttributes, ReactNode } from 'react';
 import React, { forwardRef } from 'react';
 import cl from 'clsx';
+import { Slot } from '@radix-ui/react-slot';
 
 import type { OverridableComponent } from '../../types/OverridableComponent';
 
@@ -18,20 +19,29 @@ export type LinkProps = {
 
   /** The URL that the link points to. This can also be an email address (starting with `mailto:`) or a phone number (staring with `tel:`). */
   href?: string;
+  /**
+   * Change the default rendered element for the one passed as a child, merging their props and behavior.
+   * @default false
+   */
+  asChild?: boolean;
 } & AnchorHTMLAttributes<HTMLAnchorElement>;
 
 export const Link: OverridableComponent<LinkProps, HTMLAnchorElement> =
   forwardRef(
     (
-      { as: Component = 'a', children, className, inverted = false, ...rest },
+      { as = 'a', asChild, children, className, inverted = false, ...rest },
       ref,
-    ) => (
-      <Component
-        className={cl(classes.link, inverted && classes.inverted, className)}
-        ref={ref}
-        {...rest}
-      >
-        {children}
-      </Component>
-    ),
+    ) => {
+      const Component = asChild ? Slot : as;
+
+      return (
+        <Component
+          className={cl(classes.link, inverted && classes.inverted, className)}
+          ref={ref}
+          {...rest}
+        >
+          {children}
+        </Component>
+      );
+    },
   );


### PR DESCRIPTION
Resolves #1308