### PR TITLE
feat(storefront): Make image required in blog template

### DIFF
--- a/apps/storefront/layouts/BlogArticleLayout/BlogArticleLayout.tsx
+++ b/apps/storefront/layouts/BlogArticleLayout/BlogArticleLayout.tsx
@@ -1,7 +1,7 @@
 import type * as React from 'react';
 import { Heading, Ingress, Paragraph } from '@digdir/design-system-react';
 
-import { Container, MdxContent } from '../../components';
+import { Container, MdxContent, Image, Meta } from '../../components';
 import { Link } from '../../components/Link/Link';
 
 import classes from './BlogArticleLayout.module.css';
@@ -9,11 +9,14 @@ import { Figures } from './components/Figures';
 
 type BlogArticleLayoutProps = {
   content: React.ReactNode;
-  heading?: string;
-  ingress?: string;
+  heading: string;
+  ingress: string;
   date?: string;
   author?: string;
   figureCount?: number;
+  imageSrc: string;
+  imageAlt: string;
+  imageCaption: string;
 };
 
 const FIGURE_COUNT = 4;
@@ -24,10 +27,18 @@ const BlogArticleLayout = ({
   ingress,
   date,
   author,
+  imageSrc,
+  imageAlt,
+  imageCaption,
   figureCount = FIGURE_COUNT,
 }: BlogArticleLayoutProps) => {
   return (
     <div className={classes.wrapper}>
+      <Meta
+        title={heading}
+        description={ingress}
+        image={imageSrc}
+      />
       <Container className={classes.page}>
         {Array.from({ length: figureCount }).map((_, index) => (
           <Figures
@@ -60,6 +71,12 @@ const BlogArticleLayout = ({
             </Paragraph>
           </div>
           <MdxContent classname={classes.content}>
+            <Image
+              src={imageSrc}
+              alt={imageAlt}
+              caption={imageCaption}
+              boxShadow={false}
+            />
             {content}
             <div className={classes.wantToWrite}>
               <Heading

--- a/apps/storefront/pages/bloggen/2023/derfor-trenger-vi-et-felles-designsystem.mdx
+++ b/apps/storefront/pages/bloggen/2023/derfor-trenger-vi-et-felles-designsystem.mdx
@@ -1,5 +1,5 @@
 import { BlogArticleLayout } from '@layouts';
-import { Meta, ResponsiveIframe, Image } from '@components';
+import { ResponsiveIframe, Image } from '@components';
 import { Contributors } from '@blog';
 
 export default ({ children }) => (

--- a/apps/storefront/pages/bloggen/2023/derfor-trenger-vi-et-felles-designsystem.mdx
+++ b/apps/storefront/pages/bloggen/2023/derfor-trenger-vi-et-felles-designsystem.mdx
@@ -2,12 +2,6 @@ import { BlogArticleLayout } from '@layouts';
 import { Meta, ResponsiveIframe, Image } from '@components';
 import { Contributors } from '@blog';
 
-<Meta
-  title='Derfor trenger vi et felles designsystem'
-  description='Høsten 2023 arrangerte vi en åpen presentasjon og mini-workshop om felles designsystem. Over 200 deltok og vi fikk 440 tilbakemeldinger på gevinster og utfordringer.'
-  image='/img/bloggen/miro.png'
-/>
-
 export default ({ children }) => (
   <BlogArticleLayout
     content={children}
@@ -15,14 +9,11 @@ export default ({ children }) => (
     ingress='Høsten 2023 arrangerte vi en åpen presentasjon og mini-workshop om felles designsystem. Over 200 deltok og vi fikk 440 tilbakemeldinger på gevinster og utfordringer.'
     date='5. desember 2023'
     author='Digdir og Brønnøysundregistrene'
+    imageSrc='/img/bloggen/miro.png'
+    imageAlt='Skjermdump fra Miro som viser mange musepekere som legger inn røde og grønne notislapper'
+    imageCaption='Mange delte sine tanker i Miro om et felles designsystem. 440 røde og grønne lapper ble lagt igjen.'
   />
 );
-
-<Image
-  src='/img/bloggen/miro.png'
-  alt='Skjermdump fra Miro som viser mange musepekere som legger inn røde og grønne notislapper'
-  caption='Mange delte sine tanker i Miro om et felles designsystem. 440 røde og grønne lapper ble lagt igjen.'
-/>
 
 Ikke alle klarer å bruke offentlige digitale tjenester på egen hånd. Innsikt fra prosjektet [“Digital hele livet med bedre brukeropplevelse”](https://www.digdir.no/sammenhengende-tjenester/digital-hele-livet-med-bedre-brukeropplevelse/4405) har vist at en av grunnene er at brukskvaliteten i de digitale tjenestene ikke er god nok. Prosjektet var et oppdrag fra regjeringen og ble ledet av Digdir.
 


### PR DESCRIPTION
Resolves #1656

Meta tags still work: https://metatags.io/?url=https%3A%2F%2Fstorefront-pr-1729.dev.designsystemet.no%2Fbloggen%2F2023%2Fderfor-trenger-vi-et-felles-designsystem