### PR TITLE
chore(Button): text-align: inherit when not in full width

### DIFF
--- a/.changeset/hip-masks-greet.md
+++ b/.changeset/hip-masks-greet.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+Button: `text-align: inherit` when not in full width

--- a/packages/css/button.css
+++ b/packages/css/button.css
@@ -27,7 +27,7 @@
   cursor: pointer;
   font-family: inherit;
   justify-content: center;
-  text-align: center;
+  text-align: inherit;
   text-decoration: none;
   position: relative;
   border-radius: var(--ds-border-radius-md);
@@ -85,6 +85,7 @@
 
 .ds-btn--full-width {
   width: 100%;
+  text-align: center;
 }
 
 .ds-btn--secondary,


### PR DESCRIPTION
After discussion in daily we will make button have `text-align: inherit` when not in full width.
This is to make line breaks within the button look nicer for the user