### PR TITLE
refactor(cli): add and use getThemesFor(dimensions) in build command

### DIFF
--- a/packages/cli/bin/designsystemet.ts
+++ b/packages/cli/bin/designsystemet.ts
@@ -26,7 +26,7 @@ function makeTokenCommands() {
       const out = typeof opts.out === 'string' ? opts.out : './dist/tokens';
       const preview = opts.preview;
       const verbose = opts.verbose;
-      console.log(`Bulding tokens in ${chalk.green(tokens)}`);
+      console.log(`Building tokens in ${chalk.green(tokens)}`);
       return buildTokens({ tokens, out, preview, verbose });
     });
 

--- a/packages/cli/src/tokens/build.ts
+++ b/packages/cli/src/tokens/build.ts
@@ -8,13 +8,14 @@ import StyleDictionary from 'style-dictionary';
 
 import * as configs from './build/configs.js';
 import { makeEntryFile } from './build/utils/entryfile.js';
+import { type PermutatedTheme, groupThemes } from './build/utils/permutateThemes.js';
 
 const { permutateThemes, getConfigs } = configs;
 
 type Options = {
-  /** Design tokens path  */
+  /** Design tokens path */
   tokens: string;
-  /** Output directoru for built tokens */
+  /** Output directory for built tokens */
   out: string;
   /** Generate preview tokens */
   preview: boolean;
@@ -41,11 +42,37 @@ export async function buildTokens(options: Options): Promise<void> {
     return true;
   });
 
-  const themes = permutateThemes(relevant$themes);
+  const grouped$themes = groupThemes(relevant$themes);
+  const themes = permutateThemes(grouped$themes);
+  type ThemeDimension = keyof typeof grouped$themes;
 
-  const typographyThemes = R.filter((val) => val.mode === 'light', themes);
-  const colormodeThemes = R.filter((val) => val.typography === 'primary', themes);
-  const semanticThemes = R.filter((val) => val.mode === 'light' && val.typography === 'primary', themes);
+  /**
+   * Find the theme permutations that are relevant for the given theme dimensions.
+   *
+   * Technically, for the given dimensions all permutations are included, while for other
+   * dimensions the first permutation is used.
+   *
+   * @param dimensions Which theme dimensions to return permutations for.
+   *    'theme' (e.g. altinn/digdir/uutilsynet) is always implicitly included.
+   * @returns the relevant theme permutations
+   */
+  const getThemesFor = (...dimensions: ThemeDimension[]) => {
+    const ALL_DEPENDENT_ON: ThemeDimension[] = ['theme'];
+    const keys = R.keys(grouped$themes);
+    const nonDependentKeys = keys.filter((x) => ![...ALL_DEPENDENT_ON, ...dimensions].includes(x));
+    if (verbosity === 'verbose') {
+      console.log(chalk.cyan(`🔎 Finding theme permutations for ${dimensions}`));
+      console.log(chalk.cyan(`   (ignoring permutations for ${nonDependentKeys})`));
+    }
+    return themes.filter((val: PermutatedTheme) => {
+      const filters = nonDependentKeys.map((x) => val[x] === grouped$themes[x][0].name);
+      return filters.every((x) => x);
+    });
+  };
+
+  const typographyThemes = getThemesFor('typography');
+  const colormodeThemes = getThemesFor('mode');
+  const semanticThemes = getThemesFor('semantic');
 
   const colorModeConfigs = getConfigs(configs.colorModeVariables, outPath, tokensDir, colormodeThemes, verbosity);
   const semanticConfigs = getConfigs(configs.semanticVariables, outPath, tokensDir, semanticThemes, verbosity);

--- a/packages/cli/src/tokens/build/configs.ts
+++ b/packages/cli/src/tokens/build/configs.ts
@@ -9,7 +9,7 @@ import * as formats from './formats/css.js';
 import { jsTokens } from './formats/js-tokens.js';
 import { nameKebab, resolveMath, sizeRem, typographyName } from './transformers.js';
 import { permutateThemes as permutateThemes_ } from './utils/permutateThemes.js';
-import type { PermutatedThemes } from './utils/permutateThemes.js';
+import type { GroupedThemes, PermutatedThemes, PermutationProps } from './utils/permutateThemes.js';
 import { pathStartsWithOneOf, typeEquals } from './utils/utils.js';
 
 void register(StyleDictionary, { withSDBuiltins: false });
@@ -63,19 +63,16 @@ const outputColorReferences = (token: TransformedToken) => {
 
 export type IsCalculatedToken = (token: TransformedToken, options?: Config) => boolean;
 
-export const permutateThemes = ($themes: ThemeObject[]) =>
-  permutateThemes_($themes, {
+export const permutateThemes = (groupedThemes: GroupedThemes) =>
+  permutateThemes_(groupedThemes, {
     separator,
   });
 
-type GetConfig = (options: {
-  mode?: string;
-  theme?: string;
-  semantic?: string;
-  size?: string;
-  typography?: string;
-  outPath?: string;
-}) => Config;
+type GetConfig = (
+  options: PermutationProps & {
+    outPath?: string;
+  },
+) => Config;
 
 export const colorModeVariables: GetConfig = ({ mode = 'light', outPath, theme }) => {
   const selector = `${mode === 'light' ? ':root, ' : ''}[data-ds-color-mode="${mode}"]`;
@@ -262,7 +259,7 @@ type getConfigs = (
   tokensDir: string,
   themes: PermutatedThemes,
   logVerbosity: LogConfig['verbosity'],
-) => { mode: string; theme: string; semantic: string; size: string; typography: string; config: Config }[];
+) => (PermutationProps & { config: Config })[];
 
 export const getConfigs: getConfigs = (getConfig, outPath, tokensDir, permutatedThemes, logVerbosity) =>
   permutatedThemes


### PR DESCRIPTION
This automates the config filtering which so far has been done manually, e.g. this
```ts
const semanticThemes = R.filter((val) => val.mode === 'light' && val.typography === 'primary', themes)
```

is now this
```
const semanticThemes = getThemesFor('semantic');
```

The main reason for doing this is that it requires no changes to the filters when adding new modes, while the code as it is before this commit would require every `R.filter(...)` statement to be updated to ignore irrelevant modes -- or suffer exponential increase in build time.

The resulting css files from the build command remain unchanged.