### PR TITLE
fix(card): add `display: block`

### DIFF
--- a/packages/css/card.css
+++ b/packages/css/card.css
@@ -9,6 +9,7 @@
   --dsc-card-padding: var(--ds-spacing-6);
 
   all: unset; /* Reset if <button> */
+  display: block;
   background: var(--dsc-card-background);
   border-radius: min(1rem, var(--ds-border-radius-md));
   border: var(--dsc-card-border);


### PR DESCRIPTION
fixes this:
![image](https://github.com/user-attachments/assets/67e9c232-1c97-477a-91a8-c142117b4409)
