### PR TITLE
fix(Radio): :bug: Correct orientation of radio and label

### DIFF
--- a/packages/css/react-css-modules.css
+++ b/packages/css/react-css-modules.css
@@ -1687,7 +1687,7 @@
 }
 
 .fds-radio-container-7a9bd584:has(.fds-radio-label-7a9bd584) {
-  grid-template-columns: var(--fds-checkbox-size) auto;
+  grid-template-columns: var(--fds-radio-size) auto;
   gap: var(--fds-spacing-2);
 }
 

--- a/packages/react/src/components/form/Radio/Radio.module.css
+++ b/packages/react/src/components/form/Radio/Radio.module.css
@@ -9,7 +9,7 @@
 }
 
 .container:has(.label) {
-  grid-template-columns: var(--fds-checkbox-size) auto;
+  grid-template-columns: var(--fds-radio-size) auto;
   gap: var(--fds-spacing-2);
 }
 


### PR DESCRIPTION
Fix copy-pasta 🍝 bug which causes missaligned radio and label.

![image](https://github.com/digdir/designsystemet/assets/1070981/e8eb3602-6c8c-4a4e-8f88-997aec3173b3)
