### PR TITLE
fix(Button): Remove `display: inline-block` for icons

### DIFF
--- a/packages/react/src/components/Button/Button.module.css
+++ b/packages/react/src/components/Button/Button.module.css
@@ -50,7 +50,6 @@
 }
 
 .button > :is(svg, img, i) {
-  display: inline-block;
   height: var(--fc-button-icon-size);
   width: var(--fc-button-icon-size);
 }


### PR DESCRIPTION
Removed due to interfering with using `display` to toggle different icons.