### PR TITLE
chore(storefront): Fix build errors with using `as`

### DIFF
--- a/apps/storefront/layouts/NotFoundLayout/NotFoundLayout.tsx
+++ b/apps/storefront/layouts/NotFoundLayout/NotFoundLayout.tsx
@@ -32,12 +32,15 @@ const NotFoundLayout = ({ content, data }: NotFoundLayoutProps) => {
           <h1 className={classes.title}>{data.title}</h1>
           <p className={classes.desc}>{data.description}</p>
           <Link
-            as={NextLink}
             className={classes.link}
-            href='/'
-            prefetch={false}
+            asChild
           >
-            Gå til forsiden
+            <NextLink
+              href='/'
+              prefetch={false}
+            >
+              Gå til forsiden
+            </NextLink>
           </Link>
         </div>
         {content}

--- a/apps/storefront/layouts/PageLayout/PageLayout.tsx
+++ b/apps/storefront/layouts/PageLayout/PageLayout.tsx
@@ -30,16 +30,19 @@ const PageLayout = ({ content, data }: PageLayoutProps) => {
         <Container>
           <div className={classes.headerContent}>
             <Link
-              as={NextLink}
-              href={'/' + data.backUrl}
+              asChild
               className={classes.backBtn}
-              prefetch={false}
             >
-              <ArrowLeftIcon
-                title='Tilbake'
-                fontSize={28}
-              />
-              {data.backText}
+              <NextLink
+                href={'/' + data.backUrl}
+                prefetch={false}
+              >
+                <ArrowLeftIcon
+                  title='Tilbake'
+                  fontSize={28}
+                />
+                {data.backText}
+              </NextLink>
             </Link>
             <div className={classes.meta}>
               <span>


### PR DESCRIPTION
Next was complaining about using `as`, changed these to use `asChild`