### PR TITLE
chore(Tabs): set ambiguous orientation

### DIFF
--- a/.changeset/eighty-cougars-think.md
+++ b/.changeset/eighty-cougars-think.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+Tabs: Make arrow keys work in any direction

--- a/packages/react/src/components/Tabs/TabList.tsx
+++ b/packages/react/src/components/Tabs/TabList.tsx
@@ -27,6 +27,7 @@ export const TabList = forwardRef<
       role='tablist'
       activeValue={value}
       className={cl('ds-tabs__tablist', className)}
+      orientation='ambiguous'
       ref={ref}
       {...rest}
     >


### PR DESCRIPTION
 makes arrow keys work in any direction, always.