### PR TITLE
feat(switch): Accessibility update

### DIFF
--- a/packages/react/src/components/form/Switch/Switch.tsx
+++ b/packages/react/src/components/form/Switch/Switch.tsx
@@ -54,6 +54,8 @@ export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
           <input
             className={`fds-switch__input`}
             ref={ref}
+            role="switch"
+            aria-checked={inputProps.checked}
             {...omit(['size', 'error'], rest)}
             {...inputProps}
           />


### PR DESCRIPTION
Fix for #2057

Tested with NVDA for readout for screen readers. 

Before code changes: "clickable  (label text) check box  not checked"

After code changes: "clickable (label text) switch  off"

For a standard switch this would be an improvement. (Not part of a form submission. A toggle switch on a website)

For the design system usecase: "A choice between two options" and being a part of forms I think the checkbox (eg code before this pull request) conveys how to use the component to screen readers. 