### PR TITLE
fix(Heading): :coffin: Remove non-working `3xlarge`/`3xl` size

### DIFF
--- a/packages/css/heading.css
+++ b/packages/css/heading.css
@@ -10,13 +10,6 @@
     margin-bottom: var(--fdsc-bottom-spacing);
   }
 
-  .fds-heading--3xl {
-    --fdsc-bottom-spacing: var(--fds-spacing-8);
-
-    font: var(--fds-typography-heading-3xlarge);
-    font-family: inherit;
-  }
-
   .fds-heading--2xl {
     --fdsc-bottom-spacing: var(--fds-spacing-7);
 

--- a/packages/react/src/components/Typography/Heading/Heading.tsx
+++ b/packages/react/src/components/Typography/Heading/Heading.tsx
@@ -12,8 +12,7 @@ type OldHeadingSizes =
   | 'medium'
   | 'large'
   | 'xlarge'
-  | '2xlarge'
-  | '3xlarge';
+  | '2xlarge';
 
 export type HeadingProps = {
   /** Heading level. This will translate into any h1-6 level unless `as` is defined */
@@ -23,16 +22,7 @@ export type HeadingProps = {
    *
    * @note `xxsmall`, `xsmall`, `small`, `medium`, `large`, `xlarge`, `2xlarge`, `3xlarge` is deprecated
    */
-  size?:
-    | '2xs'
-    | 'xs'
-    | 'sm'
-    | 'md'
-    | 'lg'
-    | 'xl'
-    | '2xl'
-    | '3xl'
-    | OldHeadingSizes;
+  size?: '2xs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | OldHeadingSizes;
   /** Adds margin-bottom */
   spacing?: boolean;
   /**

--- a/packages/react/src/utilities/getSize.ts
+++ b/packages/react/src/utilities/getSize.ts
@@ -15,8 +15,10 @@ export function getSize(size: string) {
     case 'xlarge':
       return 'xl';
     case 'xxlarge':
+    case '2xlarge':
       return '2xl';
     case 'xxxlarge':
+    case '3xlarge':
       return '3xl';
     case 'xxxxlarge':
       return '4xl';


### PR DESCRIPTION
Remove non working size `3xl` (previously `xxxlarge`). This was removed when we converted to static font scales so its not working today at all since token does not exits anymore