### PR TITLE
fix(storefront): Fixed broken link and NavCard styling

### DIFF
--- a/apps/storefront/components/NavigationCard/NavigationCard.module.css
+++ b/apps/storefront/components/NavigationCard/NavigationCard.module.css
@@ -57,7 +57,7 @@
 .title {
   font: var(--fds-typography-heading-xsmall);
   margin-top: var(--fds-spacing-4);
-  margin-bottom: var(--fds-spacing-3);
+  margin-bottom: var(--fds-spacing-4);
   text-align: center;
   text-decoration: underline;
   text-underline-offset: 7px;

--- a/apps/storefront/pages/grunnleggende/index.mdx
+++ b/apps/storefront/pages/grunnleggende/index.mdx
@@ -5,7 +5,7 @@ import {
   PackageIcon,
   BranchingIcon,
   LightBulbIcon,
-  MeasuringTapeIcon,
+  RulerIcon,
   CodeIcon,
   MoonIcon,
 } from '@navikt/aksel-icons';
@@ -78,8 +78,8 @@ Stilene i designsystemet er grunnleggende designelementer som brukes i komponent
   <NavigationCard
     title='Avstander'
     color='blue'
-    icon={<MeasuringTapeIcon fontSize={34} />}
-    url='grunnleggende/designelementer/spacing'
+    icon={<RulerIcon fontSize={34} />}
+    url='grunnleggende/designelementer/storrelser-og-avstander'
     description='Settet med avstander som er definert i tokens sikrer konsistens på tvers av grensesnitt.'
     backgroundColor='white'
   />


### PR DESCRIPTION
* Fixed a broken link on the "Avstander" Card under "Grunnleggende".
* Changed icon to Ruler
* Added more spacing under title.