### PR TITLE
fix(Popover): place arrow correctly

### DIFF
--- a/.changeset/hot-crews-perform.md
+++ b/.changeset/hot-crews-perform.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+Popover: Make sure arrow does not leave the popover

--- a/packages/react/src/components/Popover/Popover.stories.tsx
+++ b/packages/react/src/components/Popover/Popover.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryFn } from '@storybook/react';
 import { expect, userEvent, within } from '@storybook/test';
 import { useEffect, useState } from 'react';
 
-import { Button, Paragraph } from '../..';
+import { Button, Paragraph, Textfield } from '../..';
 
 import { Popover } from '.';
 
@@ -32,7 +32,10 @@ export const Preview: StoryFn<typeof Popover> = (args) => {
   return (
     <Popover.Context>
       <Popover.Trigger>My trigger!</Popover.Trigger>
-      <Popover {...args}>popover content</Popover>
+      <Popover {...args}>
+        popover content 3rgoi heroigj eoijg eijgoeirj goiergjjgerierjg oierg
+        joiergjeoigijgeigjeroig jeroig jerijeor
+      </Popover>
     </Popover.Context>
   );
 };

--- a/packages/react/src/components/Popover/Popover.stories.tsx
+++ b/packages/react/src/components/Popover/Popover.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryFn } from '@storybook/react';
 import { expect, userEvent, within } from '@storybook/test';
 import { useEffect, useState } from 'react';
 
-import { Button, Paragraph, Textfield } from '../..';
+import { Button, Paragraph } from '../..';
 
 import { Popover } from '.';
 
@@ -32,10 +32,7 @@ export const Preview: StoryFn<typeof Popover> = (args) => {
   return (
     <Popover.Context>
       <Popover.Trigger>My trigger!</Popover.Trigger>
-      <Popover {...args}>
-        popover content 3rgoi heroigj eoijg eijgoeirj goiergjjgerierjg oierg
-        joiergjeoigijgeigjeroig jeroig jerijeor
-      </Popover>
+      <Popover {...args}>popover content</Popover>
     </Popover.Context>
   );
 };

--- a/packages/react/src/components/Popover/Popover.tsx
+++ b/packages/react/src/components/Popover/Popover.tsx
@@ -181,26 +181,26 @@ const arrowPseudoElement = {
     let arrowY = 0;
 
     if (placement.includes('bottom') || placement.includes('top')) {
-      /* default `arrowX` is if popover is bigger than the reference */
+      /* It will always be the same height away when top or bottom */
+      arrowY = rects.reference.height / 2 + rects.reference.y - data.y;
+
+      /* default `arrowX` to center of reference, if popover is wider */
       arrowX = rects.reference.width / 2 + rects.reference.x - data.x;
 
-      arrowY = rects.reference.height / 2 + rects.reference.y - data.y;
-      /**
-       * if popover is wider, set arrow in the middle of the reference
-       */
+      /* if reference is wider, set arrow in the middle of the floating */
       if (rects.reference.width > rects.floating.width) {
-        arrowX = rects.floating.width / 2 - ARROW_HEIGHT / 2;
+        arrowX = rects.floating.width / 2;
       }
     } else if (placement.includes('left') || placement.includes('right')) {
-      /* default `arrowX` is if popover is bigger than the reference */
-      arrowX = rects.reference.height / 2 + rects.reference.x - data.x;
+      /* It will always be the same width away when right or left */
+      arrowX = rects.reference.width / 2 + rects.reference.x - data.x;
 
+      /* default `arrowY` to center of reference, if popover is taller */
       arrowY = rects.reference.height / 2 + rects.reference.y - data.y;
-      /**
-       * if popover is taller, set arrow in the middle of the reference
-       */
+
+      /* if reference is taller, set arrow in the middle of the floating */
       if (rects.reference.height > rects.floating.height) {
-        arrowY = rects.floating.height / 2 - ARROW_HEIGHT / 2;
+        arrowY = rects.floating.height / 2;
       }
     }
 

--- a/packages/react/src/components/Popover/Popover.tsx
+++ b/packages/react/src/components/Popover/Popover.tsx
@@ -176,12 +176,30 @@ const arrowPseudoElement = {
   name: 'ArrowPseudoElement',
   fn(data: MiddlewareState) {
     const { elements, rects, placement } = data;
-    const arrowX = rects.reference.width / 2 + rects.reference.x - data.x;
-    const arrowY = rects.reference.height / 2 + rects.reference.y - data.y;
+    let arrowX = 0;
+    let arrowY = 0;
+
+    /**
+     * if popover is wider, set arrow in the middle of the reference
+     * if the reference is wider, set the arrow in the middle of the popover
+     */
+    if (rects.reference.width > rects.floating.width) {
+      arrowX = rects.floating.width / 2 - ARROW_HEIGHT / 2;
+      arrowY = rects.reference.height / 2 + rects.reference.y - data.y;
+    } else {
+      arrowX = rects.reference.width / 2 + rects.reference.x - data.x;
+      arrowY = rects.reference.height / 2 + rects.reference.y - data.y;
+    }
 
     elements.floating.setAttribute('data-placement', placement.split('-')[0]); // We only need top/left/right/bottom
-    elements.floating.style.setProperty('--ds-popover-arrow-x', `${arrowX}px`);
-    elements.floating.style.setProperty('--ds-popover-arrow-y', `${arrowY}px`);
+    elements.floating.style.setProperty(
+      '--ds-popover-arrow-x',
+      `${Math.round(arrowX)}px`,
+    );
+    elements.floating.style.setProperty(
+      '--ds-popover-arrow-y',
+      `${Math.round(arrowY)}px`,
+    );
     return data;
   },
 };

--- a/packages/react/src/components/Popover/Popover.tsx
+++ b/packages/react/src/components/Popover/Popover.tsx
@@ -176,19 +176,32 @@ const arrowPseudoElement = {
   name: 'ArrowPseudoElement',
   fn(data: MiddlewareState) {
     const { elements, rects, placement } = data;
+
     let arrowX = 0;
     let arrowY = 0;
 
-    /**
-     * if popover is wider, set arrow in the middle of the reference
-     * if the reference is wider, set the arrow in the middle of the popover
-     */
-    if (rects.reference.width > rects.floating.width) {
-      arrowX = rects.floating.width / 2 - ARROW_HEIGHT / 2;
-      arrowY = rects.reference.height / 2 + rects.reference.y - data.y;
-    } else {
+    if (placement.includes('bottom') || placement.includes('top')) {
+      /* default `arrowX` is if popover is bigger than the reference */
       arrowX = rects.reference.width / 2 + rects.reference.x - data.x;
+
       arrowY = rects.reference.height / 2 + rects.reference.y - data.y;
+      /**
+       * if popover is wider, set arrow in the middle of the reference
+       */
+      if (rects.reference.width > rects.floating.width) {
+        arrowX = rects.floating.width / 2 - ARROW_HEIGHT / 2;
+      }
+    } else if (placement.includes('left') || placement.includes('right')) {
+      /* default `arrowX` is if popover is bigger than the reference */
+      arrowX = rects.reference.height / 2 + rects.reference.x - data.x;
+
+      arrowY = rects.reference.height / 2 + rects.reference.y - data.y;
+      /**
+       * if popover is taller, set arrow in the middle of the reference
+       */
+      if (rects.reference.height > rects.floating.height) {
+        arrowY = rects.floating.height / 2 - ARROW_HEIGHT / 2;
+      }
     }
 
     elements.floating.setAttribute('data-placement', placement.split('-')[0]); // We only need top/left/right/bottom

--- a/packages/react/src/components/Popover/Popover.tsx
+++ b/packages/react/src/components/Popover/Popover.tsx
@@ -177,31 +177,15 @@ const arrowPseudoElement = {
   fn(data: MiddlewareState) {
     const { elements, rects, placement } = data;
 
-    let arrowX = 0;
-    let arrowY = 0;
+    let arrowX = rects.reference.width / 2 + rects.reference.x - data.x;
+    let arrowY = rects.reference.height / 2 + rects.reference.y - data.y;
 
-    if (placement.includes('bottom') || placement.includes('top')) {
-      /* It will always be the same height away when top or bottom */
-      arrowY = rects.reference.height / 2 + rects.reference.y - data.y;
+    if (rects.reference.width > rects.floating.width) {
+      arrowX = rects.floating.width / 2;
+    }
 
-      /* default `arrowX` to center of reference, if popover is wider */
-      arrowX = rects.reference.width / 2 + rects.reference.x - data.x;
-
-      /* if reference is wider, set arrow in the middle of the floating */
-      if (rects.reference.width > rects.floating.width) {
-        arrowX = rects.floating.width / 2;
-      }
-    } else if (placement.includes('left') || placement.includes('right')) {
-      /* It will always be the same width away when right or left */
-      arrowX = rects.reference.width / 2 + rects.reference.x - data.x;
-
-      /* default `arrowY` to center of reference, if popover is taller */
-      arrowY = rects.reference.height / 2 + rects.reference.y - data.y;
-
-      /* if reference is taller, set arrow in the middle of the floating */
-      if (rects.reference.height > rects.floating.height) {
-        arrowY = rects.floating.height / 2;
-      }
+    if (rects.reference.height > rects.floating.height) {
+      arrowY = rects.floating.height / 2;
     }
 
     elements.floating.setAttribute('data-placement', placement.split('-')[0]); // We only need top/left/right/bottom


### PR DESCRIPTION
resolves #2649

This check the width of both elements, and places the arrow in the center of the shortest one,