### PR TITLE
chore: add siteimprove to storefront

### DIFF
--- a/apps/storefront/app/layout.tsx
+++ b/apps/storefront/app/layout.tsx
@@ -3,10 +3,10 @@ import '@digdir/designsystemet-css';
 import '@digdir/designsystemet-theme';
 
 import { Header } from '@repo/components';
-import { Analytics } from '@vercel/analytics/react';
 import type { Metadata } from 'next';
 
 import { VersionBanner } from '@components';
+import Script from 'next/script';
 import { Footer } from '../components/Footer/Footer';
 
 export const metadata: Metadata = {
@@ -62,7 +62,9 @@ export default function RootLayout({
           <Header menu={menu} />
           {children}
           <Footer />
-          <Analytics />
+          {process.env.VERCEL_GIT_COMMIT_REF === 'main' && (
+            <Script src='https://siteimproveanalytics.com/js/siteanalyze_6255470.js' />
+          )}
         </div>
       </body>
     </html>

--- a/apps/storefront/app/layout.tsx
+++ b/apps/storefront/app/layout.tsx
@@ -62,7 +62,7 @@ export default function RootLayout({
           <Header menu={menu} />
           {children}
           <Footer />
-          {process.env.VERCEL_GIT_COMMIT_REF === 'main' && (
+          {process.env.VERCEL_GIT_COMMIT_REF === 'next' && (
             <Script src='https://siteimproveanalytics.com/js/siteanalyze_6255470.js' />
           )}
         </div>


### PR DESCRIPTION
Add the Siteimprove script tag and remove Vercel analytics. The Siteimprove tag should only be loaded when the Storefront is deployed from the main branch (production).