### PR TITLE
feat(storybook): Add getting started page

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -175,6 +175,7 @@ const preview: Preview = {
         method: 'alphabetical',
         order: [
           'Oversikt',
+          'Kom i gang',
           'Endringslogger',
           'Komponenter',
           'Experimental',

--- a/packages/get-started.mdx
+++ b/packages/get-started.mdx
@@ -1,0 +1,8 @@
+import { Meta } from '@storybook/blocks';
+
+import { Markdown } from '@storybook/blocks';
+import changelog from '../README.md';
+
+<Meta title='Kom i gang' />
+
+<Markdown>{changelog}</Markdown>

--- a/packages/get-started.mdx
+++ b/packages/get-started.mdx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/blocks';
 
 import { Markdown } from '@storybook/blocks';
-import changelog from '../README.md';
+import readme from '../README.md';
 
 <Meta title='Kom i gang' />
 
-<Markdown>{changelog}</Markdown>
+<Markdown>{readme}</Markdown>

--- a/packages/get-started.mdx
+++ b/packages/get-started.mdx
@@ -2,17 +2,17 @@ import { Meta } from '@storybook/blocks';
 
 <Meta title='Kom i gang' />
 
-## 🚀 Kom i gang
+# 🚀 Kom i gang
 
 Følg disse stegene for å komme i gang med React-komponentene.
 
-### 1. Installer pakkene
+## 1. Installer pakkene
 
 ```sh
 npm i @digdir/designsystemet-react @digdir/designsystemet-theme @digdir/designsystemet-css
 ```
 
-#### Typescript
+### Typescript
 
 Dersom du bruker Typescript, sørg for at du har typescript >= 3.8 i `devDependencies`:
 
@@ -20,19 +20,19 @@ Dersom du bruker Typescript, sørg for at du har typescript >= 3.8 i `devDepende
 npm i typescript --save-dev
 ```
 
-### 2. Font
+## 2. Font
 
 Du kan fritt bruke hvilken som helst font-familie med komponentene.
 
 Komponentene er designet og utviklet med [Inter fonten](https://github.com/rsms/inter), så variasjoner kan forekomme dersom du bruker en annen font.
 
-#### Legg til Inter fonten (valgfritt)
+### Legg til Inter fonten (valgfritt)
 
 Legg til `<link>` taggen i `<head>`, og sett `font-family` til `Inter` i din globale css fil.
 
 `font-feature-settings` legger til en hale på små `L`'er og må settes med `!important` flagget.
 
-##### HTML
+#### HTML
 
 ```html
 <link
@@ -41,7 +41,7 @@ Legg til `<link>` taggen i `<head>`, og sett `font-family` til `Inter` i din glo
 />
 ```
 
-##### CSS
+#### CSS
 
 ```css
 body {
@@ -52,7 +52,7 @@ body {
 
 Dersom du velger å installere fonten på en annen måte, husk å inkludere fontvektene `400`, `500` og `600`.
 
-### 3. Bruk en React-komponent
+## 3. Bruk en React-komponent
 
 ```jsx
 import '@digdir/designsystemet-theme';

--- a/packages/get-started.mdx
+++ b/packages/get-started.mdx
@@ -1,8 +1,66 @@
 import { Meta } from '@storybook/blocks';
 
-import { Markdown } from '@storybook/blocks';
-import readme from '../README.md';
-
 <Meta title='Kom i gang' />
 
-<Markdown>{readme}</Markdown>
+## 🚀 Kom i gang
+
+Følg disse stegene for å komme i gang med React-komponentene.
+
+### 1. Installer pakkene
+
+```sh
+npm i @digdir/designsystemet-react @digdir/designsystemet-theme @digdir/designsystemet-css
+```
+
+#### Typescript
+
+Dersom du bruker Typescript, sørg for at du har typescript >= 3.8 i `devDependencies`:
+
+```sh
+npm i typescript --save-dev
+```
+
+### 2. Font
+
+Du kan fritt bruke hvilken som helst font-familie med komponentene.
+
+Komponentene er designet og utviklet med [Inter fonten](https://github.com/rsms/inter), så variasjoner kan forekomme dersom du bruker en annen font.
+
+#### Legg til Inter fonten (valgfritt)
+
+Legg til `<link>` taggen i `<head>`, og sett `font-family` til `Inter` i din globale css fil.
+
+`font-feature-settings` legger til en hale på små `L`'er og må settes med `!important` flagget.
+
+##### HTML
+
+```html
+<link
+  rel="stylesheet"
+  href="https://altinncdn.no/fonts/inter/inter.css"
+/>
+```
+
+##### CSS
+
+```css
+body {
+  font-family: 'Inter', sans-serif;
+  font-feature-settings: 'cv05' 1 !important; /* Enable lowercase l with tail */
+}
+```
+
+Dersom du velger å installere fonten på en annen måte, husk å inkludere fontvektene `400`, `500` og `600`.
+
+### 3. Bruk en React-komponent
+
+```jsx
+import '@digdir/designsystemet-theme';
+import '@digdir/designsystemet-css';
+
+import { Button } from '@digdir/designsystemet-react';
+
+<Button variant='secondary'>Jeg er en knapp!</Button>;
+```
+
+`@digdir/designsystemet-theme` og `@digdir/designsystemet-css` må kun importeres én gang i applikasjonen.

--- a/packages/react-old/src/components/legacy/LegacyTable/Table.stories.mdx
+++ b/packages/react-old/src/components/legacy/LegacyTable/Table.stories.mdx
@@ -60,7 +60,10 @@ export const Template = (args) => (
 
 # LegacyTable
 
-<Information text='deprecated' />
+<Information
+  text='deprecated'
+  description='**Denne komponenten er erstattet av [Table](/?path=/docs/komponenter-table--docs) komponent.**'
+/>
 
 ## Eksempel
 

--- a/packages/react/src/components/Accordion/Accordion.mdx
+++ b/packages/react/src/components/Accordion/Accordion.mdx
@@ -23,7 +23,6 @@ Med `Accordion` kan du presentere mye innhold på liten plass i en eller flere r
 ## Bruk
 
 ```tsx
-import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.
 import { Accordion } from '@digdir/designsystemet-react';
 
 <Accordion>

--- a/packages/react/src/components/Accordion/Accordion.mdx
+++ b/packages/react/src/components/Accordion/Accordion.mdx
@@ -1,7 +1,5 @@
 import { Meta, Canvas, Controls, Primary, ArgTypes } from '@storybook/blocks';
 
-import { Information } from '../../../../../docs-components';
-
 import * as AccordionStories from './Accordion.stories';
 
 import { Accordion } from '.';
@@ -23,8 +21,6 @@ Med `Accordion` kan du presentere mye innhold på liten plass i en eller flere r
 <Controls />
 
 ## Bruk
-
-<Information text='token' />
 
 ```tsx
 import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.

--- a/packages/react/src/components/Alert/Alert.mdx
+++ b/packages/react/src/components/Alert/Alert.mdx
@@ -21,7 +21,6 @@ Bruk `Alert` til budskap det er ekstra viktig at brukerne ser og forstår. Den e
 ## Bruk
 
 ```tsx
-import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.
 import { Alert } from '@digdir/designsystemet-react';
 
 <Alert>You are using the Alert component!</Alert>;

--- a/packages/react/src/components/Alert/Alert.mdx
+++ b/packages/react/src/components/Alert/Alert.mdx
@@ -1,6 +1,6 @@
 import { Meta, Canvas, Controls, Primary } from '@storybook/blocks';
 
-import { Information, Do, Dont, Stack } from '../../../../../docs-components';
+import { Do, Dont, Stack } from '../../../../../docs-components';
 
 import * as AlertStories from './Alert.stories';
 
@@ -19,8 +19,6 @@ Bruk `Alert` til budskap det er ekstra viktig at brukerne ser og forstår. Den e
 <Controls />
 
 ## Bruk
-
-<Information text='token' />
 
 ```tsx
 import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.

--- a/packages/react/src/components/Button/Button.mdx
+++ b/packages/react/src/components/Button/Button.mdx
@@ -1,6 +1,6 @@
 import { Meta, Canvas, Controls, Primary } from '@storybook/blocks';
 
-import { Information, Do, Dont, Stack } from '../../../../../docs-components';
+import { Do, Dont, Stack } from '../../../../../docs-components';
 
 import * as ButtonStories from './Button.stories';
 
@@ -14,8 +14,6 @@ Knapper lar brukerne utføre handlinger. Vi har variantene `primary`, `secondary
 <Controls />
 
 ## Slik bruker du button
-
-<Information text='token' />
 
 ```tsx
 import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.

--- a/packages/react/src/components/Button/Button.mdx
+++ b/packages/react/src/components/Button/Button.mdx
@@ -16,7 +16,6 @@ Knapper lar brukerne utføre handlinger. Vi har variantene `primary`, `secondary
 ## Slik bruker du button
 
 ```tsx
-import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.
 import { Button } from '@digdir/designsystemet-react';
 
 <Button>Trykk på meg!</Button>;

--- a/packages/react/src/components/Card/Card.mdx
+++ b/packages/react/src/components/Card/Card.mdx
@@ -1,7 +1,5 @@
 import { Meta, Canvas, Controls, Primary } from '@storybook/blocks';
 
-import { Information } from '../../../../../docs-components';
-
 import * as CardStories from './Card.stories';
 
 <Meta of={CardStories} />
@@ -20,8 +18,6 @@ Med `Card` kan du presentere informasjon på en strukturert og oversiktlig måte
 <Controls />
 
 ## Bruk
-
-<Information text='token' />
 
 ```tsx
 import { Card } from '@digdir/designsystemet-react';

--- a/packages/react/src/components/Chip/Chip.mdx
+++ b/packages/react/src/components/Chip/Chip.mdx
@@ -1,7 +1,5 @@
 import { Meta, Canvas, Controls, Primary } from '@storybook/blocks';
 
-import { Information } from '../../../../../docs-components';
-
 import * as ChipStories from './Chip.stories';
 import * as ToggleChipStories from './Toggle/Toggle.stories';
 import * as RemovableChipStories from './Removable/Removable.stories';
@@ -25,8 +23,6 @@ Chip eksisterer i ulike varianter:
 <Controls />
 
 ## Bruk
-
-<Information text='token' />
 
 ```tsx
 import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.

--- a/packages/react/src/components/Chip/Chip.mdx
+++ b/packages/react/src/components/Chip/Chip.mdx
@@ -25,7 +25,6 @@ Chip eksisterer i ulike varianter:
 ## Bruk
 
 ```tsx
-import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.
 import { Chip } from '@digdir/designsystemet-react';
 
 <Chip.Toggle>You are using the Chip component!</Chip.Toggle>;

--- a/packages/react/src/components/DropdownMenu/DropdownMenu.mdx
+++ b/packages/react/src/components/DropdownMenu/DropdownMenu.mdx
@@ -14,7 +14,6 @@ import { DropdownMenu } from './';
 ## Slik bruker du `DropdownMenu`
 
 ```tsx
-import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.
 import { DropdownMenu } from '@digdir/designsystemet-react';
 
 <DropdownMenu>

--- a/packages/react/src/components/ErrorSummary/ErrorSummary.mdx
+++ b/packages/react/src/components/ErrorSummary/ErrorSummary.mdx
@@ -17,7 +17,6 @@ import { ErrorSummary } from './';
 Alle `ErrorSummary.Item` må ha en `href` for å kunne navigere til riktig sted i skjemaet.
 
 ```tsx
-import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.
 import { ErrorSummary } from '@digdir/designsystemet-react';
 
 <ErrorSummary.Root>

--- a/packages/react/src/components/Link/Link.mdx
+++ b/packages/react/src/components/Link/Link.mdx
@@ -1,7 +1,5 @@
 import { Meta, Canvas, Controls, Primary } from '@storybook/blocks';
 
-import { Information } from '../../../../../docs-components';
-
 import * as LinkStories from './Link.stories';
 
 <Meta of={LinkStories} />
@@ -14,8 +12,6 @@ import * as LinkStories from './Link.stories';
 <Controls />
 
 ## Bruk
-
-<Information text='token' />
 
 ```tsx
 import '@digdir/designsystemet-theme'; // Importeres kun én gang i din applikasjon

--- a/packages/react/src/components/Link/Link.mdx
+++ b/packages/react/src/components/Link/Link.mdx
@@ -14,7 +14,6 @@ import * as LinkStories from './Link.stories';
 ## Bruk
 
 ```tsx
-import '@digdir/designsystemet-theme'; // Importeres kun én gang i din applikasjon
 import { Link } from '@digdir/designsystemet-react';
 
 <Link href='https://designsystemet.no/'>Gå til designsystemet</Link>;

--- a/packages/react/src/components/List/List.mdx
+++ b/packages/react/src/components/List/List.mdx
@@ -19,7 +19,6 @@ Lista kan være både ordnet og uordnet, dette endrer du ved å bruke `List.Orde
 `List.Root` er påkrevd for å får riktig aria attributter (`aria-labelledby`) mellom listen og tittel.
 
 ```tsx
-import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.
 import { List } from '@digdir/designsystemet-react';
 
 <List.Root>

--- a/packages/react/src/components/Pagination/Pagination.mdx
+++ b/packages/react/src/components/Pagination/Pagination.mdx
@@ -1,7 +1,5 @@
 import { Meta, Controls, Primary, Canvas } from '@storybook/blocks';
 
-import { Information } from '../../../../../docs-components';
-
 import * as PaginationStories from './Pagination.stories';
 
 <Meta of={PaginationStories} />
@@ -22,8 +20,6 @@ Vær oppmerksom på:
 <Controls of={PaginationStories.Preview} />
 
 ## Bruk
-
-<Information text='token' />
 
 ### Eksempel på bruk med `Pagination`
 

--- a/packages/react/src/components/Pagination/Pagination.mdx
+++ b/packages/react/src/components/Pagination/Pagination.mdx
@@ -26,7 +26,6 @@ Vær oppmerksom på:
 `Pagination` er en kontrollert komponent. Det vil si at komponentens tilstand om hvilken side som er aktiv styres utenfra. Når komponenten er på første eller siste side, skjules "forrige"/"neste"-pilene.
 
 ```tsx
-import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.
 import { Pagination } from '@digdir/designsystemet-react';
 
 const [currentPage, setCurrentPage] = useState(1);

--- a/packages/react/src/components/Popover/Popover.mdx
+++ b/packages/react/src/components/Popover/Popover.mdx
@@ -12,9 +12,6 @@ import * as PopoverStories from './Popover.stories.tsx';
 ## Slik bruker du `Popover`
 
 ```tsx
-import '@digdir/designsystemet-theme';
-import '@digdir/designsystemet-css';
-
 import { Popover } from '@digdir/designsystemet-react';
 
 <Popover>

--- a/packages/react/src/components/SkipLink/SkipLink.mdx
+++ b/packages/react/src/components/SkipLink/SkipLink.mdx
@@ -14,7 +14,6 @@ Skiplink-komponenten hjelper de som bruker tastatur og skjermleser med å hoppe 
 ## Bruk
 
 ```tsx
-import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.
 import { SkipLink } from '@digdir/designsystemet-react';
 
 <SkipLink href='#main-content'>Hopp til hovedinnhold</SkipLink>

--- a/packages/react/src/components/Tabs/Tabs.mdx
+++ b/packages/react/src/components/Tabs/Tabs.mdx
@@ -14,7 +14,6 @@ Description of the Tabs component.
 ## Bruk
 
 ```tsx
-import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.
 import { Tabs } from '@digdir/designsystemet-react';
 
 <Tabs defaultValue='value1'>

--- a/packages/react/src/components/Tabs/Tabs.mdx
+++ b/packages/react/src/components/Tabs/Tabs.mdx
@@ -1,7 +1,5 @@
 import { Meta, Canvas, Controls, Primary } from '@storybook/blocks';
 
-import { Information } from '../../../../../docs-components';
-
 import * as TabsStories from './Tabs.stories';
 
 <Meta of={TabsStories} />
@@ -14,8 +12,6 @@ Description of the Tabs component.
 <Controls />
 
 ## Bruk
-
-<Information text='token' />
 
 ```tsx
 import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.

--- a/packages/react/src/components/Tag/Tag.mdx
+++ b/packages/react/src/components/Tag/Tag.mdx
@@ -1,7 +1,5 @@
 import { Meta, Canvas, Story, Controls, Primary } from '@storybook/blocks';
 
-import { Information } from '../../../../../docs-components';
-
 import * as TagStories from './Tag.stories';
 
 <Meta of={TagStories} />
@@ -14,8 +12,6 @@ Tags er merkelapper som kan brukes til å kategorisere elementer eller kommunise
 <Controls />
 
 ## Bruk
-
-<Information text='token' />
 
 ```tsx
 import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.

--- a/packages/react/src/components/Tag/Tag.mdx
+++ b/packages/react/src/components/Tag/Tag.mdx
@@ -14,7 +14,6 @@ Tags er merkelapper som kan brukes til å kategorisere elementer eller kommunise
 ## Bruk
 
 ```tsx
-import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.
 import { Tag } from '@digdir/designsystemet-react';
 
 <Tag>Beta</Tag>;

--- a/packages/react/src/components/ToggleGroup/ToggleGroup.mdx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroup.mdx
@@ -1,7 +1,5 @@
 import { Meta, Canvas, Controls, Primary } from '@storybook/blocks';
 
-import { Information } from '../../../../../docs-components';
-
 import * as ToggleGroupStories from './ToggleGroup.stories';
 
 <Meta of={ToggleGroupStories} />
@@ -14,8 +12,6 @@ Description of the ToggleGroup component.
 <Controls />
 
 ## Bruk
-
-<Information text='token' />
 
 ```tsx
 import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.

--- a/packages/react/src/components/ToggleGroup/ToggleGroup.mdx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroup.mdx
@@ -14,7 +14,6 @@ Description of the ToggleGroup component.
 ## Bruk
 
 ```tsx
-import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.
 import { ToggleGroup } from '@digdir/designsystemet-react';
 
 <ToggleGroup defaultValue='value1'>

--- a/packages/react/src/components/Typography/Typography.mdx
+++ b/packages/react/src/components/Typography/Typography.mdx
@@ -1,7 +1,5 @@
 import { Meta, Canvas, Story, Controls } from '@storybook/blocks';
 
-import { Information } from '../../../../../docs-components';
-
 import * as typographyStories from './Typography.stories';
 import * as HeadingStories from './Heading/Heading.stories';
 import * as ParagraphStories from './Paragraph/Paragraph.stories';
@@ -19,8 +17,6 @@ prosessere informasjonen som er der. Typografien er delt inn i fire kategorier s
 ment å dekke alle behov som måtte dukke opp på et nettsted:
 
 ## Bruk
-
-<Information text='token' />
 
 Typografikomponentene kommer med hverken innebygd eller definert font-familie. Det er opp til bruker å selv å importere ønsket font.
 

--- a/packages/react/src/components/form/Checkbox/Checkbox.mdx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.mdx
@@ -23,7 +23,6 @@ Vær oppmerksom på:
 ## Bruk
 
 ```tsx
-import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.
 import { Checkbox } from '@digdir/designsystemet-react';
 
 <Checkbox.Group legend='What would your D&D party like to eat?'>

--- a/packages/react/src/components/form/Checkbox/Checkbox.mdx
+++ b/packages/react/src/components/form/Checkbox/Checkbox.mdx
@@ -1,11 +1,6 @@
 import { Meta, Canvas, Controls, Primary } from '@storybook/blocks';
 
-import {
-  Information,
-  Do,
-  Dont,
-  Stack,
-} from '../../../../../../docs-components';
+import { Do, Dont, Stack } from '../../../../../../docs-components';
 import * as TableStories from '../../Table/Table.stories';
 
 import * as CheckboxStories from './Checkbox.stories';
@@ -26,8 +21,6 @@ Vær oppmerksom på:
 <Controls />
 
 ## Bruk
-
-<Information text='token' />
 
 ```tsx
 import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.

--- a/packages/react/src/components/form/NativeSelect/NativeSelect.mdx
+++ b/packages/react/src/components/form/NativeSelect/NativeSelect.mdx
@@ -19,7 +19,6 @@ For eksempel er det ikke mulig å overstyre formateringen av alternativene.
 ## Bruk
 
 ```tsx
-import '@digdir/designsystemet-theme'; // Importeres kun én gang i din applikasjon
 import { NativeSelect } from '@digdir/designsystemet-react';
 
 <NativeSelect label='Ta et valg'>

--- a/packages/react/src/components/form/NativeSelect/NativeSelect.mdx
+++ b/packages/react/src/components/form/NativeSelect/NativeSelect.mdx
@@ -1,7 +1,5 @@
 import { Meta, Canvas, Controls, Primary } from '@storybook/blocks';
 
-import { Information } from '../../../../../../docs-components';
-
 import * as NativeSelectStories from './NativeSelect.stories';
 
 <Meta of={NativeSelectStories} />
@@ -19,8 +17,6 @@ For eksempel er det ikke mulig å overstyre formateringen av alternativene.
 <Controls />
 
 ## Bruk
-
-<Information text='token' />
 
 ```tsx
 import '@digdir/designsystemet-theme'; // Importeres kun én gang i din applikasjon

--- a/packages/react/src/components/form/Radio/Radio.mdx
+++ b/packages/react/src/components/form/Radio/Radio.mdx
@@ -15,7 +15,6 @@ import * as RadioGroupStories from './Group/Group.stories';
 ## Bruk
 
 ```tsx
-import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.
 import { Radio } from '@digdir/designsystemet-react';
 
 <Radio.Group legend='Er du over 18 år?'>

--- a/packages/react/src/components/form/Radio/Radio.mdx
+++ b/packages/react/src/components/form/Radio/Radio.mdx
@@ -1,7 +1,5 @@
 import { Meta, Canvas, Controls, Primary } from '@storybook/blocks';
 
-import { Information } from '../../../../../../docs-components';
-
 import * as RadioStories from './Radio.stories';
 import * as RadioGroupStories from './Group/Group.stories';
 
@@ -15,8 +13,6 @@ import * as RadioGroupStories from './Group/Group.stories';
 <Controls />
 
 ## Bruk
-
-<Information text='token' />
 
 ```tsx
 import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.

--- a/packages/react/src/components/form/Switch/Switch.mdx
+++ b/packages/react/src/components/form/Switch/Switch.mdx
@@ -1,7 +1,5 @@
 import { Meta, Canvas, Controls, Primary } from '@storybook/blocks';
 
-import { Information } from '../../../../../../docs-components';
-
 import * as SwitchStories from './Switch.stories';
 
 <Meta of={SwitchStories} />
@@ -12,8 +10,6 @@ import * as SwitchStories from './Switch.stories';
 <Controls />
 
 ## Bruk
-
-<Information text='token' />
 
 ```tsx
 import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.

--- a/packages/react/src/components/form/Switch/Switch.mdx
+++ b/packages/react/src/components/form/Switch/Switch.mdx
@@ -12,7 +12,6 @@ import * as SwitchStories from './Switch.stories';
 ## Bruk
 
 ```tsx
-import '@digdir/designsystemet-theme'; // Importeres kun en gang i appen din.
 import { Switch, Fieldset } from '@digdir/designsystemet-react';
 
 <Fieldset legend='Profil instillinger'>


### PR DESCRIPTION
Resolves #1699

Get started page has the same text as our root readme, but in norwegian.
Removed all `<Information />`, except the ones telling the user about deprecation.