### PR TITLE
fix(Fieldset): Make hideLegend work again

### DIFF
--- a/packages/react/src/components/form/Fieldset/Fieldset.tsx
+++ b/packages/react/src/components/form/Fieldset/Fieldset.tsx
@@ -77,13 +77,13 @@ export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(
             asChild
             size={size}
           >
-            <legend
-              className={cl(
-                classes.legend,
-                hideLegend && utilityclasses.visuallyHidden,
-              )}
-            >
-              <span className={classes.legendContent}>
+            <legend className={classes.legend}>
+              <span
+                className={cl(
+                  classes.legendContent,
+                  hideLegend && utilityclasses.visuallyHidden,
+                )}
+              >
                 {readOnly && (
                   <PadlockLockedFillIcon
                     className={classes.padlock}


### PR DESCRIPTION
My recent change broke the `hideLegend` functionality since `display: contents` basically makes the legend ignore most of the styling applied to it. Fixed it by moving the `visuallyHidden` class to the child component.