### PR TITLE
feat(Paragraph): Remove deprecated `as` prop

### DIFF
--- a/packages/react/src/components/Chip/Removable/Removable.tsx
+++ b/packages/react/src/components/Chip/Removable/Removable.tsx
@@ -35,7 +35,7 @@ export const RemovableChip = forwardRef<HTMLButtonElement, RemovableChipProps>(
         <Paragraph
           asChild
           size={group?.size || size}
-          short
+          variant='short'
         >
           <span className={classes.label}>
             <span>{children}</span>

--- a/packages/react/src/components/Chip/Toggle/Toggle.tsx
+++ b/packages/react/src/components/Chip/Toggle/Toggle.tsx
@@ -55,7 +55,7 @@ export const ToggleChip = forwardRef<HTMLButtonElement, ToggleChipProps>(
         <Paragraph
           asChild
           size={group?.size || size}
-          short
+          variant='short'
         >
           <span className={classes.label}>
             {shouldDisplayCheckmark && (

--- a/packages/react/src/components/Typography/Paragraph/Paragraph.stories.tsx
+++ b/packages/react/src/components/Typography/Paragraph/Paragraph.stories.tsx
@@ -16,8 +16,6 @@ export const Preview: Story = {
     children:
       'Personvernerklæringen gir informasjon om hvilke personopplysninger vi behandler, hvordan disse blir behandlet og hvilke rettigheter du har.',
     spacing: false,
-    short: false,
-    long: false,
     size: 'medium',
   },
 };

--- a/packages/react/src/components/Typography/Paragraph/Paragraph.tsx
+++ b/packages/react/src/components/Typography/Paragraph/Paragraph.tsx
@@ -3,8 +3,6 @@ import { forwardRef } from 'react';
 import cl from 'clsx';
 import { Slot } from '@radix-ui/react-slot';
 
-import type { OverridableComponent } from '../../../types/OverridableComponent';
-
 import classes from './Paragraph.module.css';
 
 export type ParagraphProps = {
@@ -22,23 +20,9 @@ export type ParagraphProps = {
 } & HTMLAttributes<HTMLParagraphElement>;
 
 /** Use `Paragraph` to display text with paragraph text styles. */
-export const Paragraph: OverridableComponent<
-  ParagraphProps,
-  HTMLParagraphElement
-> = forwardRef(
-  (
-    {
-      className,
-      size = 'medium',
-      spacing,
-      as = 'p',
-      asChild,
-      variant,
-      ...rest
-    },
-    ref,
-  ) => {
-    const Component = asChild ? Slot : as;
+export const Paragraph = forwardRef<HTMLParagraphElement, ParagraphProps>(
+  ({ className, size = 'medium', spacing, asChild, variant, ...rest }, ref) => {
+    const Component = asChild ? Slot : 'p';
 
     return (
       <Component

--- a/packages/react/src/components/Typography/Typography.stories.tsx
+++ b/packages/react/src/components/Typography/Typography.stories.tsx
@@ -50,7 +50,7 @@ export const EksempelTekst: StoryFn = () => (
     </Heading>
 
     <Paragraph
-      short
+      variant='short'
       spacing
     >
       Når du skal signere meldingen vil du motta en signeringsoppgave i
@@ -83,7 +83,7 @@ export const EksempelTekst: StoryFn = () => (
     </Heading>
 
     <Paragraph
-      short
+      variant='short'
       spacing
     >
       Personvernerklæringen gir informasjon om hvilke personopplysninger vi

--- a/packages/react/src/components/form/Fieldset/Fieldset.tsx
+++ b/packages/react/src/components/form/Fieldset/Fieldset.tsx
@@ -90,8 +90,8 @@ export const Fieldset = forwardRef<HTMLFieldSetElement, FieldsetProps>(
           {description && (
             <Paragraph
               size={size}
+              variant='short'
               asChild
-              short
             >
               <div
                 id={descriptionId}

--- a/packages/react/src/components/form/Textfield/Textfield.tsx
+++ b/packages/react/src/components/form/Textfield/Textfield.tsx
@@ -146,7 +146,7 @@ export const Textfield = forwardRef<HTMLInputElement, TextfieldProps>(
               <Paragraph
                 asChild
                 size={size}
-                short
+                variant='short'
               >
                 <div
                   className={cl(classes.adornment, classes.prefix)}
@@ -179,7 +179,7 @@ export const Textfield = forwardRef<HTMLInputElement, TextfieldProps>(
               <Paragraph
                 asChild
                 size={size}
-                short
+                variant='short'
               >
                 <div
                   className={cl(classes.adornment, classes.suffix)}


### PR DESCRIPTION
Seems like the typechecking did not catch a few things when we removed `short`, so I fixed this as well.