### PR TITLE
ci: add a "Test reports" workflow

### DIFF
--- a/.github/workflows/test-reports.yml
+++ b/.github/workflows/test-reports.yml
@@ -1,0 +1,23 @@
+name: Test reports
+on:
+  workflow_dispatch:
+    inputs:
+      calling_workflow_id:
+        required: true
+      calling_workflow_run_id:
+        required: true
+      calling_workflow_head_sha:
+        required: true
+
+permissions:
+  checks: write
+  pull-requests: write
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      # This is just a placeholder workflow, the actual contents of the workflow will be populated in
+      # another pull request. But https://github.com/digdir/designsystemet/actions/workflows/test-reports.yml
+      # only works if the workflow file is already present on the default branch
+      - run: echo "Hello, dummy workflow"


### PR DESCRIPTION
This is just a placeholder workflow, the actual contents of the workflow will be populated in #2400. But [the workflow dispatch GUI](https://github.com/digdir/designsystemet/actions/workflows/test-reports.yml) (and `gh workflow run` CLI) only works if the workflow file is already present on the default branch.