### PR TITLE
fix: use standard side effects

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -17,7 +17,6 @@
       "require": "./dist/cjs/index.js"
     }
   },
-  "sideEffects": false,
   "files": [
     "dist/**"
   ],


### PR DESCRIPTION
- Removes non-standard `sideEffects: "false"` from `package.json` of `@digirdir/designsystemet-react`
- This is a property only [supported by Webpack](https://webpack.js.org/configuration/optimization/#optimizationsideeffects) and [by Vite/Rollup](https://github.com/rollup/rollup/issues/2593)
- This property caused issues when importing Designsystemet into another project and _then_ building with Vite - aka. an issue that is non-detectable in our own repository
- Many thanks to @unekinn for very good pinpong on resolving this issue <3

Vite building with non-standard `"sideEffects": false`:
<img width="1364" alt="image" src="https://github.com/user-attachments/assets/088c7b8f-da17-4eb6-86b4-239ef0de0af1">

Vite building when removing non-standard `"sideEffects": false`:
<img width="1391" alt="image" src="https://github.com/user-attachments/assets/f943a73d-3661-4621-bd68-2f028280dbe7">