### PR TITLE
style(Switch): :fire: Remove dead css

### DIFF
--- a/packages/react/src/components/form/Switch/Switch.module.css
+++ b/packages/react/src/components/form/Switch/Switch.module.css
@@ -212,13 +212,3 @@
     background-color: var(--fds-semantic-surface-success-hover);
   }
 }
-
-.input:focus-visible:not(:disabled) ~ {
-  outline: var(--fds-focus-border-width) solid var(--fds-outer-focus-border-color);
-  outline-offset: 0;
-}
-
-.input:focus-visible:not(:disabled) + .label .track {
-  stroke: var(--fds-inner-focus-border-color);
-  stroke-width: var(--fds-focus-border-width);
-}


### PR DESCRIPTION
Removed unused css, on had css syntax error and the stroke does nothing as `.track` is no longer an svg.