### PR TITLE
fix: modal backdrop was invisible in some browser versions

### DIFF
--- a/.changeset/twelve-onions-laugh.md
+++ b/.changeset/twelve-onions-laugh.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+Modal backdrop was invisible in some browser versions. See https://caniuse.com/mdn-css_selectors_backdrop_inherit_from_originating_element for affected versions.

--- a/apps/storybook/chromatic.config.json
+++ b/apps/storybook/chromatic.config.json
@@ -1,6 +1,7 @@
 {
   "onlyChanged": true,
   "projectId": "Project:66fe736b9d639fe6801bf130",
+  "buildScriptName": "build",
   "storybookBaseDir": "apps/storybook",
   "storybookBuildDir": "dist",
   "zip": true,

--- a/package.json
+++ b/package.json
@@ -43,14 +43,14 @@
     "@types/node": "^22.1.0",
     "@vitejs/plugin-react-swc": "^3.7.0",
     "@vitest/coverage-v8": "^2.0.5",
+    "@vitest/expect": "^2.0.5",
     "chromatic": "^11.11.0",
     "copyfiles": "^2.4.1",
     "storybook-addon-pseudo-states": "^4.0.2",
     "typescript": "^5.5.4",
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^5.3.6",
-    "vitest": "^2.0.5",
-    "@vitest/expect": "^2.0.5"
+    "vitest": "^2.0.5"
   },
   "engines": {
     "node": ">=18.12.0"

--- a/packages/css/modal.css
+++ b/packages/css/modal.css
@@ -22,7 +22,9 @@
 
   &::backdrop {
     animation: fade-in 300ms ease-in-out;
-    background: var(--dsc-modal-backdrop-background);
+    /* we include a fallback color because ::backdrop didn't inherit
+       custom properties in Chrome until version 122 (mid-2024) */
+    background: var(--dsc-modal-backdrop-background, rgb(0 0 0 / 0.5));
   }
 
   &[open] {


### PR DESCRIPTION
See https://caniuse.com/mdn-css_selectors_backdrop_inherit_from_originating_element for affected versions.