### PR TITLE
chore: Remove text about `!important`

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -17,7 +17,7 @@
   }
 
   * {
-    font-feature-settings: 'cv05' 1 !important;
+    font-feature-settings: 'cv05' 1;
   }
   html {
     font-family: 'Inter', sans-serif;

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -19,6 +19,7 @@
   * {
     font-feature-settings: 'cv05' 1;
   }
+
   html {
     font-family: 'Inter', sans-serif;
   }

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -9,7 +9,7 @@
 
 <style>
   * {
-    font-feature-settings: 'cv05' 1 !important;
+    font-feature-settings: 'cv05' 1;
   }
   html {
     font-family: 'Inter', sans-serif;

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The components are designed and developed using the [Inter font](https://github.
 
 Add the `<link>` tag in `<head>`, and set `font-family` to `Inter` in your global css file.
 
-The `font-feature-settings` adds a tail to lowercase `L`'s and must be set with the `!important` flag.
+The `font-feature-settings` adds a tail to lowercase `L`'s.
 
 ##### HTML
 
@@ -89,7 +89,7 @@ The `font-feature-settings` adds a tail to lowercase `L`'s and must be set with 
 ```css
 body {
   font-family: 'Inter', sans-serif;
-  font-feature-settings: 'cv05' 1 !important; /* Enable lowercase l with tail */
+  font-feature-settings: 'cv05' 1; /* Enable lowercase l with tail */
 }
 ```
 

--- a/apps/storefront/globals.css
+++ b/apps/storefront/globals.css
@@ -22,7 +22,7 @@ body {
 
 * {
   box-sizing: border-box;
-  font-feature-settings: 'cv05' 1 !important;
+  font-feature-settings: 'cv05' 1;
 }
 
 h1,

--- a/apps/storefront/pages/grunnleggende/designelementer/typografi.mdx
+++ b/apps/storefront/pages/grunnleggende/designelementer/typografi.mdx
@@ -54,10 +54,8 @@ For å aktivere lowercase l with tail, legg til følgende i din CSS:
 
 <CodeSnippet language='css'>
   {`font-family: 'Inter', sans-serif;
-font-feature-settings: 'cv05' 1 !important; /* Enable lowercase l with tail */`}
+font-feature-settings: 'cv05' 1; /* Enable lowercase l with tail */`}
 </CodeSnippet>
-
-Bruk `!important` på `font-feature-settings` fordi våre typography tokens og komponenter bruker [font](https://developer.mozilla.org/en-US/docs/Web/CSS/font) shorthand som resetter dette til sin initielle verdi.
 
 ## Tekststørrelse
 

--- a/packages/get-started.mdx
+++ b/packages/get-started.mdx
@@ -46,7 +46,7 @@ Legg til `<link>` taggen i `<head>`, og sett `font-family` til `Inter` i din glo
 ```css
 body {
   font-family: 'Inter', sans-serif;
-  font-feature-settings: 'cv05' 1 !important; /* Enable lowercase l with tail */
+  font-feature-settings: 'cv05' 1; /* Enable lowercase l with tail */
 }
 ```
 


### PR DESCRIPTION
After we implemented cascade layers, we don't need to have `!important` on `font-feature-settings: 'cv05' 1;` anymore.
This removes this in our code, and our documentation