### PR TITLE
chore(storefront): Fix smaller MDX styling issues

### DIFF
--- a/apps/storefront/components/Image/Image.module.css
+++ b/apps/storefront/components/Image/Image.module.css
@@ -1,6 +1,6 @@
 .container {
   display: flex;
-  max-width: 800px;
+  max-width: var(--media-max-width);
   margin: var(--fds-spacing-7) 0;
   border-radius: var(--fds-border_radius-medium);
   flex-wrap: wrap;

--- a/apps/storefront/components/MdxContent/MdxContent.module.css
+++ b/apps/storefront/components/MdxContent/MdxContent.module.css
@@ -156,7 +156,9 @@
   font-weight: 600;
 }
 
-.content p code {
+.content p code,
+.content ul code,
+.content ol code {
   padding: 0.2em 0.5em;
   margin: 1px;
   font-size: 0.9em;

--- a/apps/storefront/components/MdxContent/MdxContent.module.css
+++ b/apps/storefront/components/MdxContent/MdxContent.module.css
@@ -5,7 +5,9 @@
 .content > p,
 .content > h2,
 .content > h3,
-.content > h4 {
+.content > h4,
+.content > ul,
+.content > ol {
   max-width: 740px;
 }
 

--- a/apps/storefront/components/ResponsiveIframe/ResponsiveIframe.module.css
+++ b/apps/storefront/components/ResponsiveIframe/ResponsiveIframe.module.css
@@ -2,6 +2,7 @@
   position: relative;
   overflow: hidden;
   width: 100%;
+  max-width: var(--media-max-width);
   padding-top: 56.25%;
   box-shadow: var(--fds-shadow-medium);
   border-radius: 4px;

--- a/apps/storefront/globals.css
+++ b/apps/storefront/globals.css
@@ -13,6 +13,7 @@
   --grid-gap: var(--fds-spacing-8);
   --page-spacing-top: var(--fds-spacing-14);
   --page-spacing-bottom: var(--fds-spacing-14);
+  --media-max-width: 800px;
 }
 
 body {

--- a/apps/storefront/pages/grunnleggende/for-designere/kom-i-gang.mdx
+++ b/apps/storefront/pages/grunnleggende/for-designere/kom-i-gang.mdx
@@ -31,7 +31,7 @@ Jobber du i Digdir trenger du ikke laste ned noe, da filene ligger i organisasjo
 
 Etter at du har åpnet dem må du
 
-- Plassere `filene` der du vil ha dem i din egen Figma-organisasjon
+- Plassere filene der du vil ha dem i din egen Figma-organisasjon
 - Publisere filene
 - Aktivere de to fellesbibliotekene i filene du jobber i
 

--- a/apps/storefront/pages/grunnleggende/for-designere/kom-i-gang.mdx
+++ b/apps/storefront/pages/grunnleggende/for-designere/kom-i-gang.mdx
@@ -31,7 +31,7 @@ Jobber du i Digdir trenger du ikke laste ned noe, da filene ligger i organisasjo
 
 Etter at du har åpnet dem må du
 
-- Plassere filene der du vil ha dem i din egen Figma-organisasjon
+- Plassere `filene` der du vil ha dem i din egen Figma-organisasjon
 - Publisere filene
 - Aktivere de to fellesbibliotekene i filene du jobber i
 


### PR DESCRIPTION
resolves #1912 
resolves #1911 
resolves #1921

**Width of videos:** Added a CSS variable to set max-width on media elements. Added this to the `ResponsiveIframe` component that is used to show videos. /grunnleggende/for-designere/kom-i-gang has a video

**Lists wider than paragraph:** Added `ul` and `ol` tags to the same width as paragraphs.

**Code inside lists:** Added styling of the `code` tag to `ul` and `ol` lists.
