### PR TITLE
feat(Button): Add `asChild` support to `Button`

### DIFF
--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef } from 'react';
 import type { ButtonHTMLAttributes } from 'react';
 import cl from 'clsx';
+import { Slot } from '@radix-ui/react-slot';
 
 import utilityClasses from '../../utilities/utility.module.css';
 import type { OverridableComponent } from '../../types/OverridableComponent';
@@ -20,6 +21,11 @@ export type ButtonProps = {
    * @default false
    */
   icon?: boolean;
+  /**
+   * Change the default rendered element for the one passed as a child, merging their props and behavior.
+   * @default false
+   */
+  asChild?: boolean;
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
 /**
@@ -37,27 +43,32 @@ export const Button: OverridableComponent<ButtonProps, HTMLButtonElement> =
         icon = false,
         type = 'button',
         className,
-        as: Component = 'button',
+        as = 'button',
+        asChild,
         ...rest
       },
       ref,
-    ) => (
-      <Component
-        ref={ref}
-        type={type}
-        className={cl(
-          classes.button,
-          utilityClasses.focusable,
-          classes[size],
-          classes[variant],
-          classes[color],
-          { [classes.fullWidth]: fullWidth },
-          { [classes.onlyIcon]: icon },
-          className,
-        )}
-        {...rest}
-      >
-        {children}
-      </Component>
-    ),
+    ) => {
+      const Component = asChild ? Slot : as;
+
+      return (
+        <Component
+          ref={ref}
+          type={type}
+          className={cl(
+            classes.button,
+            utilityClasses.focusable,
+            classes[size],
+            classes[variant],
+            classes[color],
+            { [classes.fullWidth]: fullWidth },
+            { [classes.onlyIcon]: icon },
+            className,
+          )}
+          {...rest}
+        >
+          {children}
+        </Component>
+      );
+    },
   );


### PR DESCRIPTION
Resolves #1305