### PR TITLE
feat(Button): add shorthand sizes

### DIFF
--- a/packages/css/button.css
+++ b/packages/css/button.css
@@ -30,7 +30,7 @@
     opacity: var(--fds-opacity-disabled);
   }
 
-  .fds-btn--small {
+  .fds-btn--sm {
     --fds-btn-padding: var(--fds-spacing-2) var(--fds-spacing-3);
 
     gap: var(--fds-sizing-1);
@@ -39,7 +39,7 @@
     min-height: var(--fds-sizing-10);
   }
 
-  .fds-btn--small::before {
+  .fds-btn--sm::before {
     position: absolute;
     top: 0;
     left: 0;
@@ -48,7 +48,7 @@
     content: '';
   }
 
-  .fds-btn--small::after {
+  .fds-btn--sm::after {
     position: absolute;
     top: -5px;
     left: 0;
@@ -57,7 +57,7 @@
     content: '';
   }
 
-  .fds-btn--medium {
+  .fds-btn--md {
     --fds-btn-padding: var(--fds-spacing-2) var(--fds-spacing-4);
 
     gap: var(--fds-sizing-2);
@@ -66,7 +66,7 @@
     min-height: var(--fds-sizing-12);
   }
 
-  .fds-btn--large {
+  .fds-btn--lg {
     --fds-btn-padding: var(--fds-spacing-3) var(--fds-spacing-5);
 
     gap: var(--fds-sizing-2);

--- a/packages/react/src/components/Button/Button.mdx
+++ b/packages/react/src/components/Button/Button.mdx
@@ -115,9 +115,9 @@ Når du bruker ikon må du sette størrelsen på ikonet selv. Vi anbefaler å br
 
 | Størrelse på Button | Aksel Ikon `fontSize` |
 | :------------------ | :-------------------- |
-| small               | 1rem                  |
-| medium              | 1.5rem                |
-| large               | 2rem                  |
+| sm                  | 1rem                  |
+| md                  | 1.5rem                |
+| lg                  | 2rem                  |
 
 <Canvas of={ButtonStories.Ikoner} />
 
@@ -137,7 +137,7 @@ Når vi skal vise brukeren at knappen laster noe, kan vi kombinere knappen med e
 
 I eksempelet over har vi brukt `aria-disabled` til å deaktivere knappene. Dette er den anbefalte måten for å vise at en knapp er deaktivert. Da kan den fortsatt få fokus når noen navigerer med tastaturet. Slik vil blant annet skjermlesere og andre hjelpemidler bli informert om at knappen finnes, men ikke er aktiv.
 
-Denne egenskapen stopper ikke automatisk knappen fra å utløse `onCLick`.
+Denne egenskapen stopper ikke automatisk knappen fra å utløse `onClick`.
 
 Pass på at callback-funksjonen ikke kjører når knappen er deaktivert.
 

--- a/packages/react/src/components/Button/Button.stories.tsx
+++ b/packages/react/src/components/Button/Button.stories.tsx
@@ -370,21 +370,21 @@ export const Ikoner: StoryFn<typeof Button> = () => (
   <>
     <Button
       variant='primary'
-      size='small'
+      size='sm'
     >
       <CogIcon fontSize='1rem' />
       small
     </Button>
     <Button
       variant='primary'
-      size='medium'
+      size='md'
     >
       <CogIcon fontSize='1.5rem' />
       medium
     </Button>
     <Button
       variant='primary'
-      size='large'
+      size='lg'
     >
       <CogIcon fontSize='2rem' />
       large

--- a/packages/react/src/components/Button/Button.stories.tsx
+++ b/packages/react/src/components/Button/Button.stories.tsx
@@ -43,7 +43,7 @@ export const Preview: Story = {
     disabled: false,
     variant: 'primary',
     color: 'first',
-    size: 'medium',
+    size: 'md',
     icon: false,
     fullWidth: false,
   },

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -3,13 +3,22 @@ import type { ButtonHTMLAttributes } from 'react';
 import cl from 'clsx/lite';
 import { Slot } from '@radix-ui/react-slot';
 
+import { getSize } from '../../utilities/getSize';
+
+type OldButtonSize = 'small' | 'medium' | 'large';
+
 export type ButtonProps = {
   /** Specify which variant to use */
   variant?: 'primary' | 'secondary' | 'tertiary';
   /** Specify which color palette to use */
   color?: 'first' | 'second' | 'success' | 'danger';
-  /** Size */
-  size?: 'small' | 'medium' | 'large';
+  /**
+   * Size
+   * @default md
+   *
+   * @note Use `sm`, `md`, `lg` instead of `small`, `medium`, `large`, as the latter will be deprecated
+   */
+  size?: 'sm' | 'md' | 'lg' | OldButtonSize;
   /** If `Button` should fill full width of its container */
   fullWidth?: boolean;
   /** Toggle icon only styling, pass icon as children
@@ -32,7 +41,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       children,
       color = 'first',
       variant = 'primary',
-      size = 'medium',
       fullWidth = false,
       icon = false,
       type = 'button',
@@ -42,6 +50,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     },
     ref,
   ) => {
+    const size = getSize(rest.size || 'md');
     const Component = asChild ? Slot : 'button';
 
     return (

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -14,7 +14,7 @@ export type ButtonProps = {
   color?: 'first' | 'second' | 'success' | 'danger';
   /**
    * Size
-   * @default md
+   * @default `md`
    * @note `small`, `medium`, `large` is deprecated
    */
   size?: 'sm' | 'md' | 'lg' | OldButtonSizes;

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -5,7 +5,7 @@ import { Slot } from '@radix-ui/react-slot';
 
 import { getSize } from '../../utilities/getSize';
 
-type OldButtonSize = 'small' | 'medium' | 'large';
+type OldButtonSizes = 'small' | 'medium' | 'large';
 
 export type ButtonProps = {
   /** Specify which variant to use */
@@ -15,9 +15,9 @@ export type ButtonProps = {
   /**
    * Size
    * @default md
-   * @note Use `sm`, `md`, `lg` instead of `small`, `medium`, `large`, as the latter will be deprecated
+   * @note `small`, `medium`, `large` is deprecated
    */
-  size?: 'sm' | 'md' | 'lg' | OldButtonSize;
+  size?: 'sm' | 'md' | 'lg' | OldButtonSizes;
   /** If `Button` should fill full width of its container */
   fullWidth?: boolean;
   /** Toggle icon only styling, pass icon as children

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -15,7 +15,6 @@ export type ButtonProps = {
   /**
    * Size
    * @default md
-   *
    * @note Use `sm`, `md`, `lg` instead of `small`, `medium`, `large`, as the latter will be deprecated
    */
   size?: 'sm' | 'md' | 'lg' | OldButtonSize;

--- a/packages/react/src/utilities/getSize.ts
+++ b/packages/react/src/utilities/getSize.ts
@@ -1,0 +1,26 @@
+export function getSize(size: string) {
+  switch (size) {
+    case 'xxxsmall':
+      return '3xs';
+    case 'xxsmall':
+      return '2xs';
+    case 'xsmall':
+      return 'xs';
+    case 'small':
+      return 'sm';
+    case 'medium':
+      return 'md';
+    case 'large':
+      return 'lg';
+    case 'xlarge':
+      return 'xl';
+    case 'xxlarge':
+      return '2xl';
+    case 'xxxlarge':
+      return '3xl';
+    case 'xxxxlarge':
+      return '4xl';
+    default:
+      return size;
+  }
+}

--- a/packages/react/stories/testing.stories.tsx
+++ b/packages/react/stories/testing.stories.tsx
@@ -10,7 +10,6 @@ import {
   Tag,
   Combobox,
   Chip,
-  type ButtonProps,
 } from '../src/components';
 
 export default {
@@ -18,7 +17,7 @@ export default {
 } as Meta;
 
 export const MediumRow: StoryFn<{
-  size: ButtonProps['size'];
+  size: 'small' | 'medium' | 'large';
   direction: 'column' | 'row';
 }> = ({ size, direction = 'row' }) => {
   return (


### PR DESCRIPTION
#1981

Added an internal utility function to give us the new size names, if a user passes an old one.
Had to change the type for the testing page.
