### PR TITLE
feat(Accordion): open when using search-in-page

### DIFF
--- a/packages/css/accordion.css
+++ b/packages/css/accordion.css
@@ -23,13 +23,23 @@
 }
 
 .ds-accordion__content {
-  padding: var(--ds-spacing-5, 1rem);
+  padding-top: var(--ds-spacing-5, 1rem);
+  padding-bottom: var(--ds-spacing-5, 1rem);
+  padding-left: var(--ds-spacing-5, 1rem);
+  padding-right: var(--ds-spacing-5, 1rem);
   overflow: hidden;
   text-overflow: ellipsis;
+  transition-property: height, padding-top, padding-bottom;
+  transition-timing-function: ease;
+  transition-duration: 0.3s;
 }
 
 .ds-accordion__content--closed {
-  padding: 0;
+  padding-left: 0;
+  padding-right: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  height: 0;
 }
 
 .ds-accordion__header {

--- a/packages/css/accordion.css
+++ b/packages/css/accordion.css
@@ -28,7 +28,7 @@
   text-overflow: ellipsis;
 }
 
-.ds-accordion__content--closed {
+.ds-accordion__content[hidden] {
   padding: 0;
 }
 

--- a/packages/css/accordion.css
+++ b/packages/css/accordion.css
@@ -23,23 +23,13 @@
 }
 
 .ds-accordion__content {
-  padding-top: var(--ds-spacing-5, 1rem);
-  padding-bottom: var(--ds-spacing-5, 1rem);
-  padding-left: var(--ds-spacing-5, 1rem);
-  padding-right: var(--ds-spacing-5, 1rem);
+  padding: var(--ds-spacing-5, 1rem);
   overflow: hidden;
   text-overflow: ellipsis;
-  transition-property: height, padding-top, padding-bottom;
-  transition-timing-function: ease;
-  transition-duration: 0.3s;
 }
 
 .ds-accordion__content--closed {
-  padding-left: 0;
-  padding-right: 0;
-  padding-top: 0;
-  padding-bottom: 0;
-  height: 0;
+  padding: 0;
 }
 
 .ds-accordion__header {

--- a/packages/css/accordion.css
+++ b/packages/css/accordion.css
@@ -28,6 +28,10 @@
   text-overflow: ellipsis;
 }
 
+.ds-accordion__content--closed {
+  padding: 0;
+}
+
 .ds-accordion__header {
   margin: 0;
   width: 100%;

--- a/packages/css/utilities.css
+++ b/packages/css/utilities.css
@@ -34,5 +34,4 @@
 
 .ds-animate-height--closed .ds-animate-height__content {
   height: 0;
-  display: none;
 }

--- a/packages/react/src/components/Accordion/AccordionContent.tsx
+++ b/packages/react/src/components/Accordion/AccordionContent.tsx
@@ -1,6 +1,6 @@
 import cl from 'clsx/lite';
 import type { HTMLAttributes } from 'react';
-import { forwardRef, useContext, useEffect, useRef } from 'react';
+import { forwardRef, useContext, useEffect, useRef, useState } from 'react';
 import { useMergeRefs } from '@floating-ui/react';
 
 import { Paragraph } from '..';
@@ -19,10 +19,14 @@ export const AccordionContent = forwardRef<
   HTMLDivElement,
   AccordionContentProps
 >(({ children, className, ...rest }, ref) => {
+  const [hasOpenedOnce, setHasOpenedOnce] = useState(false);
   const context = useContext(AccordionItemContext);
   const contentRef = useRef<HTMLDivElement>(null);
   const mergedRefs = useMergeRefs([ref, contentRef]);
 
+  // Passing `string` to `hidden` in JSX is not currently supported
+  // https://github.com/facebook/react/issues/24740
+  // The `onbeforematch` event is not supported in JSX either
   useEffect(() => {
     const node = contentRef.current;
 
@@ -40,6 +44,14 @@ export const AccordionContent = forwardRef<
       node?.removeEventListener('beforematch', eventHander);
     };
   }, [context]);
+
+  /* Needed for browsers that does not support "beforematch" */
+  if (!('onbeforematch' in document.body) && !hasOpenedOnce) {
+    // expand all hidden content
+    contentRef.current?.removeAttribute('hidden');
+    context?.toggleOpen();
+    setHasOpenedOnce(true);
+  }
 
   if (context === null) {
     console.error(

--- a/packages/react/src/components/Accordion/AccordionContent.tsx
+++ b/packages/react/src/components/Accordion/AccordionContent.tsx
@@ -40,7 +40,7 @@ export const AccordionContent = forwardRef<
     return () => {
       node?.removeEventListener('beforematch', eventHander);
     };
-  });
+  }, [context]);
 
   if (context === null) {
     console.error(

--- a/packages/react/src/components/Accordion/AccordionContent.tsx
+++ b/packages/react/src/components/Accordion/AccordionContent.tsx
@@ -24,6 +24,10 @@ export const AccordionContent = forwardRef<
 
   useEffect(() => {
     const node = contentRef.current;
+    const eventHander = () => {
+      context?.toggleOpen();
+    };
+
     if (!node) return;
     if (!context?.open) {
       node?.setAttribute('hidden', 'until-found');
@@ -31,10 +35,11 @@ export const AccordionContent = forwardRef<
       node?.removeAttribute('hidden');
     }
 
-    node?.addEventListener('beforematch', () => {
-      console.log('i have been found');
-      context?.toggleOpen();
-    });
+    node?.addEventListener('beforematch', eventHander);
+
+    return () => {
+      node?.removeEventListener('beforematch', eventHander);
+    };
   });
 
   if (context === null) {

--- a/packages/react/src/components/Accordion/AccordionContent.tsx
+++ b/packages/react/src/components/Accordion/AccordionContent.tsx
@@ -4,6 +4,7 @@ import { forwardRef, useContext, useEffect, useRef } from 'react';
 import { useMergeRefs } from '@floating-ui/react';
 
 import { Paragraph } from '..';
+import { AnimateHeight } from '../../utilities/AnimateHeight';
 
 import { AccordionItemContext } from './AccordionItem';
 
@@ -50,7 +51,10 @@ export const AccordionContent = forwardRef<
   }
 
   return (
-    <>
+    <AnimateHeight
+      id={context.contentId}
+      open={context.open}
+    >
       <Paragraph
         asChild
         size='sm'
@@ -67,7 +71,7 @@ export const AccordionContent = forwardRef<
           {children}
         </div>
       </Paragraph>
-    </>
+    </AnimateHeight>
   );
 });
 

--- a/packages/react/src/components/Accordion/AccordionContent.tsx
+++ b/packages/react/src/components/Accordion/AccordionContent.tsx
@@ -64,7 +64,7 @@ export const AccordionContent = forwardRef<
     <AnimateHeight
       id={context.contentId}
       open={context.open}
-      animationFinished={(state) => {
+      onAnimationFinished={(state) => {
         state === 'closed' &&
           contentRef.current?.setAttribute('hidden', 'until-found');
       }}

--- a/packages/react/src/components/Accordion/AccordionContent.tsx
+++ b/packages/react/src/components/Accordion/AccordionContent.tsx
@@ -1,8 +1,8 @@
 import cl from 'clsx/lite';
 import type { HTMLAttributes } from 'react';
-import { forwardRef, useContext } from 'react';
+import { forwardRef, useContext, useEffect, useRef } from 'react';
+import { useMergeRefs } from '@floating-ui/react';
 
-import { AnimateHeight } from '../../utilities/AnimateHeight';
 import { Paragraph } from '..';
 
 import { AccordionItemContext } from './AccordionItem';
@@ -19,6 +19,23 @@ export const AccordionContent = forwardRef<
   AccordionContentProps
 >(({ children, className, ...rest }, ref) => {
   const context = useContext(AccordionItemContext);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const mergedRefs = useMergeRefs([ref, contentRef]);
+
+  useEffect(() => {
+    const node = contentRef.current;
+    if (!node) return;
+    if (!context?.open) {
+      node?.setAttribute('hidden', 'until-found');
+    } else {
+      node?.removeAttribute('hidden');
+    }
+
+    node?.addEventListener('beforematch', () => {
+      console.log('i have been found');
+      context?.toggleOpen();
+    });
+  });
 
   if (context === null) {
     console.error(
@@ -28,23 +45,24 @@ export const AccordionContent = forwardRef<
   }
 
   return (
-    <AnimateHeight
-      id={context.contentId}
-      open={context.open}
-    >
+    <>
       <Paragraph
         asChild
         size='sm'
       >
         <div
-          ref={ref}
-          className={cl('ds-accordion__content', className)}
+          ref={mergedRefs}
+          className={cl(
+            'ds-accordion__content',
+            !context.open && 'ds-accordion__content--closed',
+            className,
+          )}
           {...rest}
         >
           {children}
         </div>
       </Paragraph>
-    </AnimateHeight>
+    </>
   );
 });
 

--- a/packages/react/src/components/Accordion/AccordionContent.tsx
+++ b/packages/react/src/components/Accordion/AccordionContent.tsx
@@ -25,16 +25,14 @@ export const AccordionContent = forwardRef<
 
   useEffect(() => {
     const node = contentRef.current;
+
+    if (!node) return;
+
     const eventHander = () => {
       context?.toggleOpen();
     };
 
-    if (!node) return;
-    if (!context?.open) {
-      node?.setAttribute('hidden', 'until-found');
-    } else {
-      node?.removeAttribute('hidden');
-    }
+    if (context?.open) node?.removeAttribute('hidden');
 
     node?.addEventListener('beforematch', eventHander);
 
@@ -54,6 +52,10 @@ export const AccordionContent = forwardRef<
     <AnimateHeight
       id={context.contentId}
       open={context.open}
+      animationFinished={(state) => {
+        state === 'closed' &&
+          contentRef.current?.setAttribute('hidden', 'until-found');
+      }}
     >
       <Paragraph
         asChild
@@ -61,11 +63,7 @@ export const AccordionContent = forwardRef<
       >
         <div
           ref={mergedRefs}
-          className={cl(
-            'ds-accordion__content',
-            !context.open && 'ds-accordion__content--closed',
-            className,
-          )}
+          className={cl('ds-accordion__content', className)}
           {...rest}
         >
           {children}

--- a/packages/react/src/utilities/AnimateHeight/AnimateHeight.tsx
+++ b/packages/react/src/utilities/AnimateHeight/AnimateHeight.tsx
@@ -6,7 +6,7 @@ import { useMediaQuery, usePrevious } from '../../utilities';
 
 export type AnimateHeightProps = {
   open: boolean;
-  animationFinished?: (state: 'open' | 'closed') => void;
+  onAnimationFinished?: (state: 'open' | 'closed') => void;
 } & React.HTMLAttributes<HTMLDivElement>;
 
 type InternalState = 'open' | 'closed' | 'openingOrClosing';
@@ -20,7 +20,7 @@ export const AnimateHeight = ({
   children,
   className,
   open = false,
-  animationFinished,
+  onAnimationFinished,
   style,
   ...rest
 }: AnimateHeightProps) => {
@@ -45,11 +45,11 @@ export const AnimateHeight = ({
         timeoutRef.current && clearTimeout(timeoutRef.current); // Reset timeout if already active (i.e. if the user closes the component before it finishes opening)
         timeoutRef.current = setTimeout(() => {
           setState(openOrClosed);
-          animationFinished && animationFinished(openOrClosed);
+          onAnimationFinished && onAnimationFinished(openOrClosed);
         }, transitionDurationInMilliseconds);
       }
     },
-    [animationFinished, open, openOrClosed, prevOpen, shouldAnimate],
+    [onAnimationFinished, open, openOrClosed, prevOpen, shouldAnimate],
   );
 
   const transition =

--- a/packages/react/src/utilities/AnimateHeight/AnimateHeight.tsx
+++ b/packages/react/src/utilities/AnimateHeight/AnimateHeight.tsx
@@ -6,6 +6,7 @@ import { useMediaQuery, usePrevious } from '../../utilities';
 
 export type AnimateHeightProps = {
   open: boolean;
+  animationFinished?: (state: 'open' | 'closed') => void;
 } & React.HTMLAttributes<HTMLDivElement>;
 
 type InternalState = 'open' | 'closed' | 'openingOrClosing';
@@ -19,6 +20,7 @@ export const AnimateHeight = ({
   children,
   className,
   open = false,
+  animationFinished,
   style,
   ...rest
 }: AnimateHeightProps) => {
@@ -43,10 +45,11 @@ export const AnimateHeight = ({
         timeoutRef.current && clearTimeout(timeoutRef.current); // Reset timeout if already active (i.e. if the user closes the component before it finishes opening)
         timeoutRef.current = setTimeout(() => {
           setState(openOrClosed);
+          animationFinished && animationFinished(openOrClosed);
         }, transitionDurationInMilliseconds);
       }
     },
-    [open, openOrClosed, prevOpen, shouldAnimate],
+    [animationFinished, open, openOrClosed, prevOpen, shouldAnimate],
   );
 
   const transition =


### PR DESCRIPTION
POC for opening `Accordion` when the user uses search-in-page.

Uses `hidden="until-found"`, which is not yet supported in Firefox. 
If you are in a browser that does not support the `beforematch` event, it starts opened.

Edits how `AnimateHeight` works.

References:
https://developer.chrome.com/docs/css-ui/hidden-until-found
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden#the_hidden_until_found_state