### PR TITLE
feat(Paragraph): Add `asChild` support to `Paragraph`

### DIFF
--- a/packages/react/src/components/Typography/Paragraph/Paragraph.tsx
+++ b/packages/react/src/components/Typography/Paragraph/Paragraph.tsx
@@ -1,6 +1,7 @@
 import type { HTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
 import cl from 'clsx';
+import { Slot } from '@radix-ui/react-slot';
 
 import type { OverridableComponent } from '../../../types/OverridableComponent';
 
@@ -13,6 +14,11 @@ export type ParagraphProps = {
   spacing?: boolean;
   /** Reduces line-height for short paragraphs */
   short?: boolean;
+  /**
+   * Change the default rendered element for the one passed as a child, merging their props and behavior.
+   * @default false
+   */
+  asChild?: boolean;
 } & HTMLAttributes<HTMLParagraphElement>;
 
 /** Use `Paragraph` to display text with paragraph text styles. */
@@ -21,28 +27,25 @@ export const Paragraph: OverridableComponent<
   HTMLParagraphElement
 > = forwardRef(
   (
-    {
-      className,
-      size = 'medium',
-      spacing,
-      as: Component = 'p',
-      short,
-      ...rest
-    },
+    { className, size = 'medium', spacing, as = 'p', asChild, short, ...rest },
     ref,
-  ) => (
-    <Component
-      ref={ref}
-      className={cl(
-        classes.paragraph,
-        classes[size],
-        {
-          [classes.spacing]: !!spacing,
-          [classes.short]: short,
-        },
-        className,
-      )}
-      {...rest}
-    />
-  ),
+  ) => {
+    const Component = asChild ? Slot : as;
+
+    return (
+      <Component
+        ref={ref}
+        className={cl(
+          classes.paragraph,
+          classes[size],
+          {
+            [classes.spacing]: !!spacing,
+            [classes.short]: short,
+          },
+          className,
+        )}
+        {...rest}
+      />
+    );
+  },
 );


### PR DESCRIPTION
Resolves #1313