### PR TITLE
style(Table): remove hover on zebra colored row

### DIFF
--- a/packages/css/table.css
+++ b/packages/css/table.css
@@ -103,7 +103,7 @@
   border-bottom: 0;
 }
 
-.ds-table--zebra tr:nth-child(even):not(:hover) .ds-table__cell {
+.ds-table--zebra tr:nth-child(even) .ds-table__cell {
   background-color: var(--dsc-table-cell-zebra-background);
 }
 


### PR DESCRIPTION
table with zebra enabled made zebra colored rows white on hover. Removed this.
This does not need a changeset, since the changes to table has not been pushed to next yet