### PR TITLE
chore: Remove unnecessary React imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
     'plugin:jsx-a11y/recommended',
     'plugin:react/recommended',
     'plugin:react-hooks/recommended',
+    'plugin:react/jsx-runtime',
     'plugin:storybook/recommended',
     'plugin:prettier/recommended',
   ],

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import type { Preview } from '@storybook/react';
 import cssVariablesTheme from '@etchteam/storybook-addon-css-variables-theme';
 

--- a/apps/dev/src/app/layout.tsx
+++ b/apps/dev/src/app/layout.tsx
@@ -1,17 +1,13 @@
 import 'normalize.css/normalize.css';
 import './globals.css';
 
-import React from 'react';
+import type { ReactNode } from 'react';
 
 export const metadata = {
   title: 'Dev - Designsystemet',
 };
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang='en'>
       <body>{children}</body>

--- a/apps/dev/src/app/page.tsx
+++ b/apps/dev/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { CountdownCircleTimer } from 'react-countdown-circle-timer';
 
 import { PullRequestCard } from '../components/PullRequestCard/PullRequestCard';

--- a/apps/dev/src/components/Alias/Alias.tsx
+++ b/apps/dev/src/components/Alias/Alias.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { DateTime } from 'luxon';
 import { ExternalLinkIcon, ClockIcon } from '@navikt/aksel-icons';
 

--- a/apps/dev/src/components/PullRequestCard/PullRequestCard.tsx
+++ b/apps/dev/src/components/PullRequestCard/PullRequestCard.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 
 import classes from './PullRequestCard.module.css';
 
 type PullRequestCardProps = {
-  children: React.ReactNode;
+  children: ReactNode;
   title: string;
   user: string;
   userAvatar: string;

--- a/apps/dev/src/components/SkeletonCard/SkeletonCard.tsx
+++ b/apps/dev/src/components/SkeletonCard/SkeletonCard.tsx
@@ -1,5 +1,4 @@
 import cl from 'clsx';
-import React from 'react';
 
 import classes from './SkeletonCard.module.css';
 

--- a/apps/dev/tsconfig.json
+++ b/apps/dev/tsconfig.json
@@ -1,19 +1,6 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve",
-    "incremental": true,
     "plugins": [
       {
         "name": "next"
@@ -21,7 +8,8 @@
     ],
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "jsx": "preserve"
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/apps/storefront/components/Banner/Banner.tsx
+++ b/apps/storefront/components/Banner/Banner.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import cl from 'clsx';
 
 import { Tag } from '../Tag/Tag';

--- a/apps/storefront/components/ClipboardBtn/ClipboardBtn.tsx
+++ b/apps/storefront/components/ClipboardBtn/ClipboardBtn.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { ClipboardIcon } from '@navikt/aksel-icons';
 import Tippy from '@tippyjs/react';
 

--- a/apps/storefront/components/CodeSnippet/CodeSnippet.tsx
+++ b/apps/storefront/components/CodeSnippet/CodeSnippet.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { FilesIcon } from '@navikt/aksel-icons';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import prettier from 'prettier/standalone.js';

--- a/apps/storefront/components/Container/Container.tsx
+++ b/apps/storefront/components/Container/Container.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import cl from 'clsx';
 
 import classes from './Container.module.css';
 
 interface ContainerProps {
-  children: React.ReactNode;
+  children: ReactNode;
   className?: string;
 }
 

--- a/apps/storefront/components/Footer/Footer.tsx
+++ b/apps/storefront/components/Footer/Footer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import Image from 'next/image';
 import { EnvelopeClosedIcon } from '@navikt/aksel-icons';
 import NextLink from 'next/link';
@@ -70,7 +70,7 @@ const rightLinks = [
 type LinkListItemProps = {
   text: string;
   url: string;
-  prefix?: React.ReactNode;
+  prefix?: ReactNode;
 };
 
 const getCurrentYear = () => {

--- a/apps/storefront/components/Grid/Grid.tsx
+++ b/apps/storefront/components/Grid/Grid.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 
 import classes from './Grid.module.css';
 
 interface GridProps {
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 const Grid = ({ children }: GridProps) => {

--- a/apps/storefront/components/Header/Header.tsx
+++ b/apps/storefront/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
@@ -42,7 +42,7 @@ const Header = () => {
   return (
     <header className={classes.header}>
       <div className={classes.container}>
-        <div className={classes.left}>
+        <div>
           <Link
             className={classes.logoLink}
             href='/'
@@ -60,7 +60,7 @@ const Header = () => {
             />
           </Link>
         </div>
-        <div className={classes.right}>
+        <div>
           <button
             aria-expanded={open}
             aria-label='Meny'

--- a/apps/storefront/components/Image/Image.tsx
+++ b/apps/storefront/components/Image/Image.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import cl from 'clsx';
 
 import classes from './Image.module.css';

--- a/apps/storefront/components/ImageSection/ImageSection.tsx
+++ b/apps/storefront/components/ImageSection/ImageSection.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useState, createElement } from 'react';
+import { useEffect, useState, createElement } from 'react';
+import type { ReactNode } from 'react';
 import Image from 'next/image';
 import cl from 'clsx';
 
@@ -12,19 +13,19 @@ interface ImageSectionProps {
   imgSrc: string;
   imgAlt?: string;
   headingLevel?: 'h1' | 'h2';
-  content?: React.ReactNode;
-  children?: React.ReactNode;
+  content?: ReactNode;
+  children?: ReactNode;
   imgWidth: number;
   imgHeight: number;
   backgroundColor?: 'blue' | 'yellow' | 'red' | 'white';
   buttons?: ImageSectionButtonProps[];
-  link?: { text: string; href: string; prefix: React.ReactNode };
+  link?: { text: string; href: string; prefix: ReactNode };
   imgPosition?: 'left' | 'right';
 }
 
 type ImageSectionButtonProps = {
   text: string;
-  prefix?: React.ReactNode;
+  prefix?: ReactNode;
   href: string;
 };
 
@@ -43,7 +44,7 @@ const ImageSection = ({
   imgAlt = '',
   headingLevel = 'h1',
 }: ImageSectionProps) => {
-  const [heading, setHeading] = useState<React.ReactNode | null>(null);
+  const [heading, setHeading] = useState<ReactNode | null>(null);
 
   useEffect(() => {
     setHeading(

--- a/apps/storefront/components/JumpToMain/JumpToMain.tsx
+++ b/apps/storefront/components/JumpToMain/JumpToMain.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import classes from './JumpToMain.module.css';
 
 const JumpToMain = () => {

--- a/apps/storefront/components/Link/Github/GithubLink.tsx
+++ b/apps/storefront/components/Link/Github/GithubLink.tsx
@@ -1,6 +1,5 @@
 'use client';
 import type { HTMLAttributes } from 'react';
-import React from 'react';
 import Image from 'next/image';
 import { Link } from '@digdir/design-system-react';
 import { useRouter } from 'next/router';

--- a/apps/storefront/components/Link/Link.tsx
+++ b/apps/storefront/components/Link/Link.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type * as React from 'react';
 import NextLink from 'next/link';
 
 import classes from './Link.module.css';

--- a/apps/storefront/components/MdxContent/MdxContent.tsx
+++ b/apps/storefront/components/MdxContent/MdxContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type * as React from 'react';
 import cl from 'clsx';
 
 import classes from './MdxContent.module.css';

--- a/apps/storefront/components/Meta/Meta.tsx
+++ b/apps/storefront/components/Meta/Meta.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Head from 'next/head';
 
 interface MetaProps {

--- a/apps/storefront/components/NavigationCard/NavigationCard.tsx
+++ b/apps/storefront/components/NavigationCard/NavigationCard.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import cl from 'clsx';
-import React from 'react';
+import type * as React from 'react';
 
 import classes from './NavigationCard.module.css';
 

--- a/apps/storefront/components/ResponsiveIframe/ResponsiveIframe.tsx
+++ b/apps/storefront/components/ResponsiveIframe/ResponsiveIframe.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import cl from 'clsx';
 
 import classes from './ResponsiveIframe.module.css';

--- a/apps/storefront/components/Section/Section.tsx
+++ b/apps/storefront/components/Section/Section.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type * as React from 'react';
 import cl from 'clsx';
 import Image from 'next/image';
 

--- a/apps/storefront/components/SidebarMenu/SidebarMenu.tsx
+++ b/apps/storefront/components/SidebarMenu/SidebarMenu.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import cl from 'clsx';
 import { Button } from '@digdir/design-system-react';

--- a/apps/storefront/components/Tag/Tag.tsx
+++ b/apps/storefront/components/Tag/Tag.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import cl from 'clsx';
 
 import { capitalizeString } from '../../utils/StringHelpers';

--- a/apps/storefront/components/TeaserCard/TeaserCard.tsx
+++ b/apps/storefront/components/TeaserCard/TeaserCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Link from 'next/link';
 
 import classes from './TeaserCard.module.css';

--- a/apps/storefront/components/Tokens/TokenBorderRadius/TokenBorderRadius.tsx
+++ b/apps/storefront/components/Tokens/TokenBorderRadius/TokenBorderRadius.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const TokenBorderRadius = () => {
   return (
     <div>

--- a/apps/storefront/components/Tokens/TokenColor/TokenColor.tsx
+++ b/apps/storefront/components/Tokens/TokenColor/TokenColor.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import classes from './TokenColor.module.css';
 
 interface TokenColorProps {

--- a/apps/storefront/components/Tokens/TokenFontSize/TokenFontSize.tsx
+++ b/apps/storefront/components/Tokens/TokenFontSize/TokenFontSize.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import classes from './TokenFontSize.module.css';
 
 interface TokenFontSizeProps {

--- a/apps/storefront/components/Tokens/TokenList/TokenList.tsx
+++ b/apps/storefront/components/Tokens/TokenList/TokenList.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from 'react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Dropdown, Button } from '@navikt/ds-react';
 import cl from 'clsx';
 import type { TransformedToken as Token } from 'style-dictionary';

--- a/apps/storefront/components/Tokens/TokenShadow/TokenShadow.tsx
+++ b/apps/storefront/components/Tokens/TokenShadow/TokenShadow.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import classes from './TokenShadow.module.css';
 
 interface TokenColorProps {

--- a/apps/storefront/components/Tokens/TokenSize/TokenSize.tsx
+++ b/apps/storefront/components/Tokens/TokenSize/TokenSize.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import classes from './TokenSize.module.css';
 
 interface TokenFontSizeProps {

--- a/apps/storefront/layouts/FrontpageLayout/FrontpageLayout.tsx
+++ b/apps/storefront/layouts/FrontpageLayout/FrontpageLayout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type * as React from 'react';
 
 type FrontpageLayoutProps = {
   content: React.ReactNode;

--- a/apps/storefront/layouts/MenuPageLayout/MenuPageLayout.tsx
+++ b/apps/storefront/layouts/MenuPageLayout/MenuPageLayout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type * as React from 'react';
 import { useRouter } from 'next/router';
 
 import GithubLink from 'components/Link/Github/GithubLink';

--- a/apps/storefront/layouts/NavMenuPageLayout/NavMenuPageLayout.tsx
+++ b/apps/storefront/layouts/NavMenuPageLayout/NavMenuPageLayout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type * as React from 'react';
 import { useRouter } from 'next/router';
 
 import { Container, SidebarMenu, MdxContent } from '../../components';

--- a/apps/storefront/layouts/NavPageLayout/NavPageLayout.tsx
+++ b/apps/storefront/layouts/NavPageLayout/NavPageLayout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type * as React from 'react';
 
 import { Container, ImageSection, MdxContent } from '../../components';
 import type { ImageSectionProps } from '../../components';

--- a/apps/storefront/layouts/NotFoundLayout/NotFoundLayout.tsx
+++ b/apps/storefront/layouts/NotFoundLayout/NotFoundLayout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type * as React from 'react';
 import NextLink from 'next/link';
 import { Link } from '@digdir/design-system-react';
 import Image from 'next/image';

--- a/apps/storefront/layouts/PageLayout/PageLayout.tsx
+++ b/apps/storefront/layouts/PageLayout/PageLayout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type * as React from 'react';
 import NextLink from 'next/link';
 import { Link } from '@digdir/design-system-react';
 import { ArrowLeftIcon } from '@navikt/aksel-icons';

--- a/apps/storefront/pages/_app.tsx
+++ b/apps/storefront/pages/_app.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import 'normalize.css/normalize.css';
 import 'tippy.js/dist/tippy.css';
 import '@altinn/figma-design-tokens/dist/tokens.css';

--- a/apps/storefront/tsconfig.json
+++ b/apps/storefront/tsconfig.json
@@ -1,24 +1,12 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve",
-    "incremental": true,
     "baseUrl": ".",
     "paths": {
       "@components": ["components"],
       "@layouts": ["layouts"]
-    }
+    },
+    "jsx": "preserve"
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]

--- a/docs-components/Changelog/Changelog.tsx
+++ b/docs-components/Changelog/Changelog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { Markdown } from '@storybook/blocks';
 
 import classes from './Changelog.module.css';

--- a/docs-components/DoAndDont/DoAndDont.tsx
+++ b/docs-components/DoAndDont/DoAndDont.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import cl from 'clsx';
 import { Heading, Paragraph } from '@digdir/design-system-react';
 import { CheckmarkIcon, XMarkIcon } from '@navikt/aksel-icons';

--- a/docs-components/Information/Information.tsx
+++ b/docs-components/Information/Information.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Markdown } from '@storybook/blocks';
 import type { AlertProps } from '@digdir/design-system-react';
 import { Paragraph, Alert, Heading } from '@digdir/design-system-react';

--- a/docs-components/LinkHeading/LinkHeading.tsx
+++ b/docs-components/LinkHeading/LinkHeading.tsx
@@ -2,7 +2,7 @@ import { Heading, Link } from '@digdir/design-system-react';
 import type { HeadingProps } from '@digdir/design-system-react';
 import { LinkIcon } from '@navikt/aksel-icons';
 import cl from 'clsx';
-import React from 'react';
+import type * as React from 'react';
 
 import classes from './LinkHeading.module.css';
 

--- a/docs-components/Stack/Stack.tsx
+++ b/docs-components/Stack/Stack.tsx
@@ -1,5 +1,4 @@
-import type { HTMLAttributes } from 'react';
-import React from 'react';
+import type { HTMLAttributes, ReactNode, CSSProperties } from 'react';
 
 import classes from './Stack.module.css';
 
@@ -23,8 +22,8 @@ export const Stack = ({
 );
 
 type FlexContainerProps = {
-  children: React.ReactNode;
-  style?: React.CSSProperties;
+  children: ReactNode;
+  style?: CSSProperties;
   gap?: string;
   direction?: 'row' | 'column' | 'row-reverse' | 'column-reverse';
   wrap?: 'wrap' | 'nowrap' | 'wrap-reverse';

--- a/docs-components/Table/Table.tsx
+++ b/docs-components/Table/Table.tsx
@@ -3,8 +3,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // TODO This will be removed so disabling stuff for now to save work
-import React from 'react';
-
 import classes from './Table.module.css';
 
 export interface TableProps {

--- a/docs-components/Table/TableCells/TableCells.tsx
+++ b/docs-components/Table/TableCells/TableCells.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import classes from './TableCells.module.css';
 
 const TableCellColor = (props: { color: string }) => {

--- a/docs-components/Table/TokenTable/TokensTable.tsx
+++ b/docs-components/Table/TokenTable/TokensTable.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import tokens from '@altinn/figma-design-tokens/dist/tokens';
 
 import { Table } from '../Table';

--- a/docs-components/declarations.d.ts
+++ b/docs-components/declarations.d.ts
@@ -1,0 +1,4 @@
+declare module '*.css' {
+  const styles: { [className: string]: string };
+  export default styles;
+}

--- a/docs-components/tsconfig.json
+++ b/docs-components/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../tsconfig.json"
+}

--- a/docs-components/tsconfig.json
+++ b/docs-components/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../tsconfig.json"
+  "extends": "../tsconfig.json",
+  "include": ["declarations.d.ts", "**/*.tsx"]
 }

--- a/packages/react/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/react/src/components/Accordion/Accordion.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
 import { Button, Link } from '../';

--- a/packages/react/src/components/Accordion/Accordion.test.tsx
+++ b/packages/react/src/components/Accordion/Accordion.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/Accordion/Accordion.tsx
+++ b/packages/react/src/components/Accordion/Accordion.tsx
@@ -1,5 +1,5 @@
-import type { HTMLAttributes } from 'react';
-import React, { forwardRef } from 'react';
+import type { ReactNode, HTMLAttributes } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 
 import classes from './Accordion.module.css';
@@ -10,23 +10,22 @@ export type AccordionProps = {
   /** Show border */
   border?: boolean;
   /** Instances of `Accordion.Item` */
-  children: React.ReactNode;
+  children: ReactNode;
 } & HTMLAttributes<HTMLDivElement>;
 
-export const Accordion = forwardRef<
-  HTMLDivElement,
-  AccordionProps & { children: React.ReactNode }
->(({ border = false, color = 'neutral', className, ...rest }, ref) => (
-  <div
-    className={cl(
-      classes.accordion,
-      classes[color],
-      {
-        [classes.border]: border,
-      },
-      className,
-    )}
-    ref={ref}
-    {...rest}
-  />
-));
+export const Accordion = forwardRef<HTMLDivElement, AccordionProps>(
+  ({ border = false, color = 'neutral', className, ...rest }, ref) => (
+    <div
+      className={cl(
+        classes.accordion,
+        classes[color],
+        {
+          [classes.border]: border,
+        },
+        className,
+      )}
+      ref={ref}
+      {...rest}
+    />
+  ),
+);

--- a/packages/react/src/components/Accordion/AccordionContent/AccordionContent.test.tsx
+++ b/packages/react/src/components/Accordion/AccordionContent/AccordionContent.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { Accordion } from '..';

--- a/packages/react/src/components/Accordion/AccordionContent/AccordionContent.tsx
+++ b/packages/react/src/components/Accordion/AccordionContent/AccordionContent.tsx
@@ -1,6 +1,6 @@
 import cl from 'clsx';
-import type { HTMLAttributes } from 'react';
-import React, { forwardRef, useContext } from 'react';
+import type { ReactNode, HTMLAttributes } from 'react';
+import { forwardRef, useContext } from 'react';
 
 import { AnimateHeight } from '../../../utilities/AnimateHeight';
 import { Paragraph } from '../../..';
@@ -9,7 +9,7 @@ import { AccordionItemContext } from '../AccordionItem';
 
 export type AccordionContentProps = {
   /** Content inside `Accordion.Content`*/
-  children: React.ReactNode;
+  children: ReactNode;
 } & HTMLAttributes<HTMLDivElement>;
 
 export const AccordionContent = forwardRef<

--- a/packages/react/src/components/Accordion/AccordionHeader/AccordionHeader.test.tsx
+++ b/packages/react/src/components/Accordion/AccordionHeader/AccordionHeader.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/Accordion/AccordionHeader/AccordionHeader.tsx
+++ b/packages/react/src/components/Accordion/AccordionHeader/AccordionHeader.tsx
@@ -1,7 +1,7 @@
 import { ChevronDownIcon } from '@navikt/aksel-icons';
 import cl from 'clsx';
-import type { MouseEventHandler, HTMLAttributes } from 'react';
-import React, { forwardRef, useContext } from 'react';
+import type { ReactNode, MouseEventHandler, HTMLAttributes } from 'react';
+import { forwardRef, useContext } from 'react';
 
 import { Paragraph, Heading } from '../..';
 import classes from '../Accordion.module.css';
@@ -14,7 +14,7 @@ export type AccordionHeaderProps = {
   /** Handle when clicked on header */
   onHeaderClick?: MouseEventHandler<HTMLButtonElement> | undefined;
   /** Heading text */
-  children: React.ReactNode;
+  children: ReactNode;
 } & HTMLAttributes<HTMLHeadingElement>;
 
 export const AccordionHeader = forwardRef<
@@ -30,7 +30,7 @@ export const AccordionHeader = forwardRef<
     return null;
   }
 
-  const handleClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+  const handleClick: MouseEventHandler<HTMLButtonElement> = (e) => {
     context.toggleOpen();
     onHeaderClick && onHeaderClick(e);
   };

--- a/packages/react/src/components/Accordion/AccordionItem/AccordionItem.test.tsx
+++ b/packages/react/src/components/Accordion/AccordionItem/AccordionItem.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { Accordion } from '..';

--- a/packages/react/src/components/Accordion/AccordionItem/AccordionItem.tsx
+++ b/packages/react/src/components/Accordion/AccordionItem/AccordionItem.tsx
@@ -1,6 +1,6 @@
 import cl from 'clsx';
-import type { HTMLAttributes } from 'react';
-import React, { createContext, forwardRef, useState, useId } from 'react';
+import type { ReactNode, HTMLAttributes } from 'react';
+import { createContext, forwardRef, useState, useId } from 'react';
 
 import classes from '../Accordion.module.css';
 
@@ -14,7 +14,7 @@ export type AccordionItemProps = {
   /**  Defaults the accordion to open if not controlled */
   defaultOpen?: boolean;
   /** Content should be one `<Accordion.Header>` and `<Accordion.Content>` */
-  children: React.ReactNode;
+  children: ReactNode;
 } & HTMLAttributes<HTMLDivElement>;
 
 export type AccordionItemContextProps = {

--- a/packages/react/src/components/Alert/Alert.stories.tsx
+++ b/packages/react/src/components/Alert/Alert.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
 import { Heading, Paragraph, Link } from '../';

--- a/packages/react/src/components/Alert/Alert.test.tsx
+++ b/packages/react/src/components/Alert/Alert.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { Heading } from '../';

--- a/packages/react/src/components/Alert/Alert.tsx
+++ b/packages/react/src/components/Alert/Alert.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from 'react';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import {
   InformationSquareFillIcon,
   CheckmarkCircleFillIcon,

--- a/packages/react/src/components/Box/Box.stories.tsx
+++ b/packages/react/src/components/Box/Box.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
 import { Box } from './Box';

--- a/packages/react/src/components/Box/Box.test.tsx
+++ b/packages/react/src/components/Box/Box.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render as renderRtl, screen } from '@testing-library/react';
 
 import { Box } from './Box';

--- a/packages/react/src/components/Box/Box.tsx
+++ b/packages/react/src/components/Box/Box.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from 'react';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 import { Slot } from '@radix-ui/react-slot';
 

--- a/packages/react/src/components/Button/Button.stories.tsx
+++ b/packages/react/src/components/Button/Button.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryObj, StoryFn, ReactRenderer } from '@storybook/react';
 import type { PartialStoryFn } from '@storybook/types';
 import * as akselIcons from '@navikt/aksel-icons';

--- a/packages/react/src/components/Button/Button.test.tsx
+++ b/packages/react/src/components/Button/Button.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render as renderRtl, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { CheckmarkIcon } from '@navikt/aksel-icons';

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { ButtonHTMLAttributes } from 'react';
 import cl from 'clsx';
 import { Slot } from '@radix-ui/react-slot';

--- a/packages/react/src/components/Card/Card.stories.tsx
+++ b/packages/react/src/components/Card/Card.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 import { TrashFillIcon } from '@navikt/aksel-icons';
 

--- a/packages/react/src/components/Card/Card.test.tsx
+++ b/packages/react/src/components/Card/Card.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render as renderRtl, screen } from '@testing-library/react';
 
 import type { CardProps } from './Card';

--- a/packages/react/src/components/Card/Card.tsx
+++ b/packages/react/src/components/Card/Card.tsx
@@ -1,5 +1,5 @@
-import type { HTMLAttributes } from 'react';
-import React, { forwardRef } from 'react';
+import type { ReactNode, HTMLAttributes } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 import { Slot } from '@radix-ui/react-slot';
 
@@ -25,7 +25,7 @@ export type CardProps = {
    */
   isLink?: boolean;
   /** Instances of `Card.Header`, `Card.Content`, `Card.Footer` or other React nodes like `Divider` */
-  children: React.ReactNode;
+  children: ReactNode;
 
   /**
    * @deprecated Use `asChild` and `isLink={true}` instead

--- a/packages/react/src/components/Card/CardContent.tsx
+++ b/packages/react/src/components/Card/CardContent.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, type HTMLAttributes } from 'react';
+import type { HTMLAttributes } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 import { Slot } from '@radix-ui/react-slot';
 

--- a/packages/react/src/components/Card/CardFooter.tsx
+++ b/packages/react/src/components/Card/CardFooter.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, type HTMLAttributes } from 'react';
+import type { HTMLAttributes } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 import { Slot } from '@radix-ui/react-slot';
 

--- a/packages/react/src/components/Card/CardHeader.tsx
+++ b/packages/react/src/components/Card/CardHeader.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, type HTMLAttributes } from 'react';
+import type { HTMLAttributes } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 import { Slot } from '@radix-ui/react-slot';
 

--- a/packages/react/src/components/Card/CardMedia.tsx
+++ b/packages/react/src/components/Card/CardMedia.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, type HTMLAttributes } from 'react';
+import type { HTMLAttributes } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 import { Slot } from '@radix-ui/react-slot';
 

--- a/packages/react/src/components/Chip/Group/Group.stories.tsx
+++ b/packages/react/src/components/Chip/Group/Group.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
 import { Chip } from '..';

--- a/packages/react/src/components/Chip/Group/Group.test.tsx
+++ b/packages/react/src/components/Chip/Group/Group.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { Chip } from '..';

--- a/packages/react/src/components/Chip/Group/Group.tsx
+++ b/packages/react/src/components/Chip/Group/Group.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from 'react';
-import React, { forwardRef, createContext } from 'react';
+import { Children, isValidElement, forwardRef, createContext } from 'react';
 import cl from 'clsx';
 
 import classes from '../Chip.module.css';
@@ -25,10 +25,8 @@ export const Group = forwardRef<HTMLUListElement, ChipGroupProps>(
       {...rest}
     >
       <ChipGroupContext.Provider value={{ size }}>
-        {React.Children.toArray(children).map((child, index) =>
-          React.isValidElement(child) ? (
-            <li key={`chip-${index}`}>{child}</li>
-          ) : null,
+        {Children.toArray(children).map((child, index) =>
+          isValidElement(child) ? <li key={`chip-${index}`}>{child}</li> : null,
         )}
       </ChipGroupContext.Provider>
     </ul>

--- a/packages/react/src/components/Chip/Removable/Removable.test.tsx
+++ b/packages/react/src/components/Chip/Removable/Removable.test.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/Chip/Removable/Removable.tsx
+++ b/packages/react/src/components/Chip/Removable/Removable.tsx
@@ -1,5 +1,5 @@
 import type { ButtonHTMLAttributes } from 'react';
-import React, { useContext, forwardRef } from 'react';
+import { useContext, forwardRef } from 'react';
 import cl from 'clsx';
 import { XMarkIcon } from '@navikt/aksel-icons';
 

--- a/packages/react/src/components/Chip/Toggle/Toggle.test.tsx
+++ b/packages/react/src/components/Chip/Toggle/Toggle.test.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/Chip/Toggle/Toggle.tsx
+++ b/packages/react/src/components/Chip/Toggle/Toggle.tsx
@@ -1,5 +1,5 @@
 import type { ButtonHTMLAttributes } from 'react';
-import React, { forwardRef, useContext } from 'react';
+import { forwardRef, useContext } from 'react';
 import { CheckmarkIcon } from '@navikt/aksel-icons';
 import cl from 'clsx';
 

--- a/packages/react/src/components/Divider/Divider.stories.tsx
+++ b/packages/react/src/components/Divider/Divider.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
 import { Paragraph } from '../Typography';

--- a/packages/react/src/components/Divider/Divider.tsx
+++ b/packages/react/src/components/Divider/Divider.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type * as React from 'react';
 import cl from 'clsx';
 
 import classes from './Divider.module.css';

--- a/packages/react/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/react/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -1,5 +1,5 @@
 import type { StoryFn, Meta } from '@storybook/react';
-import React, { useEffect, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { LinkIcon } from '@navikt/aksel-icons';
 
 import { Button, Divider } from '../..';
@@ -117,7 +117,7 @@ export const InPortal: StoryFn<typeof DropdownMenu> = () => {
 };
 
 export const Controlled: StoryFn<typeof DropdownMenu> = () => {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
 
   return (
     <>
@@ -156,7 +156,7 @@ export const Controlled: StoryFn<typeof DropdownMenu> = () => {
 
 export const WithAnchorEl: StoryFn<typeof DropdownMenu> = (args) => {
   const buttonRef = useRef<HTMLButtonElement | null>(null);
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     setOpen(args.open || false);

--- a/packages/react/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/react/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { act, render as renderRtl, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/DropdownMenu/DropdownMenu.tsx
+++ b/packages/react/src/components/DropdownMenu/DropdownMenu.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useEffect, useRef, useState } from 'react';
+import { createContext, useEffect, useRef, useState } from 'react';
+import type * as React from 'react';
 import type { Placement } from '@floating-ui/react';
 
 import type { PortalProps } from '../../types/Portal';

--- a/packages/react/src/components/DropdownMenu/DropdownMenuContent.tsx
+++ b/packages/react/src/components/DropdownMenu/DropdownMenuContent.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, useContext, useRef } from 'react';
+import { forwardRef, useContext, useRef } from 'react';
+import * as React from 'react';
 import {
   useFloating,
   autoUpdate,

--- a/packages/react/src/components/DropdownMenu/DropdownMenuGroup/DropdownMenuGroup.tsx
+++ b/packages/react/src/components/DropdownMenu/DropdownMenuGroup/DropdownMenuGroup.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, useContext, useId } from 'react';
+import { forwardRef, useContext, useId } from 'react';
+import type * as React from 'react';
 import cl from 'clsx';
 
 import { Paragraph } from '../../Typography';

--- a/packages/react/src/components/DropdownMenu/DropdownMenuItem/DropdownMenuItem.tsx
+++ b/packages/react/src/components/DropdownMenu/DropdownMenuItem/DropdownMenuItem.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useContext } from 'react';
+import { forwardRef, useContext } from 'react';
 
 import type { ButtonProps } from '../../Button';
 import { Button } from '../../Button';

--- a/packages/react/src/components/DropdownMenu/DropdownMenuTrigger.tsx
+++ b/packages/react/src/components/DropdownMenu/DropdownMenuTrigger.tsx
@@ -1,5 +1,6 @@
 import { Slot } from '@radix-ui/react-slot';
-import React, { forwardRef, useContext } from 'react';
+import { forwardRef, useContext } from 'react';
+import type * as React from 'react';
 import { useMergeRefs } from '@floating-ui/react';
 
 import { Button } from '../Button';

--- a/packages/react/src/components/HelpText/HelpText.stories.tsx
+++ b/packages/react/src/components/HelpText/HelpText.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryFn, StoryObj } from '@storybook/react';
-import React from 'react';
 
 import { HelpText } from '.';
 

--- a/packages/react/src/components/HelpText/HelpText.test.tsx
+++ b/packages/react/src/components/HelpText/HelpText.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { act, render as renderRtl, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/HelpText/HelpText.tsx
+++ b/packages/react/src/components/HelpText/HelpText.tsx
@@ -1,5 +1,5 @@
 import type { ButtonHTMLAttributes } from 'react';
-import React from 'react';
+import { useState } from 'react';
 import cl from 'clsx';
 import type { Placement } from '@floating-ui/utils';
 
@@ -38,7 +38,7 @@ const HelpText = ({
   children,
   ...rest
 }: HelpTextProps) => {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
 
   return (
     <>

--- a/packages/react/src/components/HelpText/HelpTextIcon.test.tsx
+++ b/packages/react/src/components/HelpText/HelpTextIcon.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render as renderRtl, screen } from '@testing-library/react';
 
 import type { HelpTextIconProps } from './HelpTextIcon';

--- a/packages/react/src/components/HelpText/HelpTextIcon.tsx
+++ b/packages/react/src/components/HelpText/HelpTextIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export type HelpTextIconProps = {
   className: string;
   filled?: boolean;

--- a/packages/react/src/components/Link/Link.stories.tsx
+++ b/packages/react/src/components/Link/Link.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { EnvelopeClosedIcon } from '@navikt/aksel-icons';
 

--- a/packages/react/src/components/Link/Link.test.tsx
+++ b/packages/react/src/components/Link/Link.test.tsx
@@ -1,4 +1,4 @@
-import React, { createRef } from 'react';
+import { createRef } from 'react';
 import type { ComponentProps, RefObject } from 'react';
 import { render as renderRtl, screen } from '@testing-library/react';
 

--- a/packages/react/src/components/Link/Link.tsx
+++ b/packages/react/src/components/Link/Link.tsx
@@ -1,5 +1,5 @@
 import type { AnchorHTMLAttributes, ReactNode } from 'react';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 import { Slot } from '@radix-ui/react-slot';
 

--- a/packages/react/src/components/List/List.stories.tsx
+++ b/packages/react/src/components/List/List.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
 import { Link } from '../Link';

--- a/packages/react/src/components/List/List.test.tsx
+++ b/packages/react/src/components/List/List.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render as renderRtl, screen } from '@testing-library/react';
 
 import type { ListProps } from './List';

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes, ReactNode } from 'react';
-import React, { useId, useMemo } from 'react';
+import { forwardRef, useId, useMemo } from 'react';
 import cl from 'clsx';
 
 import type { HeadingProps } from '../Typography';
@@ -40,7 +40,7 @@ export type ListProps = {
   headingId?: string;
 } & HTMLAttributes<HTMLDivElement>;
 
-export const List = React.forwardRef<HTMLDivElement, ListProps>(
+export const List = forwardRef<HTMLDivElement, ListProps>(
   (
     {
       children,

--- a/packages/react/src/components/List/ListItem/ListItem.tsx
+++ b/packages/react/src/components/List/ListItem/ListItem.tsx
@@ -1,12 +1,12 @@
-import React from 'react';
 import type { HTMLAttributes } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 
 import classes from './ListItem.module.css';
 
 export type ListItemProps = HTMLAttributes<HTMLLIElement>;
 
-export const ListItem = React.forwardRef<HTMLLIElement, ListItemProps>(
+export const ListItem = forwardRef<HTMLLIElement, ListItemProps>(
   ({ children, className, ...rest }, ref) => (
     <li
       className={cl(classes.listItem, className)}

--- a/packages/react/src/components/Modal/Modal.stories.tsx
+++ b/packages/react/src/components/Modal/Modal.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
 import { Button } from '../Button';

--- a/packages/react/src/components/Modal/Modal.test.tsx
+++ b/packages/react/src/components/Modal/Modal.test.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import { useRef } from 'react';
 import { act, render as renderRtl, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -1,5 +1,5 @@
 import type { DialogHTMLAttributes } from 'react';
-import React, { createContext, forwardRef, useEffect, useRef } from 'react';
+import { createContext, forwardRef, useEffect, useRef } from 'react';
 import cl from 'clsx';
 import {
   FloatingFocusManager,

--- a/packages/react/src/components/Modal/ModalContent/ModaContent.tsx
+++ b/packages/react/src/components/Modal/ModalContent/ModaContent.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { HTMLAttributes } from 'react';
 import cl from 'clsx';
 

--- a/packages/react/src/components/Modal/ModalFooter/ModalFooter.tsx
+++ b/packages/react/src/components/Modal/ModalFooter/ModalFooter.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from 'react';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 
 import classes from './ModalFooter.module.css';

--- a/packages/react/src/components/Modal/ModalHeader/ModalHeader.tsx
+++ b/packages/react/src/components/Modal/ModalHeader/ModalHeader.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from 'react';
-import React, { forwardRef, useContext } from 'react';
+import { forwardRef, useContext } from 'react';
 import cl from 'clsx';
 import { XMarkIcon } from '@navikt/aksel-icons';
 

--- a/packages/react/src/components/Modal/useModalState.ts
+++ b/packages/react/src/components/Modal/useModalState.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 export const useModalState = (modalRef: React.RefObject<HTMLDialogElement>) => {
   const [isOpen, setIsOpen] = React.useState(false);

--- a/packages/react/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/react/src/components/Pagination/Pagination.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
 import { Pagination } from '.';

--- a/packages/react/src/components/Pagination/Pagination.test.tsx
+++ b/packages/react/src/components/Pagination/Pagination.test.tsx
@@ -1,5 +1,4 @@
 import { act, render as renderRtl, screen } from '@testing-library/react';
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 
 import type { PaginationProps } from './Pagination';

--- a/packages/react/src/components/Pagination/Pagination.tsx
+++ b/packages/react/src/components/Pagination/Pagination.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from 'react';
-import * as React from 'react';
+import type * as React from 'react';
 import cl from 'clsx';
 import { ChevronLeftIcon, ChevronRightIcon } from '@navikt/aksel-icons';
 

--- a/packages/react/src/components/Popover/Popover.stories.tsx
+++ b/packages/react/src/components/Popover/Popover.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryFn } from '@storybook/react';
-import React, { useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 
 import { Button, Paragraph } from '../..';
 
@@ -35,7 +35,7 @@ Preview.args = {
 Preview.decorators = [marginDecorator];
 
 export const Variants: StoryFn<typeof Popover> = () => {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     setOpen(true);
@@ -89,7 +89,7 @@ export const Variants: StoryFn<typeof Popover> = () => {
 Variants.decorators = [marginDecorator];
 
 export const Controlled: StoryFn<typeof Popover> = () => {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
 
   return (
     <>
@@ -130,8 +130,8 @@ export const InPortal = () => {
 };
 
 export const AnchorEl = () => {
-  const anchorEl = React.useRef<HTMLButtonElement>(null);
-  const [open, setOpen] = React.useState(false);
+  const anchorEl = useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = useState(false);
 
   return (
     <>

--- a/packages/react/src/components/Popover/Popover.test.tsx
+++ b/packages/react/src/components/Popover/Popover.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { act, render as renderRtl, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/Popover/Popover.tsx
+++ b/packages/react/src/components/Popover/Popover.tsx
@@ -1,5 +1,6 @@
 import type { Placement } from '@floating-ui/react';
-import React, { useRef } from 'react';
+import { useRef } from 'react';
+import * as React from 'react';
 
 import type { PortalProps } from '../../types/Portal';
 

--- a/packages/react/src/components/Popover/PopoverContent.tsx
+++ b/packages/react/src/components/Popover/PopoverContent.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, useContext, useMemo, useRef } from 'react';
+import { forwardRef, useContext, useMemo, useRef } from 'react';
+import * as React from 'react';
 import {
   FloatingPortal,
   arrow,

--- a/packages/react/src/components/Popover/PopoverTrigger.tsx
+++ b/packages/react/src/components/Popover/PopoverTrigger.tsx
@@ -1,5 +1,6 @@
 import { Slot } from '@radix-ui/react-slot';
-import React, { forwardRef, useContext } from 'react';
+import { forwardRef, useContext } from 'react';
+import type * as React from 'react';
 import { useMergeRefs } from '@floating-ui/react';
 
 import { Button } from '../Button';

--- a/packages/react/src/components/Skeleton/Circle/Circle.test.tsx
+++ b/packages/react/src/components/Skeleton/Circle/Circle.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { Skeleton } from '..';

--- a/packages/react/src/components/Skeleton/Circle/Circle.tsx
+++ b/packages/react/src/components/Skeleton/Circle/Circle.tsx
@@ -1,4 +1,4 @@
-import React, { type HTMLAttributes } from 'react';
+import type { HTMLAttributes } from 'react';
 import cl from 'clsx';
 
 import classes from '../Skeleton.module.css';

--- a/packages/react/src/components/Skeleton/Rectangle/Rectangle.test.tsx
+++ b/packages/react/src/components/Skeleton/Rectangle/Rectangle.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { Skeleton } from '..';

--- a/packages/react/src/components/Skeleton/Rectangle/Rectangle.tsx
+++ b/packages/react/src/components/Skeleton/Rectangle/Rectangle.tsx
@@ -1,4 +1,4 @@
-import React, { type HTMLAttributes } from 'react';
+import type { HTMLAttributes } from 'react';
 import cl from 'clsx';
 
 import { useSynchronizedAnimation } from '../../../hooks';

--- a/packages/react/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/react/src/components/Skeleton/Skeleton.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryObj, StoryFn } from '@storybook/react';
 
 import { Paragraph, Heading } from '../Typography';

--- a/packages/react/src/components/Skeleton/Text/Text.test.tsx
+++ b/packages/react/src/components/Skeleton/Text/Text.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { Skeleton } from '..';

--- a/packages/react/src/components/Skeleton/Text/Text.tsx
+++ b/packages/react/src/components/Skeleton/Text/Text.tsx
@@ -1,4 +1,4 @@
-import React, { type HTMLAttributes } from 'react';
+import type { HTMLAttributes } from 'react';
 import cl from 'clsx';
 
 import classes from '../Skeleton.module.css';

--- a/packages/react/src/components/SkipLink/SkipLink.stories.tsx
+++ b/packages/react/src/components/SkipLink/SkipLink.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
 import { SkipLink } from '.';

--- a/packages/react/src/components/SkipLink/SkipLink.test.tsx
+++ b/packages/react/src/components/SkipLink/SkipLink.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render as renderRtl, screen } from '@testing-library/react';
 
 import { SkipLink } from './SkipLink';

--- a/packages/react/src/components/SkipLink/SkipLink.tsx
+++ b/packages/react/src/components/SkipLink/SkipLink.tsx
@@ -1,5 +1,4 @@
 import type { AnchorHTMLAttributes, ReactNode } from 'react';
-import React from 'react';
 import cl from 'clsx';
 
 import utilityClasses from './../../utilities/utility.module.css';

--- a/packages/react/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/react/src/components/Spinner/Spinner.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
 import { Spinner } from '.';

--- a/packages/react/src/components/Spinner/Spinner.test.tsx
+++ b/packages/react/src/components/Spinner/Spinner.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { Spinner } from './Spinner';

--- a/packages/react/src/components/Spinner/Spinner.tsx
+++ b/packages/react/src/components/Spinner/Spinner.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type * as React from 'react';
 import cl from 'clsx';
 
 import { useSynchronizedAnimation } from '../../hooks';

--- a/packages/react/src/components/Table/Table.stories.tsx
+++ b/packages/react/src/components/Table/Table.stories.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent } from 'react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
 import { Checkbox } from '../form/Checkbox';

--- a/packages/react/src/components/Table/Table.test.tsx
+++ b/packages/react/src/components/Table/Table.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render as renderRtl, screen } from '@testing-library/react';
 
 import type { TableProps } from './Table';

--- a/packages/react/src/components/Table/Table.tsx
+++ b/packages/react/src/components/Table/Table.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import cl from 'clsx';
 
 import { Paragraph } from '../Typography';

--- a/packages/react/src/components/Table/TableBody.tsx
+++ b/packages/react/src/components/Table/TableBody.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 export type TableBodyProps = React.HTMLAttributes<HTMLTableSectionElement>;
 

--- a/packages/react/src/components/Table/TableCell.tsx
+++ b/packages/react/src/components/Table/TableCell.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import cl from 'clsx';
 
 import classes from './Table.module.css';

--- a/packages/react/src/components/Table/TableHead.tsx
+++ b/packages/react/src/components/Table/TableHead.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import cl from 'clsx';
 
 import classes from './Table.module.css';

--- a/packages/react/src/components/Table/TableHeaderCell.test.tsx
+++ b/packages/react/src/components/Table/TableHeaderCell.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render as renderRtl, screen } from '@testing-library/react';
 
 import type { TableHeaderCellProps } from './TableHeaderCell';

--- a/packages/react/src/components/Table/TableHeaderCell.tsx
+++ b/packages/react/src/components/Table/TableHeaderCell.tsx
@@ -4,7 +4,7 @@ import {
   ChevronUpDownIcon,
 } from '@navikt/aksel-icons';
 import type { AriaAttributes } from 'react';
-import React from 'react';
+import * as React from 'react';
 import cl from 'clsx';
 
 import utilityClasses from '../../utilities/utility.module.css';

--- a/packages/react/src/components/Table/TableRow.tsx
+++ b/packages/react/src/components/Table/TableRow.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import cl from 'clsx';
 
 import classes from './Table.module.css';

--- a/packages/react/src/components/Tabs/Tab/Tab.test.tsx
+++ b/packages/react/src/components/Tabs/Tab/Tab.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/Tabs/Tab/Tab.tsx
+++ b/packages/react/src/components/Tabs/Tab/Tab.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from 'react';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 
 import { RovingTabindexItem } from '../../../utilities/RovingTabIndex';

--- a/packages/react/src/components/Tabs/TabContent/TabContent.test.tsx
+++ b/packages/react/src/components/Tabs/TabContent/TabContent.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { Tabs } from '..';

--- a/packages/react/src/components/Tabs/TabContent/TabContent.tsx
+++ b/packages/react/src/components/Tabs/TabContent/TabContent.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from 'react';
-import React, { forwardRef, useContext } from 'react';
+import { forwardRef, useContext } from 'react';
 import cl from 'clsx';
 
 import { TabsContext } from '../Tabs';

--- a/packages/react/src/components/Tabs/TabList/TabList.test.tsx
+++ b/packages/react/src/components/Tabs/TabList/TabList.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/Tabs/TabList/TabList.tsx
+++ b/packages/react/src/components/Tabs/TabList/TabList.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from 'react';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 
 import { RovingTabindexRoot } from '../../../utilities/RovingTabIndex';

--- a/packages/react/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/react/src/components/Tabs/Tabs.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 import * as icons from '@navikt/aksel-icons';
 

--- a/packages/react/src/components/Tabs/Tabs.test.tsx
+++ b/packages/react/src/components/Tabs/Tabs.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from 'react';
-import React, { createContext, forwardRef, useState } from 'react';
+import { createContext, forwardRef, useState } from 'react';
 
 export type TabsProps = {
   /** Controlled state for `Tabs` component. */

--- a/packages/react/src/components/Tag/Tag.stories.tsx
+++ b/packages/react/src/components/Tag/Tag.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 
 import { Stack } from '../../../../../docs-components';

--- a/packages/react/src/components/Tag/Tag.test.tsx
+++ b/packages/react/src/components/Tag/Tag.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { Tag } from './Tag';

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from 'react';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 
 import type { ParagraphProps } from '../Typography';

--- a/packages/react/src/components/ToggleGroup/ToggleGroup.stories.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroup.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 import * as icons from '@navikt/aksel-icons';
 

--- a/packages/react/src/components/ToggleGroup/ToggleGroup.test.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroup.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/ToggleGroup/ToggleGroup.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroup.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from 'react';
-import React, { createContext, forwardRef, useId, useState } from 'react';
+import { createContext, forwardRef, useId, useState } from 'react';
 import cl from 'clsx';
 
 import { RovingTabindexRoot } from '../../utilities/RovingTabIndex';

--- a/packages/react/src/components/ToggleGroup/ToggleGroupItem/ToggleGroupItem.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroupItem/ToggleGroupItem.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 
 import type { ButtonProps } from '../../Button';

--- a/packages/react/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj, StoryFn } from '@storybook/react';
-import React from 'react';
 
 import { Paragraph, Button } from '../..';
 

--- a/packages/react/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import {
   act,

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -1,5 +1,6 @@
 import type { HTMLAttributes } from 'react';
-import React, { cloneElement, forwardRef, useState } from 'react';
+import { cloneElement, forwardRef, useState } from 'react';
+import * as React from 'react';
 import cl from 'clsx';
 import {
   useFloating,

--- a/packages/react/src/components/Typography/ErrorMessage/ErrorMessage.tsx
+++ b/packages/react/src/components/Typography/ErrorMessage/ErrorMessage.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from 'react';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 import { Slot } from '@radix-ui/react-slot';
 

--- a/packages/react/src/components/Typography/Heading/Heading.tsx
+++ b/packages/react/src/components/Typography/Heading/Heading.tsx
@@ -1,5 +1,5 @@
 import type { ElementType, HTMLAttributes } from 'react';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 import { Slot } from '@radix-ui/react-slot';
 

--- a/packages/react/src/components/Typography/Ingress/Ingress.tsx
+++ b/packages/react/src/components/Typography/Ingress/Ingress.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from 'react';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 import { Slot } from '@radix-ui/react-slot';
 

--- a/packages/react/src/components/Typography/Label/Label.tsx
+++ b/packages/react/src/components/Typography/Label/Label.tsx
@@ -1,5 +1,5 @@
 import type { LabelHTMLAttributes } from 'react';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 import { Slot } from '@radix-ui/react-slot';
 

--- a/packages/react/src/components/Typography/Paragraph/Paragraph.tsx
+++ b/packages/react/src/components/Typography/Paragraph/Paragraph.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from 'react';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 import { Slot } from '@radix-ui/react-slot';
 

--- a/packages/react/src/components/Typography/Typography.stories.tsx
+++ b/packages/react/src/components/Typography/Typography.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
 import { Paragraph, Heading, Ingress } from './';

--- a/packages/react/src/components/form/CharacterCounter.tsx
+++ b/packages/react/src/components/form/CharacterCounter.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import utilityClasses from '../../utilities/utility.module.css';
 import { ErrorMessage } from '../Typography';
 

--- a/packages/react/src/components/form/Checkbox/Checkbox.test.tsx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/form/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.tsx
@@ -1,5 +1,5 @@
 import type { InputHTMLAttributes, ReactNode } from 'react';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 
 import { omit } from '../../../utilities';

--- a/packages/react/src/components/form/Checkbox/Group/Group.stories.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
 import { Button, Paragraph } from '../../..';

--- a/packages/react/src/components/form/Checkbox/Group/Group.test.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/form/Checkbox/Group/Group.tsx
+++ b/packages/react/src/components/form/Checkbox/Group/Group.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import React, { useState, forwardRef, createContext } from 'react';
+import { useState, forwardRef, createContext } from 'react';
 
 import type { FieldsetProps } from '../../Fieldset';
 import { Fieldset } from '../../Fieldset';

--- a/packages/react/src/components/form/Combobox/Combobox.stories.tsx
+++ b/packages/react/src/components/form/Combobox/Combobox.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
 import { Button } from '../../Button';

--- a/packages/react/src/components/form/Combobox/Combobox.test.tsx
+++ b/packages/react/src/components/form/Combobox/Combobox.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type * as React from 'react';
 import { act, render as renderRtl, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/form/Combobox/Combobox.tsx
+++ b/packages/react/src/components/form/Combobox/Combobox.tsx
@@ -1,10 +1,5 @@
-import React, {
-  useState,
-  useRef,
-  createContext,
-  useEffect,
-  useId,
-} from 'react';
+import { useState, useRef, createContext, useEffect, useId } from 'react';
+import type * as React from 'react';
 import {
   FloatingFocusManager,
   autoUpdate,

--- a/packages/react/src/components/form/Combobox/Empty/Empty.tsx
+++ b/packages/react/src/components/form/Combobox/Empty/Empty.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef, useContext } from 'react';
+import { forwardRef, useContext } from 'react';
+import type * as React from 'react';
 import cl from 'clsx';
 
 import { ComboboxContext } from '../Combobox';

--- a/packages/react/src/components/form/Combobox/Option/Description/Description.tsx
+++ b/packages/react/src/components/form/Combobox/Option/Description/Description.tsx
@@ -1,4 +1,5 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
+import type * as React from 'react';
 import cl from 'clsx';
 
 import classes from './Description.module.css';

--- a/packages/react/src/components/form/Combobox/Option/Icon/SelectedIcon.tsx
+++ b/packages/react/src/components/form/Combobox/Option/Icon/SelectedIcon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { CheckmarkIcon } from '@navikt/aksel-icons';
 import cl from 'clsx';
 

--- a/packages/react/src/components/form/Combobox/Option/Option.tsx
+++ b/packages/react/src/components/form/Combobox/Option/Option.tsx
@@ -1,10 +1,5 @@
-import React, {
-  forwardRef,
-  useContext,
-  useEffect,
-  useId,
-  useMemo,
-} from 'react';
+import { forwardRef, useContext, useEffect, useId, useMemo } from 'react';
+import type * as React from 'react';
 import cl from 'clsx';
 import { useMergeRefs } from '@floating-ui/react';
 

--- a/packages/react/src/components/form/Combobox/internal/ComboboxChips.tsx
+++ b/packages/react/src/components/form/Combobox/internal/ComboboxChips.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 
 import { ChipRemovable } from '../../../Chip';
 import { ComboboxContext } from '../Combobox';

--- a/packages/react/src/components/form/Combobox/internal/ComboboxClearButton.tsx
+++ b/packages/react/src/components/form/Combobox/internal/ComboboxClearButton.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { XMarkIcon } from '@navikt/aksel-icons';
 import cl from 'clsx';
 

--- a/packages/react/src/components/form/Combobox/internal/ComboboxError.tsx
+++ b/packages/react/src/components/form/Combobox/internal/ComboboxError.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import classes from '../Combobox.module.css';
 import { ErrorMessage } from '../../../Typography';
 import type { ComboboxProps } from '../Combobox';

--- a/packages/react/src/components/form/Combobox/internal/ComboboxInput.tsx
+++ b/packages/react/src/components/form/Combobox/internal/ComboboxInput.tsx
@@ -1,4 +1,5 @@
-import React, { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
+import type * as React from 'react';
 import cl from 'clsx';
 import { ChevronUpIcon, ChevronDownIcon } from '@navikt/aksel-icons';
 

--- a/packages/react/src/components/form/Combobox/internal/ComboboxLabel.tsx
+++ b/packages/react/src/components/form/Combobox/internal/ComboboxLabel.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import cl from 'clsx';
 import { PadlockLockedFillIcon } from '@navikt/aksel-icons';
 

--- a/packages/react/src/components/form/Combobox/internal/ComboboxNative.tsx
+++ b/packages/react/src/components/form/Combobox/internal/ComboboxNative.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import type { Option } from '../useCombobox';
 import type { ComboboxProps } from '../Combobox';
 

--- a/packages/react/src/components/form/Combobox/useCombobox.test.tsx
+++ b/packages/react/src/components/form/Combobox/useCombobox.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { renderHook } from '@testing-library/react';
 
 import type { UseComboboxProps } from './useCombobox';

--- a/packages/react/src/components/form/Combobox/useCombobox.tsx
+++ b/packages/react/src/components/form/Combobox/useCombobox.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
+import * as React from 'react';
 
 import type { ComboboxOptionProps } from './Option/Option';
 import { ComboboxOption } from './Option/Option';

--- a/packages/react/src/components/form/Fieldset/Fieldset.stories.tsx
+++ b/packages/react/src/components/form/Fieldset/Fieldset.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
 import { Fieldset } from '.';

--- a/packages/react/src/components/form/Fieldset/Fieldset.test.tsx
+++ b/packages/react/src/components/form/Fieldset/Fieldset.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 import { Fieldset } from './Fieldset';

--- a/packages/react/src/components/form/Fieldset/Fieldset.tsx
+++ b/packages/react/src/components/form/Fieldset/Fieldset.tsx
@@ -1,5 +1,5 @@
 import type { FieldsetHTMLAttributes, ReactNode } from 'react';
-import React, { useContext, forwardRef, createContext } from 'react';
+import { useContext, forwardRef, createContext } from 'react';
 import cl from 'clsx';
 import { PadlockLockedFillIcon } from '@navikt/aksel-icons';
 

--- a/packages/react/src/components/form/NativeSelect/NativeSelect.stories.tsx
+++ b/packages/react/src/components/form/NativeSelect/NativeSelect.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
 import { NativeSelect } from './NativeSelect';

--- a/packages/react/src/components/form/NativeSelect/NativeSelect.test.tsx
+++ b/packages/react/src/components/form/NativeSelect/NativeSelect.test.tsx
@@ -1,5 +1,5 @@
 import type { RefObject } from 'react';
-import React, { createRef } from 'react';
+import { createRef } from 'react';
 import { render as renderRtl, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/form/NativeSelect/NativeSelect.tsx
+++ b/packages/react/src/components/form/NativeSelect/NativeSelect.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { ForwardedRef, ReactNode, SelectHTMLAttributes } from 'react';
 import cl from 'clsx';
 import { PadlockLockedFillIcon } from '@navikt/aksel-icons';

--- a/packages/react/src/components/form/Radio/Group/Group.stories.tsx
+++ b/packages/react/src/components/form/Radio/Group/Group.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
 import { Button, Paragraph } from '../../..';

--- a/packages/react/src/components/form/Radio/Group/Group.test.tsx
+++ b/packages/react/src/components/form/Radio/Group/Group.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/form/Radio/Group/Group.tsx
+++ b/packages/react/src/components/form/Radio/Group/Group.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import React, { forwardRef, createContext, useId } from 'react';
+import { forwardRef, createContext, useId } from 'react';
 import cl from 'clsx';
 
 import type { FieldsetProps } from '../../Fieldset';

--- a/packages/react/src/components/form/Radio/Radio.test.tsx
+++ b/packages/react/src/components/form/Radio/Radio.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/form/Radio/Radio.tsx
+++ b/packages/react/src/components/form/Radio/Radio.tsx
@@ -1,5 +1,5 @@
 import type { InputHTMLAttributes, ReactNode } from 'react';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 
 import { omit } from '../../../utilities';

--- a/packages/react/src/components/form/Search/Search.stories.tsx
+++ b/packages/react/src/components/form/Search/Search.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import type { Meta, StoryObj, StoryFn } from '@storybook/react';
 import { MagnifyingGlassIcon } from '@navikt/aksel-icons';
 

--- a/packages/react/src/components/form/Search/Search.test.tsx
+++ b/packages/react/src/components/form/Search/Search.test.tsx
@@ -1,5 +1,4 @@
 import { render as renderRtl, screen } from '@testing-library/react';
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 
 import type { SearchProps } from './Search';

--- a/packages/react/src/components/form/Search/Search.tsx
+++ b/packages/react/src/components/form/Search/Search.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode, InputHTMLAttributes, ChangeEvent } from 'react';
-import React, { forwardRef, useCallback, useRef, useState } from 'react';
+import { forwardRef, useCallback, useRef, useState } from 'react';
 import cl from 'clsx';
 import { MagnifyingGlassIcon, XMarkIcon } from '@navikt/aksel-icons';
 import { useMergeRefs } from '@floating-ui/react';

--- a/packages/react/src/components/form/Switch/Switch.stories.tsx
+++ b/packages/react/src/components/form/Switch/Switch.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryFn, StoryObj } from '@storybook/react';
-import React from 'react';
 
 import { Fieldset } from '../Fieldset';
 

--- a/packages/react/src/components/form/Switch/Switch.test.tsx
+++ b/packages/react/src/components/form/Switch/Switch.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/form/Switch/Switch.tsx
+++ b/packages/react/src/components/form/Switch/Switch.tsx
@@ -1,5 +1,5 @@
 import type { InputHTMLAttributes, ReactNode, SVGAttributes } from 'react';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 import { PadlockLockedFillIcon } from '@navikt/aksel-icons';
 

--- a/packages/react/src/components/form/Textarea/Textarea.stories.tsx
+++ b/packages/react/src/components/form/Textarea/Textarea.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj, StoryFn } from '@storybook/react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { Button, Paragraph } from '../..';
 

--- a/packages/react/src/components/form/Textarea/Textarea.test.tsx
+++ b/packages/react/src/components/form/Textarea/Textarea.test.tsx
@@ -1,5 +1,4 @@
 import { render as renderRtl, screen } from '@testing-library/react';
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 
 import type { TextareaProps } from './Textarea';

--- a/packages/react/src/components/form/Textarea/Textarea.tsx
+++ b/packages/react/src/components/form/Textarea/Textarea.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode, TextareaHTMLAttributes } from 'react';
-import React, { useState, forwardRef } from 'react';
+import { useState, forwardRef } from 'react';
 import cl from 'clsx';
 import { PadlockLockedFillIcon } from '@navikt/aksel-icons';
 

--- a/packages/react/src/components/form/Textfield/Textfield.stories.tsx
+++ b/packages/react/src/components/form/Textfield/Textfield.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj, StoryFn } from '@storybook/react';
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { Button, Paragraph } from '../..';
 

--- a/packages/react/src/components/form/Textfield/Textfield.test.tsx
+++ b/packages/react/src/components/form/Textfield/Textfield.test.tsx
@@ -1,5 +1,4 @@
 import { render as renderRtl, screen } from '@testing-library/react';
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 
 import type { TextfieldProps } from './Textfield';

--- a/packages/react/src/components/form/Textfield/Textfield.tsx
+++ b/packages/react/src/components/form/Textfield/Textfield.tsx
@@ -1,5 +1,5 @@
 import type { InputHTMLAttributes, ReactNode } from 'react';
-import React, { useState, useId, forwardRef } from 'react';
+import { useState, useId, forwardRef } from 'react';
 import cl from 'clsx';
 import { PadlockLockedFillIcon } from '@navikt/aksel-icons';
 

--- a/packages/react/src/components/form/useFormField.test.tsx
+++ b/packages/react/src/components/form/useFormField.test.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from 'react';
-import React from 'react';
 import { renderHook } from '@testing-library/react';
 
 import type { FieldsetProps } from './Fieldset';

--- a/packages/react/src/components/legacy/LegacyCheckbox/Checkbox.stories.tsx
+++ b/packages/react/src/components/legacy/LegacyCheckbox/Checkbox.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryFn, StoryObj } from '@storybook/react';
 
 import { LegacyCheckbox } from './Checkbox';

--- a/packages/react/src/components/legacy/LegacyCheckbox/Checkbox.test.tsx
+++ b/packages/react/src/components/legacy/LegacyCheckbox/Checkbox.test.tsx
@@ -1,6 +1,5 @@
 import assert from 'assert';
 
-import React from 'react';
 import { act, render as renderRtl, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/legacy/LegacyCheckbox/Checkbox.tsx
+++ b/packages/react/src/components/legacy/LegacyCheckbox/Checkbox.tsx
@@ -1,5 +1,4 @@
 import type { ChangeEventHandler, ReactNode } from 'react';
-import React from 'react';
 import cl from 'clsx';
 
 import { CheckboxRadioTemplate } from '../_CheckboxRadioTemplate';

--- a/packages/react/src/components/legacy/LegacyCheckboxGroup/CheckboxGroup.test.tsx
+++ b/packages/react/src/components/legacy/LegacyCheckboxGroup/CheckboxGroup.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { act, render as renderRtl, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/legacy/LegacyCheckboxGroup/CheckboxGroup.tsx
+++ b/packages/react/src/components/legacy/LegacyCheckboxGroup/CheckboxGroup.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import React, { useReducer } from 'react';
+import { useReducer } from 'react';
 import cl from 'clsx';
 
 import { LegacyCheckbox } from '../LegacyCheckbox';

--- a/packages/react/src/components/legacy/LegacyFieldSet/FieldSet.stories.tsx
+++ b/packages/react/src/components/legacy/LegacyFieldSet/FieldSet.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
 import { LegacyTextField } from '../LegacyTextField';

--- a/packages/react/src/components/legacy/LegacyFieldSet/FieldSet.test.tsx
+++ b/packages/react/src/components/legacy/LegacyFieldSet/FieldSet.test.tsx
@@ -1,4 +1,4 @@
-import React, { createRef } from 'react';
+import { createRef } from 'react';
 import type { RefObject } from 'react';
 import { render as renderRtl, screen } from '@testing-library/react';
 

--- a/packages/react/src/components/legacy/LegacyFieldSet/FieldSet.tsx
+++ b/packages/react/src/components/legacy/LegacyFieldSet/FieldSet.tsx
@@ -1,5 +1,5 @@
 import type { FieldsetHTMLAttributes, ForwardedRef, ReactNode } from 'react';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 
 import { ErrorMessage, HelpText } from '../..';

--- a/packages/react/src/components/legacy/LegacyPopover/Popover.test.tsx
+++ b/packages/react/src/components/legacy/LegacyPopover/Popover.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { act, render as renderRtl, screen } from '@testing-library/react';
 

--- a/packages/react/src/components/legacy/LegacyPopover/Popover.tsx
+++ b/packages/react/src/components/legacy/LegacyPopover/Popover.tsx
@@ -1,5 +1,6 @@
 import type { HTMLAttributes } from 'react';
-import React, {
+import type React from 'react';
+import {
   useRef,
   useState,
   useMemo,

--- a/packages/react/src/components/legacy/LegacyRadioButton/RadioButton.test.tsx
+++ b/packages/react/src/components/legacy/LegacyRadioButton/RadioButton.test.tsx
@@ -1,6 +1,5 @@
 import assert from 'assert';
 
-import React from 'react';
 import { act, render as renderRtl, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/legacy/LegacyRadioButton/RadioButton.tsx
+++ b/packages/react/src/components/legacy/LegacyRadioButton/RadioButton.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEventHandler, ReactNode } from 'react';
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import cl from 'clsx';
 
 import { CheckboxRadioTemplate } from '../_CheckboxRadioTemplate';

--- a/packages/react/src/components/legacy/LegacyRadioGroup/RadioGroup.test.tsx
+++ b/packages/react/src/components/legacy/LegacyRadioGroup/RadioGroup.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { act, render as renderRtl, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/legacy/LegacyRadioGroup/RadioGroup.tsx
+++ b/packages/react/src/components/legacy/LegacyRadioGroup/RadioGroup.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent, ReactNode } from 'react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { LegacyRadioButton } from '../LegacyRadioButton';
 import type { LegacyFieldSetProps } from '../LegacyFieldSet';

--- a/packages/react/src/components/legacy/LegacyResponsiveTable/ResponsiveTable.tsx
+++ b/packages/react/src/components/legacy/LegacyResponsiveTable/ResponsiveTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import * as tokens from '@altinn/figma-design-tokens';
 
 import { useMediaQuery } from '../../../hooks';

--- a/packages/react/src/components/legacy/LegacySelect/MultiSelectItem/MultiSelectItem.test.tsx
+++ b/packages/react/src/components/legacy/LegacySelect/MultiSelectItem/MultiSelectItem.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/legacy/LegacySelect/MultiSelectItem/MultiSelectItem.tsx
+++ b/packages/react/src/components/legacy/LegacySelect/MultiSelectItem/MultiSelectItem.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import utilClasses from '../../../../utilities/utility.module.css';
 
 import classes from './MultiSelectItem.module.css';

--- a/packages/react/src/components/legacy/LegacySelect/OptionList/Option.test.tsx
+++ b/packages/react/src/components/legacy/LegacySelect/OptionList/Option.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import '@testing-library/jest-dom';
 import { render as renderRtl, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/packages/react/src/components/legacy/LegacySelect/OptionList/Option.tsx
+++ b/packages/react/src/components/legacy/LegacySelect/OptionList/Option.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import cl from 'clsx';
 
 import type {

--- a/packages/react/src/components/legacy/LegacySelect/OptionList/OptionList.test.tsx
+++ b/packages/react/src/components/legacy/LegacySelect/OptionList/OptionList.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { act, render as renderRtl, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/legacy/LegacySelect/OptionList/OptionList.tsx
+++ b/packages/react/src/components/legacy/LegacySelect/OptionList/OptionList.tsx
@@ -1,4 +1,4 @@
-import React, { useId, useRef, useState } from 'react';
+import { useId, useRef, useState } from 'react';
 import { FloatingPortal } from '@floating-ui/react';
 import cl from 'clsx';
 

--- a/packages/react/src/components/legacy/LegacySelect/Select.test.tsx
+++ b/packages/react/src/components/legacy/LegacySelect/Select.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/legacy/LegacySelect/Select.tsx
+++ b/packages/react/src/components/legacy/LegacySelect/Select.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent } from 'react';
-import React, { useCallback, useEffect, useId, useState } from 'react';
+import { useCallback, useEffect, useId, useState } from 'react';
 import cl from 'clsx';
 import { autoUpdate, useFloating } from '@floating-ui/react';
 import { flip, size } from '@floating-ui/dom';

--- a/packages/react/src/components/legacy/LegacyTable/SortIcon.tsx
+++ b/packages/react/src/components/legacy/LegacyTable/SortIcon.tsx
@@ -1,5 +1,4 @@
 import type { SVGProps } from 'react';
-import React from 'react';
 
 export const SortIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg

--- a/packages/react/src/components/legacy/LegacyTable/Table.test.tsx
+++ b/packages/react/src/components/legacy/LegacyTable/Table.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render as renderRtl, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/legacy/LegacyTable/Table.tsx
+++ b/packages/react/src/components/legacy/LegacyTable/Table.tsx
@@ -1,5 +1,4 @@
-import type { HTMLProps } from 'react';
-import React from 'react';
+import type { ReactNode, HTMLProps } from 'react';
 import cl from 'clsx';
 
 import classes from './Table.module.css';
@@ -8,7 +7,7 @@ import { TableContext } from './utils';
 
 export interface TableProps<T = unknown>
   extends Omit<HTMLProps<HTMLTableElement>, 'onChange'> {
-  children?: React.ReactNode;
+  children?: ReactNode;
   selectRows?: boolean;
   onChange?: ChangeHandler<T>;
   selectedValue?: T;

--- a/packages/react/src/components/legacy/LegacyTable/TableBody.tsx
+++ b/packages/react/src/components/legacy/LegacyTable/TableBody.tsx
@@ -1,12 +1,11 @@
-import type { HTMLProps } from 'react';
-import React from 'react';
+import type { ReactNode, HTMLProps } from 'react';
 import cl from 'clsx';
 
 import classes from './TableBody.module.css';
 import { TableRowTypeContext } from './utils';
 
 export interface TableBodyProps extends HTMLProps<HTMLTableSectionElement> {
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 export const TableBody = ({

--- a/packages/react/src/components/legacy/LegacyTable/TableCell.tsx
+++ b/packages/react/src/components/legacy/LegacyTable/TableCell.tsx
@@ -1,5 +1,4 @@
-import type { HTMLProps } from 'react';
-import React from 'react';
+import type { ReactNode, HTMLProps } from 'react';
 import cl from 'clsx';
 
 import classes from './TableCell.module.css';
@@ -9,7 +8,7 @@ import { SortIcon } from './SortIcon';
 
 export interface TableCellProps
   extends Omit<HTMLProps<HTMLTableCellElement>, 'onChange'> {
-  children?: React.ReactNode;
+  children?: ReactNode;
   variant?: string;
   onChange?: SortHandler;
   sortDirection?: SortDirection;

--- a/packages/react/src/components/legacy/LegacyTable/TableFooter.tsx
+++ b/packages/react/src/components/legacy/LegacyTable/TableFooter.tsx
@@ -1,12 +1,11 @@
-import type { HTMLProps } from 'react';
-import React from 'react';
+import type { ReactNode, HTMLProps } from 'react';
 import cl from 'clsx';
 
 import classes from './TableFooter.module.css';
 import { TableRowTypeContext } from './utils';
 
 export interface TableFooterProps extends HTMLProps<HTMLTableSectionElement> {
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 export const TableFooter = ({

--- a/packages/react/src/components/legacy/LegacyTable/TableHeader.tsx
+++ b/packages/react/src/components/legacy/LegacyTable/TableHeader.tsx
@@ -1,12 +1,11 @@
-import type { HTMLProps } from 'react';
-import React from 'react';
+import type { ReactNode, HTMLProps } from 'react';
 import cl from 'clsx';
 
 import classes from './TableHeader.module.css';
 import { TableRowTypeContext } from './utils';
 
 export interface TableHeaderProps extends HTMLProps<HTMLTableSectionElement> {
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 export const TableHeader = ({

--- a/packages/react/src/components/legacy/LegacyTable/TableRow.tsx
+++ b/packages/react/src/components/legacy/LegacyTable/TableRow.tsx
@@ -1,5 +1,4 @@
-import type { HTMLProps } from 'react';
-import React from 'react';
+import type { ReactNode, HTMLProps } from 'react';
 import cl from 'clsx';
 
 import classes from './TableRow.module.css';
@@ -10,7 +9,7 @@ export interface TableRowProps<T>
     HTMLProps<HTMLTableRowElement>,
     'onClick' | 'tabIndex' | 'onKeyUp'
   > {
-  children?: React.ReactNode;
+  children?: ReactNode;
   rowData?: T;
 }
 

--- a/packages/react/src/components/legacy/LegacyTabs/Tabs.stories.tsx
+++ b/packages/react/src/components/legacy/LegacyTabs/Tabs.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 
 import { LegacyTabs } from './Tabs';

--- a/packages/react/src/components/legacy/LegacyTabs/Tabs.test.tsx
+++ b/packages/react/src/components/legacy/LegacyTabs/Tabs.test.tsx
@@ -1,6 +1,5 @@
 import assert from 'assert';
 
-import React from 'react';
 import { act, screen, render as renderRtl } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/legacy/LegacyTabs/Tabs.tsx
+++ b/packages/react/src/components/legacy/LegacyTabs/Tabs.tsx
@@ -1,5 +1,5 @@
-import type { KeyboardEventHandler } from 'react';
-import React, { useEffect, useId, useRef, useState } from 'react';
+import type { ReactNode, KeyboardEventHandler } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import cl from 'clsx';
 
 import { useUpdate } from '../../../hooks';
@@ -9,7 +9,7 @@ import classes from './Tabs.module.css';
 
 export interface LegacyTabItem {
   name: string;
-  content: React.ReactNode;
+  content: ReactNode;
   tabId?: string;
   panelId?: string;
   value?: string;

--- a/packages/react/src/components/legacy/LegacyTextArea/TextArea.stories.tsx
+++ b/packages/react/src/components/legacy/LegacyTextArea/TextArea.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 
 import type { LegacyTextAreaProps } from '.';

--- a/packages/react/src/components/legacy/LegacyTextArea/TextArea.test.tsx
+++ b/packages/react/src/components/legacy/LegacyTextArea/TextArea.test.tsx
@@ -1,5 +1,4 @@
 import { render as renderRtl, screen } from '@testing-library/react';
-import React from 'react';
 import userEvent from '@testing-library/user-event';
 
 import { LegacyTextArea } from './TextArea';

--- a/packages/react/src/components/legacy/LegacyTextArea/TextArea.tsx
+++ b/packages/react/src/components/legacy/LegacyTextArea/TextArea.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useId, useState } from 'react';
+import { forwardRef, useId, useState } from 'react';
 import type { ChangeEvent, ForwardedRef, TextareaHTMLAttributes } from 'react';
 
 import { InputWrapper } from '../../../utilities/InputWrapper';

--- a/packages/react/src/components/legacy/LegacyTextField/TextField.stories.tsx
+++ b/packages/react/src/components/legacy/LegacyTextField/TextField.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import React from 'react';
 
 import type { LegacyTextFieldProps } from '.';
 import { LegacyTextField } from '.';

--- a/packages/react/src/components/legacy/LegacyTextField/TextField.test.tsx
+++ b/packages/react/src/components/legacy/LegacyTextField/TextField.test.tsx
@@ -1,5 +1,5 @@
 import { render as renderRtl, screen } from '@testing-library/react';
-import React from 'react';
+import type * as React from 'react';
 import userEvent from '@testing-library/user-event';
 
 import type { LegacyTextFieldProps } from './TextField';

--- a/packages/react/src/components/legacy/LegacyTextField/TextField.tsx
+++ b/packages/react/src/components/legacy/LegacyTextField/TextField.tsx
@@ -1,5 +1,5 @@
 import type { ForwardedRef, ChangeEvent } from 'react';
-import React, { forwardRef, useState } from 'react';
+import { forwardRef, useState } from 'react';
 import cl from 'clsx';
 import type {
   NumericFormatProps,
@@ -81,10 +81,10 @@ type ReplaceTargetValueWithUnformattedValueProps = {
 const replaceTargetValueWithUnformattedValue = ({
   values,
   sourceInfo,
-}: ReplaceTargetValueWithUnformattedValueProps): React.ChangeEvent<HTMLInputElement> => {
+}: ReplaceTargetValueWithUnformattedValueProps): ChangeEvent<HTMLInputElement> => {
   const copiedEvent = {
     ...sourceInfo.event,
-  } as React.ChangeEvent<HTMLInputElement>;
+  } as ChangeEvent<HTMLInputElement>;
 
   return {
     ...copiedEvent,

--- a/packages/react/src/components/legacy/LegacyToggleButtonGroup/ToggleButtonGroup.test.tsx
+++ b/packages/react/src/components/legacy/LegacyToggleButtonGroup/ToggleButtonGroup.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render as renderRtl, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/components/legacy/LegacyToggleButtonGroup/ToggleButtonGroup.tsx
+++ b/packages/react/src/components/legacy/LegacyToggleButtonGroup/ToggleButtonGroup.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import cl from 'clsx';
 
 import { areItemsUnique } from '../../../utilities';

--- a/packages/react/src/components/legacy/_CheckboxRadioTemplate/CheckboxRadioTemplate.test.tsx
+++ b/packages/react/src/components/legacy/_CheckboxRadioTemplate/CheckboxRadioTemplate.test.tsx
@@ -1,6 +1,5 @@
 import assert from 'assert';
 
-import React from 'react';
 import { render as renderRtl, screen } from '@testing-library/react';
 
 import type { CheckboxRadioTemplateProps } from './';

--- a/packages/react/src/components/legacy/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
+++ b/packages/react/src/components/legacy/_CheckboxRadioTemplate/CheckboxRadioTemplate.tsx
@@ -4,7 +4,7 @@
  */
 
 import type { ChangeEventHandler, ReactNode } from 'react';
-import React, { forwardRef, useId } from 'react';
+import { forwardRef, useId } from 'react';
 import cl from 'clsx';
 
 import { HelpText } from '../../HelpText';

--- a/packages/react/src/hooks/useFocusWithin.test.tsx
+++ b/packages/react/src/hooks/useFocusWithin.test.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/utilities/AnimateHeight/AnimateHeight.test.tsx
+++ b/packages/react/src/utilities/AnimateHeight/AnimateHeight.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render as renderRtl, screen, waitFor } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 

--- a/packages/react/src/utilities/AnimateHeight/AnimateHeight.tsx
+++ b/packages/react/src/utilities/AnimateHeight/AnimateHeight.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import type * as React from 'react';
 import cl from 'clsx';
 
 import { useMediaQuery, usePrevious } from '../../hooks';

--- a/packages/react/src/utilities/InputWrapper/ErrorIcon.tsx
+++ b/packages/react/src/utilities/InputWrapper/ErrorIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export const ErrorIcon = () => (
   <svg
     width='16'

--- a/packages/react/src/utilities/InputWrapper/Icon.test.tsx
+++ b/packages/react/src/utilities/InputWrapper/Icon.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render as renderRtl, screen } from '@testing-library/react';
 
 import type { IconProps } from './Icon';

--- a/packages/react/src/utilities/InputWrapper/Icon.tsx
+++ b/packages/react/src/utilities/InputWrapper/Icon.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import cl from 'clsx';
 
 import type { IconVariant_ } from './utils';

--- a/packages/react/src/utilities/InputWrapper/InputWrapper.test.tsx
+++ b/packages/react/src/utilities/InputWrapper/InputWrapper.test.tsx
@@ -1,5 +1,4 @@
 import { render as renderRtl, screen } from '@testing-library/react';
-import React from 'react';
 
 import type { InputWrapperProps } from './InputWrapper';
 import { InputWrapper } from './InputWrapper';

--- a/packages/react/src/utilities/InputWrapper/InputWrapper.tsx
+++ b/packages/react/src/utilities/InputWrapper/InputWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useId } from 'react';
+import { useId } from 'react';
 import type { ReactNode } from 'react';
 import cl from 'clsx';
 

--- a/packages/react/src/utilities/InputWrapper/SearchIcon.tsx
+++ b/packages/react/src/utilities/InputWrapper/SearchIcon.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export const SearchIcon = () => (
   <svg
     width='15'

--- a/packages/react/src/utilities/RovingTabIndex/RovingTabindexItem.tsx
+++ b/packages/react/src/utilities/RovingTabIndex/RovingTabindexItem.tsx
@@ -1,7 +1,7 @@
 // Logic from: https://www.joshuawootonn.com/react-roving-tabindex
 // Inspired by: https://github.com/radix-ui/primitives/tree/main/packages/react/roving-focus/src
 
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import type { HTMLAttributes } from 'react';
 import { useMergeRefs } from '@floating-ui/react';
 import { Slot } from '@radix-ui/react-slot';

--- a/packages/react/src/utilities/RovingTabIndex/RovingTabindexRoot.test.tsx
+++ b/packages/react/src/utilities/RovingTabIndex/RovingTabindexRoot.test.tsx
@@ -1,6 +1,5 @@
 // tests for the RovingTabindexRoot component
 
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/packages/react/src/utilities/RovingTabIndex/RovingTabindexRoot.tsx
+++ b/packages/react/src/utilities/RovingTabIndex/RovingTabindexRoot.tsx
@@ -1,8 +1,13 @@
 // Logic from: https://www.joshuawootonn.com/react-roving-tabindex
 // Inspired by: https://github.com/radix-ui/primitives/tree/main/packages/react/roving-focus/src
 
-import React, { createContext, useRef, useState, forwardRef } from 'react';
-import type { MutableRefObject, ReactNode, HTMLAttributes } from 'react';
+import { createContext, useRef, useState, forwardRef } from 'react';
+import type {
+  MutableRefObject,
+  ReactNode,
+  HTMLAttributes,
+  FocusEvent,
+} from 'react';
 import { useMergeRefs } from '@floating-ui/react';
 import { Slot } from '@radix-ui/react-slot';
 
@@ -93,11 +98,11 @@ export const RovingTabindexRoot: OverridableComponent<
         <Component
           {...rest}
           tabIndex={isShiftTabbing ? -1 : 0}
-          onBlur={(e: React.FocusEvent<HTMLElement>) => {
+          onBlur={(e: FocusEvent<HTMLElement>) => {
             onBlur?.(e);
             setIsShiftTabbing(false);
           }}
-          onFocus={(e: React.FocusEvent<HTMLElement>) => {
+          onFocus={(e: FocusEvent<HTMLElement>) => {
             onFocus?.(e);
             if (e.target !== e.currentTarget) return;
             const orderedItems = getOrderedItems();

--- a/packages/react/src/utilities/numberFormat.test.tsx
+++ b/packages/react/src/utilities/numberFormat.test.tsx
@@ -1,5 +1,4 @@
 import { render as renderRtl, screen } from '@testing-library/react';
-import React from 'react';
 import type {
   NumericFormatProps,
   PatternFormatProps,

--- a/packages/react/stories/testing.stories.tsx
+++ b/packages/react/stories/testing.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryFn } from '@storybook/react';
-import React from 'react';
 
 import {
   Textfield,

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -5,7 +5,8 @@
     "declarationDir": "./dist/types",
     "emitDeclarationOnly": false,
     "composite": false,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "noEmit": false
   },
   "include": ["./src", "declarations.d.ts"],
   "rootDir": "./src"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "es2020",
+
     // This allows our files to use window. Should be removed when RSC is added
     "lib": ["dom", "esnext", "DOM.Iterable"],
     "importHelpers": true,
@@ -30,6 +31,11 @@
 
     "moduleDetection": "force",
     "composite": true,
-    "declarationMap": true
+    "declarationMap": true,
+
+    "allowJs": true,
+    "noEmit": true,
+    "incremental": true,
+    "isolatedModules": true
   }
 }


### PR DESCRIPTION
resolves #951

- Updated applications under `apps` to extend root `tsconfig`
- Remove generic `import React from "react"` as they are no longer needed to use JSX in files.

Had to get this done so that we ensure all `apps` being built adher to the same coding standards. 

Work with the bachelor assignment prompted the need to do this.