### PR TITLE
fix(storybook): only theme on stories

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -1,5 +1,4 @@
 import { dirname, join, resolve } from 'node:path';
-import { env } from 'node:process';
 
 import type { StorybookConfig } from '@storybook/react-vite';
 import type { PropItem } from 'react-docgen-typescript';
@@ -9,11 +8,6 @@ const config: StorybookConfig = {
     check: true,
     /* If in prod, use docgen-typescript, locally use docgen */
     reactDocgen: 'react-docgen-typescript',
-    /**
-     * Enable this when docgen-typescript is faster
-     * See: https://github.com/storybookjs/storybook/issues/28269
-     */
-    /* reactDocgen: 'react-docgen-typescript', */
     reactDocgenTypescriptOptions: {
       include: [resolve(__dirname, '../../../packages/react/**/**.tsx')], // <- This is the important line.
       shouldExtractLiteralValuesFromEnum: true,

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -1,3 +1,4 @@
+import './style.css';
 import '../../../packages/css/index.css';
 import '@digdir/designsystemet-theme/digdir.css';
 
@@ -157,6 +158,7 @@ export const decorators = [
     },
     defaultTheme: 'Light',
     attributeName: 'data-ds-color-mode',
+    parentSelector: '.sbdocs, .sb-main-padded',
   }),
 ];
 

--- a/apps/storybook/.storybook/style.css
+++ b/apps/storybook/.storybook/style.css
@@ -1,0 +1,7 @@
+* {
+  font-feature-settings: 'cv05' 1;
+}
+
+html {
+  font-family: 'Inter', sans-serif;
+}


### PR DESCRIPTION
Fixes white text and other color errors when changing to dark theme.
Updated to target only stories

Old:
![image](https://github.com/user-attachments/assets/980f4ae2-74f8-473c-b916-8323154207d2)
