### PR TITLE
feat(Combobox): :sparkles: Label now supports other elements

### DIFF
--- a/.changeset/short-walls-judge.md
+++ b/.changeset/short-walls-judge.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+feat(Combobox): :sparkles: Label now supports other elements

--- a/packages/react/src/components/form/Combobox/Combobox.test.tsx
+++ b/packages/react/src/components/form/Combobox/Combobox.test.tsx
@@ -347,4 +347,20 @@ describe('Combobox', () => {
 
     expect(combobox).toHaveAttribute('aria-busy', 'true');
   });
+
+  it('should have correct label when used as ReactNode', async () => {
+    await render({
+      label: (
+        <>
+          <strong>
+            <abbr>CSS</abbr>
+          </strong>
+          (Cascading Style Sheets)
+        </>
+      ),
+    });
+    const combobox = screen.getByRole('combobox');
+
+    expect(combobox).toHaveAccessibleName('CSS (Cascading Style Sheets)');
+  });
 });

--- a/packages/react/src/components/form/Combobox/Combobox.tsx
+++ b/packages/react/src/components/form/Combobox/Combobox.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useId, forwardRef } from 'react';
-import type * as React from 'react';
+import type { ReactNode, InputHTMLAttributes } from 'react';
 import { FloatingFocusManager, FloatingPortal } from '@floating-ui/react';
 import cl from 'clsx/lite';
 import { useVirtualizer } from '@tanstack/react-virtual';
@@ -25,9 +25,11 @@ import { ComboboxContext } from './ComboboxContext';
 
 export type ComboboxProps = {
   /**
-   * Label for the combobox
+   * Label for the combobox.
+   *
+   * Passed label will be encapsulated by a `label` element.
    */
-  label?: string;
+  label?: ReactNode;
   /**
    * Visually hides `label` and `description` (still available for screen readers)
    * @default false
@@ -114,7 +116,7 @@ export type ComboboxProps = {
   chipSrLabel?: (option: Option) => string;
 } & PortalProps &
   FormFieldProps &
-  Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'>;
+  Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>;
 
 export const ComboboxComponent = forwardRef<HTMLInputElement, ComboboxProps>(
   (


### PR DESCRIPTION
resolves #2179 

`label` type changed to `ReactNode`