### PR TITLE
build: :building_construction: Add missing folders to workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "private": true,
   "workspaces": [
     "packages/*",
-    "apps/*"
+    "apps/*",
+    "docs-components/",
+    ".storybook/"
   ],
   "scripts": {
     "test": "jest",


### PR DESCRIPTION
Running Storybook from a fresh git clone failed as packages were not found due to missing npm link. 