### PR TITLE
fix: syncronized animation bug

### DIFF
--- a/packages/react/src/utilities/hooks/useSynchronizedAnimation/useSynchronizedAnimation.ts
+++ b/packages/react/src/utilities/hooks/useSynchronizedAnimation/useSynchronizedAnimation.ts
@@ -44,12 +44,16 @@ export function useSynchronizedAnimation<T>(animationName: string) {
       myAnimation.currentTime = 0;
     }
 
-    if (myAnimation && firstOfType && myAnimation !== firstOfType) {
+    if (
+      myAnimation &&
+      firstOfType?.currentTime &&
+      myAnimation !== firstOfType
+    ) {
       myAnimation.currentTime = firstOfType.currentTime;
     }
 
     return () => {
-      if (myAnimation && firstOfType) {
+      if (myAnimation && firstOfType?.currentTime) {
         myAnimation.currentTime = firstOfType.currentTime;
       }
     };


### PR DESCRIPTION
Fixes issue when multiple skeletons or spinners are removed at different times, causing crash
![image](https://github.com/user-attachments/assets/97f2fc9c-5b41-42d7-9b1b-ec1b7468098f)
The issue is because `firstOfType` might exist, but it might not have a `currentTime` and setting `myAnimation.currentTime = null` is not allowed.
Reported by Team Export Mattilsynet