### PR TITLE
feat(DropdownMenu, Popover, Modal): Using `asChild` on `Trigger` components no longer clones style to child

### DIFF
--- a/packages/react/src/components/Box/Box.stories.tsx
+++ b/packages/react/src/components/Box/Box.stories.tsx
@@ -25,17 +25,18 @@ export const Polymorphic: Story = (args) => (
   <>
     <Box
       {...args}
-      as='button'
+      asChild
       borderRadius='medium'
       borderColor='subtle'
     >
-      button
+      <button>button</button>
     </Box>
     <Box
       {...args}
       asChild
       borderRadius='medium'
       borderColor='subtle'
+      background='subtle'
     >
       <a
         href='https://designsystemet.no'

--- a/packages/react/src/components/DropdownMenu/DropdownMenu.stories.tsx
+++ b/packages/react/src/components/DropdownMenu/DropdownMenu.stories.tsx
@@ -24,19 +24,25 @@ export const Preview: StoryFn<typeof DropdownMenu> = (args) => {
         <DropdownMenu.Trigger>Dropdown</DropdownMenu.Trigger>
         <DropdownMenu.Content>
           <DropdownMenu.Group heading='Links'>
-            <DropdownMenu.Item
-              as='a'
-              href='https://github.com/digdir/designsystemet'
-              target='_blank'
-            >
-              Github
+            <DropdownMenu.Item asChild>
+              <a
+                href='https://github.com/digdir/designsystemet'
+                target='_blank'
+                rel='noreferrer'
+              >
+                <LinkIcon fontSize='1.5rem' />
+                Github
+              </a>
             </DropdownMenu.Item>
-            <DropdownMenu.Item
-              as='a'
-              href='https://designsystemet.no'
-              target='_blank'
-            >
-              Designsystemet.no
+            <DropdownMenu.Item asChild>
+              <a
+                href='https://designsystemet.no'
+                target='_blank'
+                rel='noreferrer'
+              >
+                <LinkIcon fontSize='1.5rem' />
+                Designsystemet.no
+              </a>
             </DropdownMenu.Item>
           </DropdownMenu.Group>
           <Divider />
@@ -64,21 +70,25 @@ export const Icons: StoryFn<typeof DropdownMenu> = () => {
       <DropdownMenu.Trigger>Dropdown</DropdownMenu.Trigger>
       <DropdownMenu.Content>
         <DropdownMenu.Group>
-          <DropdownMenu.Item
-            as='a'
-            href='https://github.com/digdir/designsystemet'
-            target='_blank'
-          >
-            <LinkIcon fontSize='1.5rem' />
-            Github
+          <DropdownMenu.Item asChild>
+            <a
+              href='https://github.com/digdir/designsystemet'
+              target='_blank'
+              rel='noreferrer'
+            >
+              <LinkIcon fontSize='1.5rem' />
+              Github
+            </a>
           </DropdownMenu.Item>
-          <DropdownMenu.Item
-            as='a'
-            href='https://designsystemet.no'
-            target='_blank'
-          >
-            <LinkIcon fontSize='1.5rem' />
-            Designsystemet.no
+          <DropdownMenu.Item asChild>
+            <a
+              href='https://designsystemet.no'
+              target='_blank'
+              rel='noreferrer'
+            >
+              <LinkIcon fontSize='1.5rem' />
+              Designsystemet.no
+            </a>
           </DropdownMenu.Item>
         </DropdownMenu.Group>
       </DropdownMenu.Content>
@@ -94,21 +104,25 @@ export const InPortal: StoryFn<typeof DropdownMenu> = () => {
       <DropdownMenu.Trigger>Dropdown</DropdownMenu.Trigger>
       <DropdownMenu.Content>
         <DropdownMenu.Group>
-          <DropdownMenu.Item
-            as='a'
-            href='https://github.com/digdir/designsystemet'
-            target='_blank'
-          >
-            <LinkIcon fontSize='1.5rem' />
-            Github
+          <DropdownMenu.Item asChild>
+            <a
+              href='https://github.com/digdir/designsystemet'
+              target='_blank'
+              rel='noreferrer'
+            >
+              <LinkIcon fontSize='1.5rem' />
+              Github
+            </a>
           </DropdownMenu.Item>
-          <DropdownMenu.Item
-            as='a'
-            href='https://designsystemet.no'
-            target='_blank'
-          >
-            <LinkIcon fontSize='1.5rem' />
-            Designsystemet.no
+          <DropdownMenu.Item asChild>
+            <a
+              href='https://designsystemet.no'
+              target='_blank'
+              rel='noreferrer'
+            >
+              <LinkIcon fontSize='1.5rem' />
+              Designsystemet.no
+            </a>
           </DropdownMenu.Item>
         </DropdownMenu.Group>
       </DropdownMenu.Content>
@@ -131,21 +145,25 @@ export const Controlled: StoryFn<typeof DropdownMenu> = () => {
         </DropdownMenu.Trigger>
         <DropdownMenu.Content>
           <DropdownMenu.Group>
-            <DropdownMenu.Item
-              as='a'
-              href='https://github.com/digdir/designsystemet'
-              target='_blank'
-            >
-              <LinkIcon fontSize='1.5rem' />
-              Github
+            <DropdownMenu.Item asChild>
+              <a
+                href='https://github.com/digdir/designsystemet'
+                target='_blank'
+                rel='noreferrer'
+              >
+                <LinkIcon fontSize='1.5rem' />
+                Github
+              </a>
             </DropdownMenu.Item>
-            <DropdownMenu.Item
-              as='a'
-              href='https://designsystemet.no'
-              target='_blank'
-            >
-              <LinkIcon fontSize='1.5rem' />
-              Designsystemet.no
+            <DropdownMenu.Item asChild>
+              <a
+                href='https://designsystemet.no'
+                target='_blank'
+                rel='noreferrer'
+              >
+                <LinkIcon fontSize='1.5rem' />
+                Designsystemet.no
+              </a>
             </DropdownMenu.Item>
           </DropdownMenu.Group>
         </DropdownMenu.Content>

--- a/packages/react/src/components/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/react/src/components/DropdownMenu/DropdownMenu.test.tsx
@@ -112,14 +112,11 @@ describe('Dropdown', () => {
     expect(screen.queryByText('Item')).toBeInTheDocument();
   });
 
-  it('should be able to render `Dropdown.Item` as a link', async () => {
+  it('should be able to render `Dropdown.Item` as a anchor element using asChild', async () => {
     const { user } = await render({
       children: (
-        <DropdownMenu.Item
-          as='a'
-          href='#'
-        >
-          Item 2
+        <DropdownMenu.Item asChild>
+          <a href='/'>Anchor</a>
         </DropdownMenu.Item>
       ),
     });
@@ -127,8 +124,8 @@ describe('Dropdown', () => {
 
     await user.click(dropdownTrigger);
 
-    expect(screen.getByText('Item 2')).toHaveAttribute('href', '#');
-    expect(screen.getByText('Item 2').tagName).toBe('A');
+    expect(screen.getByText('Anchor')).toHaveAttribute('href', '/');
+    expect(screen.getByText('Anchor').tagName).toBe('A');
   });
 
   it('Item should have role="menuitem"', async () => {

--- a/packages/react/src/components/DropdownMenu/DropdownMenuTrigger.tsx
+++ b/packages/react/src/components/DropdownMenu/DropdownMenuTrigger.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useContext } from 'react';
 import type * as React from 'react';
 import { useMergeRefs } from '@floating-ui/react';
+import { Slot } from '@radix-ui/react-slot';
 
 import { Button } from '../Button';
 
@@ -13,13 +14,15 @@ export type DropdownMenuTriggerProps = React.ComponentPropsWithRef<
 export const DropdownMenuTrigger = forwardRef<
   HTMLButtonElement,
   DropdownMenuTriggerProps
->(({ ...rest }, ref) => {
+>(({ asChild, ...rest }, ref) => {
   const { triggerRef, internalOpen, setInternalOpen, isControlled } =
     useContext(DropdownMenuContext);
   const mergedRefs = useMergeRefs([ref, triggerRef]);
 
+  const Component = asChild ? Slot : Button;
+
   return (
-    <Button
+    <Component
       ref={mergedRefs}
       onClick={() => {
         if (!isControlled) setInternalOpen(!internalOpen);

--- a/packages/react/src/components/Modal/ModalTrigger/ModalTrigger.tsx
+++ b/packages/react/src/components/Modal/ModalTrigger/ModalTrigger.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useContext } from 'react';
 import type * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
 
 import { Button } from '../../Button';
 import { ModalContext } from '../ModalRoot';
@@ -7,11 +8,12 @@ import { ModalContext } from '../ModalRoot';
 export type ModalTriggerProps = React.ComponentPropsWithRef<typeof Button>;
 
 export const ModalTrigger = forwardRef<HTMLButtonElement, ModalTriggerProps>(
-  ({ ...rest }, ref) => {
+  ({ asChild, ...rest }, ref) => {
     const { modalRef, open } = useContext(ModalContext);
+    const Component = asChild ? Slot : Button;
 
     return (
-      <Button
+      <Component
         ref={ref}
         onClick={() => modalRef?.current?.showModal()}
         aria-expanded={open}

--- a/packages/react/src/components/Popover/PopoverTrigger.tsx
+++ b/packages/react/src/components/Popover/PopoverTrigger.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useContext, useEffect } from 'react';
 import type * as React from 'react';
 import { useMergeRefs } from '@floating-ui/react';
+import { Slot } from '@radix-ui/react-slot';
 
 import { Button } from '../Button';
 
@@ -11,7 +12,7 @@ export type PopoverTriggerProps = React.ComponentPropsWithRef<typeof Button>;
 export const PopoverTrigger = forwardRef<
   HTMLButtonElement,
   PopoverTriggerProps
->(({ id, ...rest }, ref) => {
+>(({ id, asChild, ...rest }, ref) => {
   const {
     triggerRef,
     internalOpen,
@@ -28,17 +29,17 @@ export const PopoverTrigger = forwardRef<
     id && setTriggerId?.(id);
   }, [id, setTriggerId]);
 
+  const Component = asChild ? Slot : Button;
+
   return (
-    <Button
+    <Component
       ref={mergedRefs}
       onClick={() => {
         if (!isControlled) setInternalOpen(!internalOpen);
       }}
       aria-expanded={internalOpen}
-      role='button'
       aria-controls={internalOpen ? popoverId : undefined}
       id={triggerId}
-      type='button'
       {...rest}
     />
   );


### PR DESCRIPTION
resolves #1794 

BREAKING CHANGE: `DropdownMenu.Trigger`, `Modal.Trigger` & `Popover.Trigger` no longer clone style to child on `asChild`

- Reverted changes on hos Slot vs default component is used in `Trigger` components
- Updated `DropdownMenu` stories to use `asChild`
- Updated `Box` stories to use `asChild`