### PR TITLE
fix(ErrorSummaryItem): `href` is optional when `asChild` is `true`

### DIFF
--- a/packages/react/src/components/ErrorSummary/ErrorSummaryItem.tsx
+++ b/packages/react/src/components/ErrorSummary/ErrorSummaryItem.tsx
@@ -1,5 +1,3 @@
-import { Slot } from '@radix-ui/react-slot';
-
 import type { ListItemProps } from '../List';
 import { List } from '../List';
 import type { LinkProps } from '../Link';
@@ -32,11 +30,14 @@ export const ErrorSummaryItem = ({
   children,
   ...rest
 }: ErrorSummaryItemProps) => {
-  const Component = asChild ? Slot : Link;
-
   return (
     <List.Item {...rest}>
-      <Component href={href}>{children}</Component>
+      <Link
+        href={href}
+        asChild={asChild}
+      >
+        {children}
+      </Link>
     </List.Item>
   );
 };

--- a/packages/react/src/components/ErrorSummary/ErrorSummaryItem.tsx
+++ b/packages/react/src/components/ErrorSummary/ErrorSummaryItem.tsx
@@ -5,9 +5,26 @@ import { List } from '../List';
 import type { LinkProps } from '../Link';
 import { Link } from '../Link';
 
-export type ErrorSummaryItemProps = {
+type RequiredHref = {
   href: LinkProps['href'];
-} & ListItemProps;
+  /**
+   * Change the default rendered element for the one passed as a child, merging their props and behavior.
+   * @default false
+   */
+  asChild?: false;
+};
+
+type OptionalHref = {
+  href?: never;
+  /**
+   * Change the default rendered element for the one passed as a child, merging their props and behavior.
+   * @default false
+   */
+  asChild: true;
+};
+
+export type ErrorSummaryItemProps =
+  | (RequiredHref | OptionalHref) & Omit<ListItemProps, 'asChild'>;
 
 export const ErrorSummaryItem = ({
   href,

--- a/packages/react/src/components/ErrorSummary/ErrorSummaryItem.tsx
+++ b/packages/react/src/components/ErrorSummary/ErrorSummaryItem.tsx
@@ -15,7 +15,7 @@ type RequiredHref = {
 };
 
 type OptionalHref = {
-  href?: never;
+  href?: LinkProps['href'];
   /**
    * Change the default rendered element for the one passed as a child, merging their props and behavior.
    * @default false


### PR DESCRIPTION
resolves #1560
Also fixes lost styling from `Link` when using `asChild`