### PR TITLE
refactor: :building_construction: Use defined viewports in Storybook

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -12,29 +12,14 @@ import {
   Table,
 } from '@digdir/designsystemet-react';
 import customTheme from './customTheme';
-import metadata from '../design-tokens/$metadata.json';
 
-type Viewport = {
-  name: string;
+const viewports = [320, 375, 576, 768, 992, 1200, 1440].map((width) => ({
+  name: `${width}px`,
   styles: {
-    width: string;
-    height: string;
-  };
-};
-
-const viewports: Viewport[] = metadata.tokenSetOrder
-  .filter((name) => name.toLowerCase().includes('viewport'))
-  .map((name) => {
-    const width = name.replace(/\D/g, '');
-
-    return {
-      name: `@${width}`,
-      styles: {
-        width: `${width}px`,
-        height: '100%',
-      },
-    };
-  });
+    width: `${width}px`,
+    height: '100%',
+  },
+}));
 
 type Props = Record<string, unknown>;
 


### PR DESCRIPTION
Removed reliance on viewports design tokens as these are planned to be removed in #1849