### PR TITLE
feat(css): Add autoprefixer with configuration (#1669 #1773)

### DIFF
--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -13,6 +13,14 @@
   "publishConfig": {
     "access": "public"
   },
+  "browserslist": [
+    "cover 90% in NO",
+    "last 2 versions",
+    "Firefox ESR",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ],
   "keywords": [
     "css",
     "designsystem",
@@ -24,6 +32,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
+    "autoprefixer": "^10.4.19",
     "cssnano": "^6.0.2",
     "postcss": "^8.4.35",
     "postcss-cli": "^11.0.0",

--- a/packages/css/postcss.config.js
+++ b/packages/css/postcss.config.js
@@ -5,5 +5,6 @@ module.exports = {
       preset: 'default',
     }),
     require('./postcss-layers'),
+    require('autoprefixer'),
   ],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2597,6 +2597,7 @@ __metadata:
   resolution: "@digdir/designsystemet-css@workspace:packages/css"
   dependencies:
     "@digdir/designsystemet-react": "workspace:^"
+    autoprefixer: "npm:^10.4.19"
     cssnano: "npm:^6.0.2"
     postcss: "npm:^8.4.35"
     postcss-cli: "npm:^11.0.0"
@@ -7080,6 +7081,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"autoprefixer@npm:^10.4.19":
+  version: 10.4.19
+  resolution: "autoprefixer@npm:10.4.19"
+  dependencies:
+    browserslist: "npm:^4.23.0"
+    caniuse-lite: "npm:^1.0.30001599"
+    fraction.js: "npm:^4.3.7"
+    normalize-range: "npm:^0.1.2"
+    picocolors: "npm:^1.0.0"
+    postcss-value-parser: "npm:^4.2.0"
+  peerDependencies:
+    postcss: ^8.1.0
+  bin:
+    autoprefixer: bin/autoprefixer
+  checksum: 98378eae37b8bf0f1515e4c91b4c9c1ce69ede311d4dea7e934f5afe147d23712c577f112c4019a4c40461c585d82d474d08044f8eb6cb8a063c3d5b7aca52d2
+  languageName: node
+  linkType: hard
+
 "available-typed-arrays@npm:^1.0.5":
   version: 1.0.5
   resolution: "available-typed-arrays@npm:1.0.5"
@@ -7610,6 +7629,13 @@ __metadata:
   version: 1.0.30001605
   resolution: "caniuse-lite@npm:1.0.30001605"
   checksum: c5671465d7301ecea515698e6b680f20933d1c5351c0381b6ef1a14bf911b3f1f8b7633eedc10339268036f0a63d703bc8d36071412f89495b48630f01a21fe5
+  languageName: node
+  linkType: hard
+
+"caniuse-lite@npm:^1.0.30001599":
+  version: 1.0.30001607
+  resolution: "caniuse-lite@npm:1.0.30001607"
+  checksum: caab9ae1aa343e72da935c071041344c80338d8a12bd12a90b7d46eb8a97c7620dac72e95c994b94ce82d63f2f27151dab49206864620d8bfd7aa99f7fc75c83
   languageName: node
   linkType: hard
 
@@ -10616,6 +10642,13 @@ __metadata:
   version: 0.2.0
   resolution: "forwarded@npm:0.2.0"
   checksum: 29ba9fd347117144e97cbb8852baae5e8b2acb7d1b591ef85695ed96f5b933b1804a7fac4a15dd09ca7ac7d0cdc104410e8102aae2dd3faa570a797ba07adb81
+  languageName: node
+  linkType: hard
+
+"fraction.js@npm:^4.3.7":
+  version: 4.3.7
+  resolution: "fraction.js@npm:4.3.7"
+  checksum: bb5ebcdeeffcdc37b68ead3bdfc244e68de188e0c64e9702197333c72963b95cc798883ad16adc21588088b942bca5b6a6ff4aeb1362d19f6f3b629035dc15f5
   languageName: node
   linkType: hard
 
@@ -15386,6 +15419,13 @@ __metadata:
   version: 3.0.0
   resolution: "normalize-path@npm:3.0.0"
   checksum: 88eeb4da891e10b1318c4b2476b6e2ecbeb5ff97d946815ffea7794c31a89017c70d7f34b3c2ebf23ef4e9fc9fb99f7dffe36da22011b5b5c6ffa34f4873ec20
+  languageName: node
+  linkType: hard
+
+"normalize-range@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "normalize-range@npm:0.1.2"
+  checksum: 9b2f14f093593f367a7a0834267c24f3cb3e887a2d9809c77d8a7e5fd08738bcd15af46f0ab01cc3a3d660386f015816b5c922cea8bf2ee79777f40874063184
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Autoprefixer with browserslist config

Fixes #1669 
Fixes #1773

The suggested browserslist config was: 
`[">0.2%", "not dead", "not ie <= 11", "not op_mini all"]`
Using ">0.2%" is not recommended by browserslist: 
"[...] only using a percentage of usage numbers above 0.2% will in the long run make popular browsers even more popular. We might run into a monopoly and stagnation situation, as we had with Internet Explorer 6. Please use this setting with caution."

The default browserslist configuration is: "the [defaults](https://browsersl.ist/#q=defaults&region=NO) query which is a shortcut for > 0.5%, last 2 versions, Firefox ESR, not dead." 

Configuration can be targeted into country specific stats. I think the projects target audience is the Norwegian population. 

Taken all the above into account the configuration i suggest is: 
`["cover 90% in NO", "last 2 versions", "Firefox ESR", "not dead", "not ie <= 11", "not op_mini all" ]`
[Browserslist](https://browsersl.ist/#q=cover+90%25+in+NO%2C+last+2+versions%2C+Firefox+ESR%2C+not+dead%2C+not+ie+%3C%3D+11%2C+not+op_mini+all&region=NO) gives this a 91.8% coverage