### PR TITLE
fix: Components should now inherit font-family correctly

### DIFF
--- a/packages/react/src/components/Card/Card.module.css
+++ b/packages/react/src/components/Card/Card.module.css
@@ -17,7 +17,7 @@
   flex-wrap: wrap;
   word-wrap: break-word;
   font: var(--fds-typography-paragraph-medium);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
   padding: var(--fds-spacing-2) 0;
 }
 
@@ -31,7 +31,7 @@
   flex-wrap: wrap;
   word-wrap: break-word;
   font: var(--fds-typography-heading-medium);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
   padding: var(--fds-spacing-2) 0;
 }
 

--- a/packages/react/src/components/HelpText/HelpText.module.css
+++ b/packages/react/src/components/HelpText/HelpText.module.css
@@ -35,6 +35,7 @@
 
 .helpTextContent {
   font: var(--fds-typography-paragraph-medium);
+  font-family: inherit;
   width: fit-content;
   max-width: 700px;
 }

--- a/packages/react/src/components/Table/Table.module.css
+++ b/packages/react/src/components/Table/Table.module.css
@@ -32,6 +32,7 @@
   z-index: 0;
   box-sizing: border-box;
   font: inherit;
+  font-family: inherit;
   border-spacing: 0;
   font-weight: 500;
   border-bottom: 2px solid var(--fds-semantic-border-divider-default);
@@ -40,6 +41,7 @@
 .headerCell {
   padding: var(--table-padding);
   font: inherit;
+  font-family: inherit;
   background-color: var(--fds-semantic-surface-neutral-default);
   border-spacing: 0;
   border-bottom: 2px solid var(--fds-semantic-border-divider-default);
@@ -60,6 +62,7 @@
   width: 100%;
   border: none;
   font: inherit;
+  font-family: inherit;
   display: flex;
   cursor: pointer;
   gap: var(--fds-spacing-1);

--- a/packages/react/src/components/Tabs/Tab/Tab.module.css
+++ b/packages/react/src/components/Tabs/Tab/Tab.module.css
@@ -1,6 +1,5 @@
 .tabItem {
   --fdsc-icon-size: var(--fds-sizing-4);
-  --fdsc-typography-font-family: inherit;
   --fdsc-bottom-border-color: transparent;
 
   display: flex;
@@ -30,7 +29,6 @@
 
   font: var(--fds-typography-interactive-small);
   font-family: inherit;
-  font-family: var(--fdsc-typography-font-family);
   padding: var(--fds-spacing-2) var(--fds-spacing-4);
 }
 
@@ -39,7 +37,6 @@
 
   font: var(--fds-typography-interactive-medium);
   font-family: inherit;
-  font-family: var(--fdsc-typography-font-family);
   padding: var(--fds-spacing-3) var(--fds-spacing-5);
 }
 
@@ -48,7 +45,6 @@
 
   font: var(--fds-typography-interactive-large);
   font-family: inherit;
-  font-family: var(--fdsc-typography-font-family);
   padding: var(--fds-spacing-4) var(--fds-spacing-6);
 }
 

--- a/packages/react/src/components/Tabs/Tab/Tab.module.css
+++ b/packages/react/src/components/Tabs/Tab/Tab.module.css
@@ -29,6 +29,7 @@
   --fdsc-icon-size: var(--fds-sizing-5);
 
   font: var(--fds-typography-interactive-small);
+  font-family: inherit;
   font-family: var(--fdsc-typography-font-family);
   padding: var(--fds-spacing-2) var(--fds-spacing-4);
 }
@@ -37,6 +38,7 @@
   --fdsc-icon-size: var(--fds-sizing-6);
 
   font: var(--fds-typography-interactive-medium);
+  font-family: inherit;
   font-family: var(--fdsc-typography-font-family);
   padding: var(--fds-spacing-3) var(--fds-spacing-5);
 }
@@ -45,6 +47,7 @@
   --fdsc-icon-size: var(--fds-sizing-7);
 
   font: var(--fds-typography-interactive-large);
+  font-family: inherit;
   font-family: var(--fdsc-typography-font-family);
   padding: var(--fds-spacing-4) var(--fds-spacing-6);
 }

--- a/packages/react/src/components/Tabs/TabContent/TabContent.module.css
+++ b/packages/react/src/components/Tabs/TabContent/TabContent.module.css
@@ -1,7 +1,5 @@
 .tabContent {
-  --fdsc-typography-font-family: inherit;
-
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .tabContent.small {
@@ -18,15 +16,15 @@
 
 .tabContent.onlyText.small {
   font: var(--fds-typography-interactive-small);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .tabContent.onlyText.medium {
   font: var(--fds-typography-interactive-medium);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .tabContent.onlyText.large {
   font: var(--fds-typography-interactive-large);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }

--- a/packages/react/src/components/Tooltip/Tooltip.module.css
+++ b/packages/react/src/components/Tooltip/Tooltip.module.css
@@ -4,6 +4,7 @@
   color: var(--fds-semantic-text-neutral-on_inverted);
   border-radius: var(--fds-border_radius-medium);
   font: var(--fds-typography-paragraph-xsmall);
+  font-family: inherit;
 }
 
 .wrapper.inverted {

--- a/packages/react/src/components/Typography/ErrorMessage/ErrorMessage.module.css
+++ b/packages/react/src/components/Typography/ErrorMessage/ErrorMessage.module.css
@@ -1,5 +1,4 @@
 .errorMessage {
-  --fdsc-typography-font-family: inherit;
   --fdsc-bottom-spacing: var(--fds-spacing-5);
 
   margin: 0;
@@ -17,26 +16,26 @@
   --fdsc-bottom-spacing: var(--fds-spacing-5);
 
   font: var(--fds-typography-error_message-large);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .errorMessage.medium {
   --fdsc-bottom-spacing: var(--fds-spacing-5);
 
   font: var(--fds-typography-error_message-medium);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .errorMessage.small {
   --fdsc-bottom-spacing: var(--fds-spacing-4);
 
   font: var(--fds-typography-error_message-small);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .errorMessage.xsmall {
   --fdsc-bottom-spacing: var(--fds-spacing-3);
 
   font: var(--fds-typography-error_message-xsmall);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }

--- a/packages/react/src/components/Typography/Heading/Heading.module.css
+++ b/packages/react/src/components/Typography/Heading/Heading.module.css
@@ -1,5 +1,4 @@
 .heading {
-  --fdsc-typography-font-family: inherit;
   --fdsc-bottom-spacing: var(--fds-spacing-6);
 
   margin: 0;
@@ -14,54 +13,54 @@
   --fdsc-bottom-spacing: var(--fds-spacing-8);
 
   font: var(--fds-typography-heading-3xlarge);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .size-2xlarge {
   --fdsc-bottom-spacing: var(--fds-spacing-7);
 
   font: var(--fds-typography-heading-2xlarge);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .size-xlarge {
   --fdsc-bottom-spacing: var(--fds-spacing-6);
 
   font: var(--fds-typography-heading-xlarge);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .size-large {
   --fdsc-bottom-spacing: var(--fds-spacing-5);
 
   font: var(--fds-typography-heading-large);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .size-medium {
   --fdsc-bottom-spacing: var(--fds-spacing-4);
 
   font: var(--fds-typography-heading-medium);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .size-small {
   --fdsc-bottom-spacing: var(--fds-spacing-3);
 
   font: var(--fds-typography-heading-small);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .size-xsmall {
   --fdsc-bottom-spacing: var(--fds-spacing-2);
 
   font: var(--fds-typography-heading-xsmall);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .size-xxsmall {
   --fdsc-bottom-spacing: var(--fds-spacing-1);
 
   font: var(--fds-typography-heading-xxsmall);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }

--- a/packages/react/src/components/Typography/Ingress/Ingress.module.css
+++ b/packages/react/src/components/Typography/Ingress/Ingress.module.css
@@ -1,5 +1,4 @@
 .ingress {
-  --fdsc-typography-font-family: inherit;
   --fdsc-bottom-spacing: var(--fds-spacing-5);
 
   margin: 0;
@@ -14,5 +13,5 @@
   --fdsc-bottom-spacing: var(--fds-spacing-5);
 
   font: var(--fds-typography-ingress-medium);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }

--- a/packages/react/src/components/Typography/Label/Label.module.css
+++ b/packages/react/src/components/Typography/Label/Label.module.css
@@ -1,5 +1,4 @@
 .label {
-  --fdsc-typography-font-family: inherit;
   --fdsc-bottom-spacing: var(--fds-spacing-1);
 
   display: inline-block;
@@ -14,22 +13,22 @@
 
 .label.large {
   font: var(--fds-typography-label-large);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .label.medium {
   font: var(--fds-typography-label-medium);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .label.small {
   font: var(--fds-typography-label-small);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .label.xsmall {
   font: var(--fds-typography-label-xsmall);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .label.regularWeight {

--- a/packages/react/src/components/Typography/Paragraph/Paragraph.module.css
+++ b/packages/react/src/components/Typography/Paragraph/Paragraph.module.css
@@ -1,5 +1,4 @@
 .paragraph {
-  --fdsc-typography-font-family: inherit;
   --fdsc-bottom-spacing: var(--fds-spacing-5);
 
   color: var(--fds-semantic-text-neutral-default);
@@ -14,52 +13,52 @@
   --fdsc-bottom-spacing: var(--fds-spacing-6);
 
   font: var(--fds-typography-paragraph-large);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .large:where(.short) {
   font: var(--fds-typography-paragraph-short-large);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .medium {
   --fdsc-bottom-spacing: var(--fds-spacing-5);
 
   font: var(--fds-typography-paragraph-medium);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .medium:where(.short) {
   --fdsc-bottom-spacing: var(--fds-spacing-5);
 
   font: var(--fds-typography-paragraph-short-medium);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .small {
   --fdsc-bottom-spacing: var(--fds-spacing-4);
 
   font: var(--fds-typography-paragraph-small);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .small:where(.short) {
   --fdsc-bottom-spacing: var(--fds-spacing-4);
 
   font: var(--fds-typography-paragraph-short-small);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .xsmall {
   --fdsc-bottom-spacing: var(--fds-spacing-3);
 
   font: var(--fds-typography-paragraph-xsmall);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }
 
 .xsmall:where(.short) {
   --fdsc-bottom-spacing: var(--fds-spacing-3);
 
   font: var(--fds-typography-paragraph-short-xsmall);
-  font-family: var(--fdsc-typography-font-family);
+  font-family: inherit;
 }

--- a/packages/react/src/components/form/Combobox/Combobox.module.css
+++ b/packages/react/src/components/form/Combobox/Combobox.module.css
@@ -26,6 +26,7 @@
   height: auto;
   justify-content: space-between;
   font: var(--fds-typography-paragraph-medium);
+  font-family: inherit;
 }
 
 .inputWrapper input {
@@ -39,29 +40,35 @@
 
 .inputWrapper.small {
   font: var(--fds-typography-paragraph-small);
+  font-family: inherit;
   padding: 5px var(--fds-spacing-2);
 }
 
 .inputWrapper.small input {
   font: var(--fds-typography-paragraph-small);
+  font-family: inherit;
 }
 
 .inputWrapper.medium {
   font: var(--fds-typography-paragraph-medium);
+  font-family: inherit;
   padding: 7px var(--fds-spacing-3);
 }
 
 .inputWrapper.medium input {
   font: var(--fds-typography-paragraph-medium);
+  font-family: inherit;
 }
 
 .inputWrapper.large {
   font: var(--fds-typography-paragraph-large);
+  font-family: inherit;
   padding: 7px var(--fds-spacing-4);
 }
 
 .inputWrapper.large input {
   font: var(--fds-typography-paragraph-large);
+  font-family: inherit;
 }
 
 .inputWrapper input:focus {

--- a/packages/react/src/components/form/Combobox/Custom/Custom.module.css
+++ b/packages/react/src/components/form/Combobox/Custom/Custom.module.css
@@ -4,15 +4,18 @@
 
 .large {
   font: var(--fds-typography-label-large);
+  font-family: inherit;
   font-weight: 400;
 }
 
 .medium {
   font: var(--fds-typography-label-medium);
+  font-family: inherit;
   font-weight: 400;
 }
 
 .small {
   font: var(--fds-typography-label-small);
+  font-family: inherit;
   font-weight: 400;
 }

--- a/packages/react/src/components/form/Combobox/Empty/Empty.module.css
+++ b/packages/react/src/components/form/Combobox/Empty/Empty.module.css
@@ -4,15 +4,18 @@
 
 .large {
   font: var(--fds-typography-label-large);
+  font-family: inherit;
   font-weight: 400;
 }
 
 .medium {
   font: var(--fds-typography-label-medium);
+  font-family: inherit;
   font-weight: 400;
 }
 
 .small {
   font: var(--fds-typography-label-small);
+  font-family: inherit;
   font-weight: 400;
 }

--- a/packages/react/src/components/form/Combobox/Option/Description/Description.module.css
+++ b/packages/react/src/components/form/Combobox/Option/Description/Description.module.css
@@ -5,4 +5,5 @@
   gap: var(--fds-spacing-1);
   color: var(--fds-semantic-text-neutral-subtle);
   font: inherit;
+  font-family: inherit;
 }

--- a/packages/react/src/components/form/Combobox/Option/Option.module.css
+++ b/packages/react/src/components/form/Combobox/Option/Option.module.css
@@ -13,6 +13,7 @@
   height: auto;
   cursor: pointer;
   font: var(--fds-typography-label-medium);
+  font-family: inherit;
 }
 
 .option.active {

--- a/packages/react/src/components/form/NativeSelect/NativeSelect.module.css
+++ b/packages/react/src/components/form/NativeSelect/NativeSelect.module.css
@@ -1,6 +1,7 @@
 .select {
   position: relative;
   font: inherit;
+  font-family: inherit;
   box-sizing: border-box;
   flex: 0 1 auto;
   padding: 0 var(--fds-spacing-2);

--- a/packages/react/src/components/form/Search/Search.module.css
+++ b/packages/react/src/components/form/Search/Search.module.css
@@ -51,6 +51,7 @@
 
 .input {
   font: inherit;
+  font-family: inherit;
   position: relative;
   box-sizing: border-box;
   flex: 0 1 auto;

--- a/packages/react/src/components/form/Textarea/Textarea.module.css
+++ b/packages/react/src/components/form/Textarea/Textarea.module.css
@@ -27,6 +27,7 @@
 
 .textarea {
   font: inherit;
+  font-family: inherit;
   position: relative;
   box-sizing: border-box;
   flex: 0 1 auto;

--- a/packages/react/src/components/form/Textfield/Textfield.module.css
+++ b/packages/react/src/components/form/Textfield/Textfield.module.css
@@ -15,6 +15,7 @@
 
 .input {
   font: inherit;
+  font-family: inherit;
   position: relative;
   box-sizing: border-box;
   flex: 0 1 auto;


### PR DESCRIPTION
Add `font-family: inherit;` after `font:`
potential fix for #1632