### PR TITLE
chore: Fix use of `asChild` in some components

### DIFF
--- a/packages/react/src/components/DropdownMenu/DropdownMenuTrigger.tsx
+++ b/packages/react/src/components/DropdownMenu/DropdownMenuTrigger.tsx
@@ -1,4 +1,3 @@
-import { Slot } from '@radix-ui/react-slot';
 import { forwardRef, useContext } from 'react';
 import type * as React from 'react';
 import { useMergeRefs } from '@floating-ui/react';
@@ -7,22 +6,20 @@ import { Button } from '../Button';
 
 import { DropdownMenuContext } from './DropdownMenu';
 
-export type DropdownMenuTriggerProps = {
-  asChild?: boolean;
-} & React.ComponentPropsWithRef<typeof Button>;
+export type DropdownMenuTriggerProps = React.ComponentPropsWithRef<
+  typeof Button
+>;
 
 export const DropdownMenuTrigger = forwardRef<
   HTMLButtonElement,
   DropdownMenuTriggerProps
->(({ asChild, children, ...rest }, ref) => {
-  const Component = asChild ? Slot : Button;
-
+>(({ ...rest }, ref) => {
   const { triggerRef, internalOpen, setInternalOpen, isControlled } =
     useContext(DropdownMenuContext);
   const mergedRefs = useMergeRefs([ref, triggerRef]);
 
   return (
-    <Component
+    <Button
       ref={mergedRefs}
       onClick={() => {
         if (!isControlled) setInternalOpen(!internalOpen);
@@ -30,9 +27,7 @@ export const DropdownMenuTrigger = forwardRef<
       aria-haspopup='menu'
       aria-expanded={internalOpen}
       {...rest}
-    >
-      {children}
-    </Component>
+    />
   );
 });
 

--- a/packages/react/src/components/ErrorSummary/ErrorSummaryHeading.tsx
+++ b/packages/react/src/components/ErrorSummary/ErrorSummaryHeading.tsx
@@ -1,4 +1,3 @@
-import { Slot } from '@radix-ui/react-slot';
 import { useContext, useEffect } from 'react';
 
 import type { ListHeadingProps } from '../List';
@@ -6,21 +5,12 @@ import { List } from '../List';
 
 import { ErrorSummaryContext } from './ErrorSummaryRoot';
 
-export type ErrorSummaryHeadingProps = {
-  /**
-   * Change the default rendered element for the one passed as a child, merging their props and behavior.
-   * @default false
-   */
-  asChild?: boolean;
-} & ListHeadingProps;
+export type ErrorSummaryHeadingProps = ListHeadingProps;
 
 export const ErrorSummaryHeading = ({
-  asChild,
   id,
   ...rest
 }: ErrorSummaryHeadingProps) => {
-  const Component = asChild ? Slot : List.Heading;
-
   const { headingId, setHeadingId } = useContext(ErrorSummaryContext);
 
   useEffect(() => {
@@ -30,7 +20,7 @@ export const ErrorSummaryHeading = ({
   }, [headingId, id, setHeadingId]);
 
   return (
-    <Component
+    <List.Heading
       {...rest}
       id={headingId}
     />

--- a/packages/react/src/components/ErrorSummary/ErrorSummaryItem.tsx
+++ b/packages/react/src/components/ErrorSummary/ErrorSummaryItem.tsx
@@ -1,3 +1,5 @@
+import { Slot } from '@radix-ui/react-slot';
+
 import type { ListItemProps } from '../List';
 import { List } from '../List';
 import type { LinkProps } from '../Link';
@@ -13,7 +15,7 @@ export const ErrorSummaryItem = ({
   children,
   ...rest
 }: ErrorSummaryItemProps) => {
-  const Component = asChild ? Link : Link;
+  const Component = asChild ? Slot : Link;
 
   return (
     <List.Item {...rest}>

--- a/packages/react/src/components/Modal/ModalTrigger/ModalTrigger.tsx
+++ b/packages/react/src/components/Modal/ModalTrigger/ModalTrigger.tsx
@@ -1,22 +1,17 @@
-import { Slot } from '@radix-ui/react-slot';
 import { forwardRef, useContext } from 'react';
 import type * as React from 'react';
 
 import { Button } from '../../Button';
 import { ModalContext } from '../ModalRoot';
 
-export type ModalTriggerProps = {
-  asChild?: boolean;
-} & React.ComponentPropsWithRef<typeof Button>;
+export type ModalTriggerProps = React.ComponentPropsWithRef<typeof Button>;
 
 export const ModalTrigger = forwardRef<HTMLButtonElement, ModalTriggerProps>(
-  ({ asChild, ...rest }, ref) => {
-    const Component = asChild ? Slot : Button;
-
+  ({ ...rest }, ref) => {
     const { modalRef, open } = useContext(ModalContext);
 
     return (
-      <Component
+      <Button
         ref={ref}
         onClick={() => modalRef?.current?.showModal()}
         aria-expanded={open}

--- a/packages/react/src/components/Popover/PopoverTrigger.tsx
+++ b/packages/react/src/components/Popover/PopoverTrigger.tsx
@@ -1,4 +1,3 @@
-import { Slot } from '@radix-ui/react-slot';
 import { forwardRef, useContext } from 'react';
 import type * as React from 'react';
 import { useMergeRefs } from '@floating-ui/react';
@@ -7,31 +6,25 @@ import { Button } from '../Button';
 
 import { PopoverContext } from './Popover';
 
-export type PopoverTriggerProps = {
-  asChild?: boolean;
-} & React.ComponentPropsWithRef<typeof Button>;
+export type PopoverTriggerProps = React.ComponentPropsWithRef<typeof Button>;
 
 export const PopoverTrigger = forwardRef<
   HTMLButtonElement,
   PopoverTriggerProps
->(({ asChild, children, ...rest }, ref) => {
-  const Component = asChild ? Slot : Button;
-
+>(({ ...rest }, ref) => {
   const { triggerRef, internalOpen, setInternalOpen, isControlled } =
     useContext(PopoverContext);
   const mergedRefs = useMergeRefs([ref, triggerRef]);
 
   return (
-    <Component
+    <Button
       ref={mergedRefs}
       onClick={() => {
         if (!isControlled) setInternalOpen(!internalOpen);
       }}
       aria-expanded={internalOpen}
       {...rest}
-    >
-      {children}
-    </Component>
+    />
   );
 });
 


### PR DESCRIPTION
Some components did not need their own `asChild` props.
Also fixed an instance where `asChild` was wrong, and not using `Slot`