### PR TITLE
chore: add new orange and green base colors

### DIFF
--- a/packages/cli/src/colors/theme.ts
+++ b/packages/cli/src/colors/theme.ts
@@ -7,8 +7,8 @@ import { getContrastFromHex, getContrastFromLightness, getLightnessFromHex } fro
 
 export const baseColors: Record<GlobalColors, CssColor> = {
   blue: '#0A71C0',
-  green: '#078D19',
-  orange: '#CA5C21',
+  green: '#068718',
+  orange: '#B8581D',
   purple: '#663299',
   red: '#C01B1B',
   yellow: '#EABF28',


### PR DESCRIPTION
Adding new base colors for orange and green so the contrast color becomes white.

![image](https://github.com/user-attachments/assets/35266032-18ba-4fbc-a0df-42bc938e82db)
