### PR TITLE
fix(Fieldset): Simplify CSS

### DIFF
--- a/packages/react/src/components/form/Fieldset/Fieldset.module.css
+++ b/packages/react/src/components/form/Fieldset/Fieldset.module.css
@@ -5,7 +5,7 @@
   min-width: 0;
 }
 
-.fieldset.withSpacing {
+.withSpacing {
   display: flex;
   flex-direction: column;
   gap: var(--fds-spacing-2);
@@ -20,17 +20,17 @@
   display: contents;
 }
 
-.fieldset.readonly .legendContent {
+.readonly .legendContent {
   display: inline-flex;
 }
 
-.fieldset.readonly .padlock {
+.readonly .padlock {
   height: 1.2em;
   width: 1.2em;
 }
 
-.fieldset.disabled .legend,
-.fieldset.disabled .description {
+.disabled .legend,
+.disabled .description {
   color: var(--fds-semantic-border-neutral-subtle);
 }
 

--- a/packages/react/src/components/form/Fieldset/Fieldset.module.css
+++ b/packages/react/src/components/form/Fieldset/Fieldset.module.css
@@ -5,8 +5,10 @@
   min-width: 0;
 }
 
-.spacing > :not(:first-child, :empty) {
-  margin-top: var(--fds-spacing-2);
+.fieldset.withSpacing {
+  display: flex;
+  flex-direction: column;
+  gap: var(--fds-spacing-2);
 }
 
 .description {
@@ -14,16 +16,24 @@
   font-weight: 400;
 }
 
-.readonly > .legend {
+.legend {
+  display: contents;
+}
+
+.fieldset.readonly .legendContent {
   display: inline-flex;
 }
 
-.readonly > .legend > .padlock {
+.fieldset.readonly .padlock {
   height: 1.2em;
   width: 1.2em;
 }
 
-.disabled > .legend,
-.disabled > .description {
+.fieldset.disabled .legend,
+.fieldset.disabled .description {
   color: var(--fds-semantic-border-neutral-subtle);
+}
+
+.errorWrapper {
+  display: contents;
 }

--- a/packages/react/src/components/form/Fieldset/Fieldset.tsx
+++ b/packages/react/src/components/form/Fieldset/Fieldset.tsx
@@ -65,7 +65,7 @@ export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(
           {...fieldsetProps}
           className={cl(
             classes.fieldset,
-            !hideLegend && classes.spacing,
+            !hideLegend && classes.withSpacing,
             readOnly && classes.readonly,
             props?.disabled && classes.disabled,
             className,
@@ -83,13 +83,15 @@ export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(
                 hideLegend && utilityclasses.visuallyHidden,
               )}
             >
-              {readOnly && (
-                <PadlockLockedFillIcon
-                  className={classes.padlock}
-                  aria-hidden
-                />
-              )}
-              {legend}
+              <span className={classes.legendContent}>
+                {readOnly && (
+                  <PadlockLockedFillIcon
+                    className={classes.padlock}
+                    aria-hidden
+                  />
+                )}
+                {legend}
+              </span>
             </legend>
           </Label>
           {description && (
@@ -114,6 +116,7 @@ export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(
             id={errorId}
             aria-live='polite'
             aria-relevant='additions removals'
+            className={classes.errorWrapper}
           >
             {hasError && <ErrorMessage size={size}>{error}</ErrorMessage>}
           </div>


### PR DESCRIPTION
Here is another suggestion for making it easier to override the styling of `Fieldset`:
- Set `flex` properties directly on the `fieldset` element instead of using `margin-top` on `> :not(:first-child, :empty)`. This both simplifies the code and makes it easier to override it from the outside.
- Set `display: contents` on the legend and the error wrapper. This styles the elements like their contents, so there will be no unexpected gaps if they are empty. Also, the legend will behave like a normal element, placing itself inside the box and not on the border.