### PR TITLE
fix(Combobox): Fix `flushSync` being called inside a lifecycle method

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,7 +32,7 @@
     "@floating-ui/react": "0.26.4",
     "@navikt/aksel-icons": "^5.12.2",
     "@radix-ui/react-slot": "^1.0.2",
-    "@tanstack/react-virtual": "^3.0.1"
+    "@tanstack/react-virtual": "^3.2.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",

--- a/packages/react/src/components/form/Combobox/Combobox.tsx
+++ b/packages/react/src/components/form/Combobox/Combobox.tsx
@@ -26,6 +26,7 @@ import type {
   UseListNavigationProps,
 } from '@floating-ui/react';
 import { useVirtualizer } from '@tanstack/react-virtual';
+import { flushSync } from 'react-dom';
 
 import { Box } from '../../Box';
 import type { FormFieldProps } from '../useFormField';
@@ -246,7 +247,16 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
     // floating UI
     const { refs, floatingStyles, context } = useFloating<HTMLInputElement>({
       open,
-      onOpenChange: setOpen,
+      onOpenChange: (newOpen) => {
+        flushSync(() => {
+          if (refs.floating.current && !newOpen) {
+            refs.floating.current.scrollTop = 0;
+          }
+          setTimeout(() => {
+            setOpen(newOpen);
+          }, 1);
+        });
+      },
       whileElementsMounted: (reference, floating, update) => {
         autoUpdate(reference, floating, update);
         return () => {

--- a/packages/react/src/components/form/Combobox/Combobox.tsx
+++ b/packages/react/src/components/form/Combobox/Combobox.tsx
@@ -491,7 +491,7 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
           setInputValue,
           setActiveIndex,
           handleKeyDown,
-          setOpen: setOpen,
+          setOpen,
           getReferenceProps,
           setSelectedOptions,
           /* Recieves index of option, and the ID of the button element */

--- a/packages/react/src/components/form/Combobox/Combobox.tsx
+++ b/packages/react/src/components/form/Combobox/Combobox.tsx
@@ -462,7 +462,6 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
         return elem.getBoundingClientRect().height;
       },
       overscan: 1,
-      debug: true,
     });
 
     return (

--- a/packages/react/src/components/form/Combobox/Combobox.tsx
+++ b/packages/react/src/components/form/Combobox/Combobox.tsx
@@ -245,9 +245,14 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
 
     // floating UI
     const { refs, floatingStyles, context } = useFloating<HTMLInputElement>({
-      whileElementsMounted: autoUpdate,
       open,
       onOpenChange: setOpen,
+      whileElementsMounted: (reference, floating, update) => {
+        autoUpdate(reference, floating, update);
+        return () => {
+          floating.scrollTop = 0;
+        };
+      },
       middleware: [
         flip({ padding: 10 }),
         floatingSize({
@@ -442,11 +447,12 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
     const rowVirtualizer = useVirtualizer({
       count: optionsChildren.length,
       getScrollElement: () => refs.floating.current,
-      estimateSize: () => 40,
+      estimateSize: () => 70,
       measureElement: (elem) => {
         return elem.getBoundingClientRect().height;
       },
       overscan: 1,
+      debug: true,
     });
 
     return (
@@ -476,7 +482,7 @@ export const Combobox = forwardRef<HTMLInputElement, ComboboxProps>(
           setInputValue,
           setActiveIndex,
           handleKeyDown,
-          setOpen,
+          setOpen: setOpen,
           getReferenceProps,
           setSelectedOptions,
           /* Recieves index of option, and the ID of the button element */

--- a/yarn.lock
+++ b/yarn.lock
@@ -1663,7 +1663,7 @@ __metadata:
     "@floating-ui/react": "npm:0.26.4"
     "@navikt/aksel-icons": "npm:^5.12.2"
     "@radix-ui/react-slot": "npm:^1.0.2"
-    "@tanstack/react-virtual": "npm:^3.0.1"
+    "@tanstack/react-virtual": "npm:^3.2.0"
     "@types/fs-extra": "npm:^11.0.4"
     copyfiles: "npm:^2.4.1"
     esno: "npm:^4.7.0"
@@ -5329,10 +5329,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/react-virtual@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "@tanstack/react-virtual@npm:3.2.0"
+  dependencies:
+    "@tanstack/virtual-core": "npm:3.2.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 09bf6db0f3dbfa2245c7d78ed425bb7c0e169cbe5024cc6bfc53005505a472b36a0b5506d6fa4b8a47c07296c5982b1ac49acd4f32c48547aef7556f9ed2ed1d
+  languageName: node
+  linkType: hard
+
 "@tanstack/virtual-core@npm:3.0.0":
   version: 3.0.0
   resolution: "@tanstack/virtual-core@npm:3.0.0"
   checksum: 667941444b70773a8fc37b907718fcdbcf90b15660f427b06d6c140b72eea636d8609a8ba5ee3d2cb363066a8085fbf5b804fd08d5cfefd432cf1a14fa7c2355
+  languageName: node
+  linkType: hard
+
+"@tanstack/virtual-core@npm:3.2.0":
+  version: 3.2.0
+  resolution: "@tanstack/virtual-core@npm:3.2.0"
+  checksum: cf3ef6a2f3fa8ec4b155926da32508df45dadf268b365f206a171d011d6c728ddc9a7ea074575145266ccbdf445352ee9c9278bc1f55c3f96ad69ade7964b936
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves #1730

Updates `@tanstack/react-virtual`

After some experimenting, it seems like this bug comes from the [library](https://tanstack.com/virtual/latest/docs/api/virtualizer) we are using.

It only happens when you scroll in the list container, close and open again.
If you scroll back to the top before closing, the error does not happen.

The only fix I found is to scroll back to the top before closing.