### PR TITLE
fix: correct css var in color modal

### DIFF
--- a/packages/cli/src/colors/theme.ts
+++ b/packages/cli/src/colors/theme.ts
@@ -358,5 +358,5 @@ export const getBaseColor = (color: CssColor) => {
 };
 
 export const getCssVariable = (colorType: string, colorNumber: ColorNumber) => {
-  return `--ds-${colorType}-${getColorNameFromNumber(colorNumber).toLowerCase().replace(/\s/g, '-')}`;
+  return `--ds-color-${colorType}-${getColorNameFromNumber(colorNumber).toLowerCase().replace(/\s/g, '-')}`;
 };


### PR DESCRIPTION
we were displaying the wrong css variable in our color modals on storefront and theme.
First reported in Slack