### PR TITLE
fix(alert): add `position: relative`

### DIFF
--- a/.changeset/hip-brooms-brush.md
+++ b/.changeset/hip-brooms-brush.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+Alert: fix icon abandoning the component when scrolling

--- a/packages/css/alert.css
+++ b/packages/css/alert.css
@@ -16,6 +16,7 @@
   color: var(--dsc-alert-color);
   padding-block: var(--dsc-alert-padding);
   padding-inline: calc(var(--dsc-alert-padding) + var(--dsc-alert-icon-size) + var(--dsc-alert-gap)) var(--dsc-alert-padding);
+  position: relative;
 
   @composes ds-body-text--md from './base/base.css';
 


### PR DESCRIPTION
Add `position: relative;` to the `.ds-alert` class in `packages/css/alert.css`.

* Ensure the icon stays within the component by adding `position: relative;` to the `.ds-alert` class.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/digdir/designsystemet?shareId=753f785f-f7ec-412a-a831-0293680df6b4).