### PR TITLE
fix(Table): :label: Fix types

### DIFF
--- a/packages/react/src/components/Table/Table.test.tsx
+++ b/packages/react/src/components/Table/Table.test.tsx
@@ -6,10 +6,6 @@ import { Table } from './Table';
 
 import { TableBody, TableCell, TableHead, TableHeaderCell, TableRow } from '.';
 
-const Comp = (args: Partial<TableProps>) => {
-  return <Table {...args} />;
-};
-
 const children = (
   <>
     <TableHead>
@@ -34,8 +30,8 @@ const children = (
   </>
 );
 
-const render = (props: Partial<TableProps> = {}) => {
-  return renderRtl(<Comp {...props} />);
+const render = (props: TableProps = {}) => {
+  return renderRtl(<Table {...props} />);
 };
 
 describe('table', (): void => {

--- a/packages/react/src/components/Table/Table.tsx
+++ b/packages/react/src/components/Table/Table.tsx
@@ -26,7 +26,7 @@ export type TableProps = {
    * @default false
    */
   border?: boolean;
-} & React.HTMLAttributes<HTMLTableElement>;
+} & Omit<React.TableHTMLAttributes<HTMLTableElement>, 'border'>;
 
 export const Table = React.forwardRef<HTMLTableElement, TableProps>(
   (

--- a/packages/react/src/components/Table/TableCell.tsx
+++ b/packages/react/src/components/Table/TableCell.tsx
@@ -3,7 +3,7 @@ import cl from 'clsx';
 
 import classes from './Table.module.css';
 
-export type TableCellProps = React.HTMLAttributes<HTMLTableCellElement>;
+export type TableCellProps = React.TdHTMLAttributes<HTMLTableCellElement>;
 
 export const TableCell = React.forwardRef<HTMLTableCellElement, TableCellProps>(
   ({ className, children, ...rest }, ref) => {

--- a/packages/react/src/components/Table/TableHeaderCell.tsx
+++ b/packages/react/src/components/Table/TableHeaderCell.tsx
@@ -32,7 +32,7 @@ export type TableHeaderCellProps = {
    * @default undefined
    */
   onSortClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
-} & React.HTMLAttributes<HTMLTableCellElement>;
+} & React.ThHTMLAttributes<HTMLTableCellElement>;
 
 export const TableHeaderCell = React.forwardRef<
   HTMLTableCellElement,


### PR DESCRIPTION
Fixes #1499 

Update types to correctly include native attributes.

Checked against [IntrinsicElements](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/8b8da1a8fb5d33e7bee46d971cbf8aea10aeacb8/types/react/ts5.0/index.d.ts#L3980) to use same types as React does internally.

Omitted [border](https://developer.mozilla.org/en-US/docs/Web/API/HTMLTableElement/border) from native `<table>` props as it interfered with ours. The native one is marked as obsolete/deprecated so I think its safe to use as our own.