### PR TITLE
fix(AccordionHeading): correct exports and docs

### DIFF
--- a/.changeset/plenty-vans-sneeze.md
+++ b/.changeset/plenty-vans-sneeze.md
@@ -1,0 +1,6 @@
+---
+"@digdir/designsystemet-css": patch
+"@digdir/designsystemet-react": patch
+---
+
+AccordionHeading: Correct name on types

--- a/packages/css/accordion.css
+++ b/packages/css/accordion.css
@@ -28,7 +28,7 @@
   text-overflow: ellipsis;
 }
 
-.ds-accordion__header {
+.ds-accordion__heading {
   margin: 0;
   width: 100%;
   display: flex;
@@ -55,7 +55,7 @@
   font-family: inherit;
 }
 
-.ds-accordion__item--open .ds-accordion__header {
+.ds-accordion__item--open .ds-accordion__heading {
   background-color: var(--dsc-accordion-button-background-open);
 }
 
@@ -67,30 +67,30 @@
   transform: rotateZ(180deg);
 }
 
-.ds-accordion__item:not(:first-child) .ds-accordion__header {
+.ds-accordion__item:not(:first-child) .ds-accordion__heading {
   border-top: 1px solid var(--dsc-accordion-border-color);
 }
 
-.ds-accordion--border .ds-accordion__item:first-child .ds-accordion__header {
+.ds-accordion--border .ds-accordion__item:first-child .ds-accordion__heading {
   border-top: 0;
 }
 
-.ds-accordion--border .ds-accordion__item:first-of-type .ds-accordion__header:first-of-type {
+.ds-accordion--border .ds-accordion__item:first-of-type .ds-accordion__heading:first-of-type {
   border-top-left-radius: var(--dsc-accordion-border-radius);
   border-top-right-radius: var(--dsc-accordion-border-radius);
 }
 
-.ds-accordion--border .ds-accordion__item:last-of-type:not(.ds-accordion__item--open) .ds-accordion__header:first-of-type {
+.ds-accordion--border .ds-accordion__item:last-of-type:not(.ds-accordion__item--open) .ds-accordion__heading:first-of-type {
   border-bottom-left-radius: var(--dsc-accordion-border-radius);
   border-bottom-right-radius: var(--dsc-accordion-border-radius);
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .ds-accordion__header:hover .ds-accordion__expand-icon {
+  .ds-accordion__heading:hover .ds-accordion__expand-icon {
     background-color: var(--dsc-accordion-icon-background-hover);
   }
 
-  .ds-accordion__item--open .ds-accordion__header:hover .ds-accordion__expand-icon {
+  .ds-accordion__item--open .ds-accordion__heading:hover .ds-accordion__expand-icon {
     background-color: var(--dsc-accordion-icon-background-active);
   }
 }

--- a/packages/react/src/components/Accordion/AccordionHeading.tsx
+++ b/packages/react/src/components/Accordion/AccordionHeading.tsx
@@ -7,7 +7,7 @@ import { Heading, Paragraph } from '../Typography';
 
 import { AccordionItemContext } from './AccordionItem';
 
-export type AccordionHeaderProps = {
+export type AccordionHeadingProps = {
   /**
    * Heading level. Use this to make sure the heading is correct according to you page heading levels
    * @default 1
@@ -20,19 +20,19 @@ export type AccordionHeaderProps = {
 } & HTMLAttributes<HTMLHeadingElement>;
 
 /**
- * Accordion header component, contains a button to toggle the content.
+ * Accordion heading component, contains a button to toggle the content.
  * @example
- * <AccordionHeader>Header</AccordionHeader>
+ * <AccordionHeading>Header</AccordionHeading>
  */
 export const AccordionHeading = forwardRef<
   HTMLHeadingElement,
-  AccordionHeaderProps
+  AccordionHeadingProps
 >(({ level = 1, children, className, onHeaderClick, ...rest }, ref) => {
   const context = useContext(AccordionItemContext);
 
   if (context === null) {
     console.error(
-      '<Accordion.Header> has to be used within an <Accordion.Item>',
+      '<Accordion.Heading> has to be used within an <Accordion.Item>',
     );
     return null;
   }
@@ -47,7 +47,7 @@ export const AccordionHeading = forwardRef<
       ref={ref}
       size='xs'
       level={level}
-      className={cl('ds-accordion__header', className)}
+      className={cl('ds-accordion__heading', className)}
       {...rest}
     >
       <button

--- a/packages/react/src/components/Accordion/AccordionItem.tsx
+++ b/packages/react/src/components/Accordion/AccordionItem.tsx
@@ -33,7 +33,7 @@ export const AccordionItemContext =
  * Accordion item component, contains `Accordion.Header` and `Accordion.Content` components.
  * @example
  * <AccordionItem>
- *  <AccordionHeader>Header</AccordionHeader>
+ *  <AccordionHeading>Header</AccordionHeading>
  *  <AccordionContent>Content</AccordionContent>
  * </AccordionItem>
  */

--- a/packages/react/src/components/Accordion/index.ts
+++ b/packages/react/src/components/Accordion/index.ts
@@ -1,6 +1,6 @@
 import type { AccordionContentProps } from './AccordionContent';
 import { AccordionContent } from './AccordionContent';
-import type { AccordionHeaderProps } from './AccordionHeading';
+import type { AccordionHeadingProps } from './AccordionHeading';
 import { AccordionHeading } from './AccordionHeading';
 import type { AccordionItemProps } from './AccordionItem';
 import { AccordionItem } from './AccordionItem';
@@ -39,7 +39,7 @@ Accordion.Item.displayName = 'Accordion.Item';
 export type {
   AccordionRootProps,
   AccordionContentProps,
-  AccordionHeaderProps,
+  AccordionHeadingProps,
   AccordionItemProps,
 };
 export {

--- a/packages/react/stories/bruk.mdx
+++ b/packages/react/stories/bruk.mdx
@@ -68,11 +68,11 @@ som ligger i en klient komponent, som `Accordion` er.
 
 <CodeSnippet language='ts'>
 {`
-import { AccordionRoot, AccordionHeader, AccordionItem, AccordionContent } from '@digdir/designsystemet-react';
+import { AccordionRoot, AccordionHeading, AccordionItem, AccordionContent } from '@digdir/designsystemet-react';
 
 <AccordionRoot>
   <AccordionItem>
-    <AccordionHeader>...</AccordionHeader>
+    <AccordionHeading>...</AccordionHeading>
     <AccordionContent>...</AccordionContent>
   </AccordionItem>
 </AccordionRoot>
@@ -87,7 +87,7 @@ import { Accordion } from '@digdir/designsystemet-react';
 
 <Accordion.Root>
   <Accordion.Item>
-    <Accordion.Header>...</Accordion.Header>
+    <Accordion.Heading>...</Accordion.Heading>
     <Accordion.Content>...</Accordion.Content>
   </Accordion.Item>
 </Accordion.Root>


### PR DESCRIPTION
streamlines AccordionHeading, which had wrong names in props, logs and documentation.