### PR TITLE
feat(Combobox): Add `hideClearButton` prop

### DIFF
--- a/packages/react/src/components/form/Combobox/Combobox.stories.tsx
+++ b/packages/react/src/components/form/Combobox/Combobox.stories.tsx
@@ -96,6 +96,7 @@ Preview.args = {
   disabled: false,
   hideLabel: false,
   hideChips: false,
+  hideClearButton: false,
   virtual: false,
   description: 'Velg et sted',
   size: 'medium',

--- a/packages/react/src/components/form/Combobox/Combobox.tsx
+++ b/packages/react/src/components/form/Combobox/Combobox.tsx
@@ -87,8 +87,19 @@ export type ComboboxProps = {
   /**
    * Label for the clear button
    * @default 'Fjern alt'
+   * @deprecated Use `clearButtonLabel` instead
    */
   cleanButtonLabel?: string;
+  /**
+   * Hides the clear button
+   * @default false
+   */
+  hideClearButton?: boolean;
+  /**
+   * Label for the clear button
+   * @default 'Fjern alt'
+   */
+  clearButtonLabel?: string;
   /**
    * Enables virtualizing of options list.
    * @see https://tanstack.com/virtual
@@ -145,6 +156,8 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
       readOnly = false,
       hideChips = false,
       cleanButtonLabel = 'Fjern alt',
+      clearButtonLabel = 'Fjern alt',
+      hideClearButton = false,
       error,
       errorId,
       id,
@@ -445,7 +458,8 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
           htmlSize,
           optionValues,
           hideChips,
-          cleanButtonLabel,
+          clearButtonLabel: cleanButtonLabel || clearButtonLabel,
+          hideClearButton,
           listId,
           setInputValue,
           setActiveIndex,
@@ -594,7 +608,8 @@ type ComboboxContextType = {
   error: ComboboxProps['error'];
   htmlSize: ComboboxProps['htmlSize'];
   hideChips: NonNullable<ComboboxProps['hideChips']>;
-  cleanButtonLabel: NonNullable<ComboboxProps['cleanButtonLabel']>;
+  clearButtonLabel: NonNullable<ComboboxProps['clearButtonLabel']>;
+  hideClearButton: NonNullable<ComboboxProps['hideClearButton']>;
   options: Option[];
   selectedOptions: Option[];
   size: NonNullable<ComboboxProps['size']>;

--- a/packages/react/src/components/form/Combobox/internal/ComboboxClearButton.tsx
+++ b/packages/react/src/components/form/Combobox/internal/ComboboxClearButton.tsx
@@ -17,7 +17,7 @@ export const ComboboxClearButton = () => {
     size,
     readOnly,
     disabled,
-    cleanButtonLabel,
+    clearButtonLabel,
     inputRef,
     setSelectedOptions,
     setInputValue,
@@ -48,7 +48,7 @@ export const ComboboxClearButton = () => {
         }
       }}
       type='button'
-      aria-label={cleanButtonLabel}
+      aria-label={clearButtonLabel}
     >
       <XMarkIcon
         fontSize='1.5em'

--- a/packages/react/src/components/form/Combobox/internal/ComboboxInput.tsx
+++ b/packages/react/src/components/form/Combobox/internal/ComboboxInput.tsx
@@ -40,6 +40,7 @@ export const ComboboxInput = ({
     htmlSize,
     options,
     hideChips,
+    hideClearButton,
     setOpen,
     setActiveIndex,
     handleKeyDown,
@@ -107,6 +108,9 @@ export const ComboboxInput = ({
     }
   };
 
+  const showClearButton =
+    multiple && !hideClearButton && selectedOptions.length > 0;
+
   return (
     <Box
       /* Props from floating-ui */
@@ -168,7 +172,7 @@ export const ComboboxInput = ({
         />
       </div>
       {/* Clear button if we are in multiple mode and have at least one active value */}
-      {multiple && selectedOptions.length > 0 && <ComboboxClearButton />}
+      {showClearButton && <ComboboxClearButton />}
       {/* Arrow for combobox. Click is handled by the wrapper */}
       <div className={classes.arrow}>
         {open ? (


### PR DESCRIPTION
Resolves #1701

This also deprecates `cleanButtonLabel`, as this should be `clearButtonLabel`