### PR TITLE
feat(ErrorMessage): Add `asChild` support to `ErrorMessage`

### DIFF
--- a/packages/react/src/components/Typography/ErrorMessage/ErrorMessage.tsx
+++ b/packages/react/src/components/Typography/ErrorMessage/ErrorMessage.tsx
@@ -1,6 +1,7 @@
 import type { HTMLAttributes } from 'react';
 import React, { forwardRef } from 'react';
 import cl from 'clsx';
+import { Slot } from '@radix-ui/react-slot';
 
 import type { OverridableComponent } from '../../../types/OverridableComponent';
 
@@ -13,6 +14,11 @@ export type ErrorMessageProps = {
   spacing?: boolean;
   /** Toggle error color */
   error?: boolean;
+  /**
+   * Change the default rendered element for the one passed as a child, merging their props and behavior.
+   * @default false
+   */
+  asChild?: boolean;
 } & HTMLAttributes<HTMLParagraphElement>;
 
 /** Use `ErrorMessage` to display text as error message. */
@@ -25,24 +31,29 @@ export const ErrorMessage: OverridableComponent<
       className,
       size = 'medium',
       spacing,
-      as: Component = 'div',
+      as = 'div',
+      asChild,
       error = true,
       ...rest
     },
     ref,
-  ) => (
-    <Component
-      ref={ref}
-      className={cl(
-        classes.errorMessage,
-        classes[size],
-        {
-          [classes.spacing]: !!spacing,
-        },
-        error && classes.error,
-        className,
-      )}
-      {...rest}
-    />
-  ),
+  ) => {
+    const Component = asChild ? Slot : as;
+
+    return (
+      <Component
+        ref={ref}
+        className={cl(
+          classes.errorMessage,
+          classes[size],
+          {
+            [classes.spacing]: !!spacing,
+          },
+          error && classes.error,
+          className,
+        )}
+        {...rest}
+      />
+    );
+  },
 );


### PR DESCRIPTION
Resolves #1309