### PR TITLE
feat: :heavy_minus_sign: Remove re-export of `@digdir/designsystemet-react` components

### DIFF
--- a/packages/react-old/package.json
+++ b/packages/react-old/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "@altinn/figma-design-tokens": "^6.0.1",
-    "@digdir/designsystemet-react": "workspace:^",
     "@floating-ui/react": "0.26.4",
     "@navikt/aksel-icons": "^5.12.2",
     "react-number-format": "5.3.1"

--- a/packages/react-old/package.json
+++ b/packages/react-old/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@altinn/figma-design-tokens": "^6.0.1",
     "@floating-ui/react": "0.26.4",
+    "@digdir/designsystemet-theme": "0.15.3",
     "@navikt/aksel-icons": "^5.12.2",
     "react-number-format": "5.3.1"
   },

--- a/packages/react-old/package.json
+++ b/packages/react-old/package.json
@@ -28,8 +28,8 @@
   },
   "dependencies": {
     "@altinn/figma-design-tokens": "^6.0.1",
-    "@floating-ui/react": "0.26.4",
     "@digdir/designsystemet-theme": "0.15.3",
+    "@floating-ui/react": "0.26.4",
     "@navikt/aksel-icons": "^5.12.2",
     "react-number-format": "5.3.1"
   },

--- a/packages/react-old/src/index.ts
+++ b/packages/react-old/src/index.ts
@@ -1,3 +1,2 @@
 export * from './components';
 export { formatNumericText } from './utilities';
-export * from '@digdir/designsystemet-react';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1896,6 +1896,7 @@ __metadata:
   resolution: "@digdir/design-system-react@workspace:packages/react-old"
   dependencies:
     "@altinn/figma-design-tokens": "npm:^6.0.1"
+    "@digdir/designsystemet-theme": "npm:0.15.3"
     "@floating-ui/react": "npm:0.26.4"
     "@navikt/aksel-icons": "npm:^5.12.2"
     "@types/fs-extra": "npm:^11.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1896,7 +1896,6 @@ __metadata:
   resolution: "@digdir/design-system-react@workspace:packages/react-old"
   dependencies:
     "@altinn/figma-design-tokens": "npm:^6.0.1"
-    "@digdir/designsystemet-react": "workspace:^"
     "@floating-ui/react": "npm:0.26.4"
     "@navikt/aksel-icons": "npm:^5.12.2"
     "@types/fs-extra": "npm:^11.0.4"
@@ -1994,7 +1993,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@digdir/designsystemet-react@workspace:^, @digdir/designsystemet-react@workspace:packages/react":
+"@digdir/designsystemet-react@workspace:packages/react":
   version: 0.0.0-use.local
   resolution: "@digdir/designsystemet-react@workspace:packages/react"
   dependencies:


### PR DESCRIPTION
BREAKING CHANGE: Removes re-export of components from `@digdir/designsystemet-react`