### PR TITLE
fix(Modal): fix close button position

### DIFF
--- a/packages/css/index.css
+++ b/packages/css/index.css
@@ -1,5 +1,7 @@
 @charset "UTF-8";
 
+@layer fds.utils, fds.btn;
+
 /** Import order defines ordinal specificity for layers */
 @import url('./react-css-modules.css');
 @import url('./button.css');

--- a/packages/css/react-css-modules.css
+++ b/packages/css/react-css-modules.css
@@ -2170,7 +2170,7 @@
     color: var(--fds-semantic-text-neutral-default);
   }
 
-  .fds-modalheader-modalHeader-47e4ee5b button {
+  .fds-modalheader-modalHeaderButton-47e4ee5b {
     position: absolute;
     top: var(--fds-spacing-3);
     right: var(--fds-spacing-3);

--- a/packages/react/src/components/Modal/ModalHeader/ModalHeader.module.css
+++ b/packages/react/src/components/Modal/ModalHeader/ModalHeader.module.css
@@ -11,7 +11,7 @@
     color: var(--fds-semantic-text-neutral-default);
   }
 
-  .modalHeader button {
+  .modalHeaderButton {
     position: absolute;
     top: var(--fds-spacing-3);
     right: var(--fds-spacing-3);

--- a/packages/react/src/components/Modal/ModalHeader/ModalHeader.tsx
+++ b/packages/react/src/components/Modal/ModalHeader/ModalHeader.tsx
@@ -66,6 +66,7 @@ export const ModalHeader = forwardRef<HTMLDivElement, ModalHeaderProps>(
             onClick={context?.closeModal}
             autoFocus
             icon={true}
+            className={classes.modalHeaderButton}
           >
             <XMarkIcon
               title='close modal'


### PR DESCRIPTION
Sorts `fds.utils` and `fds.btn` first, since we use these components in other components - and want them to have lower priority.

Should probably do this to our typography components as well, but leaving that for another PR.