### PR TITLE
fix(Fieldset): Hide empty div when there is no error

### DIFF
--- a/packages/react/src/components/form/Fieldset/Fieldset.tsx
+++ b/packages/react/src/components/form/Fieldset/Fieldset.tsx
@@ -110,13 +110,15 @@ export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(
             </Paragraph>
           )}
           {children}
-          <div
-            id={errorId}
-            aria-live='polite'
-            aria-relevant='additions removals'
-          >
-            {hasError && <ErrorMessage size={size}>{error}</ErrorMessage>}
-          </div>
+          {hasError && (
+            <div
+              id={errorId}
+              aria-live='polite'
+              aria-relevant='additions removals'
+            >
+              <ErrorMessage size={size}>{error}</ErrorMessage>
+            </div>
+          )}
         </fieldset>
       </FieldsetContext.Provider>
     );


### PR DESCRIPTION
When there is no error in the fieldset, there is still an empty wrapper for it, creating an additional gap at the bottom when styled as a flexbox with `gap`. This pull request solves it by moving the `hasError` check so that it also wraps the `div` element.