### PR TITLE
chore: do arrow placing in code, not css

### DIFF
--- a/packages/css/popover.css
+++ b/packages/css/popover.css
@@ -48,22 +48,18 @@
   }
 
   &[data-placement='top']::before {
-    top: 100%;
     rotate: 45deg;
   }
 
   &[data-placement='left']::before {
-    left: 100%;
     rotate: -45deg;
   }
 
   &[data-placement='right']::before {
-    left: 0;
     rotate: 135deg;
   }
 
   &[data-placement='bottom']::before {
-    top: 0;
     rotate: -135deg;
   }
 

--- a/packages/css/tooltip.css
+++ b/packages/css/tooltip.css
@@ -25,20 +25,4 @@
     translate: -50% -50%;
     rotate: 45deg;
   }
-
-  &[data-placement='top']::before {
-    top: 100%;
-  }
-
-  &[data-placement='left']::before {
-    left: 100%;
-  }
-
-  &[data-placement='right']::before {
-    left: 0;
-  }
-
-  &[data-placement='bottom']::before {
-    top: 0;
-  }
 }

--- a/packages/react/src/components/Popover/Popover.tsx
+++ b/packages/react/src/components/Popover/Popover.tsx
@@ -188,26 +188,35 @@ const arrowPseudoElement = {
   fn(data: MiddlewareState) {
     const { elements, rects, placement } = data;
 
-    let arrowX = rects.reference.width / 2 + rects.reference.x - data.x;
-    let arrowY = rects.reference.height / 2 + rects.reference.y - data.y;
+    let arrowX = `${Math.round(rects.reference.width / 2 + rects.reference.x - data.x)}px`;
+    let arrowY = `${Math.round(rects.reference.height / 2 + rects.reference.y - data.y)}px`;
 
     if (rects.reference.width > rects.floating.width) {
-      arrowX = rects.floating.width / 2;
+      arrowX = `${Math.round(rects.floating.width / 2)}px`;
     }
 
     if (rects.reference.height > rects.floating.height) {
-      arrowY = rects.floating.height / 2;
+      arrowY = `${Math.round(rects.floating.height / 2)}px`;
+    }
+
+    switch (placement.split('-')[0]) {
+      case 'top':
+        arrowY = '100%';
+        break;
+      case 'right':
+        arrowX = '0';
+        break;
+      case 'bottom':
+        arrowY = '0';
+        break;
+      case 'left':
+        arrowX = '100%';
+        break;
     }
 
     elements.floating.setAttribute('data-placement', placement.split('-')[0]); // We only need top/left/right/bottom
-    elements.floating.style.setProperty(
-      '--ds-popover-arrow-x',
-      `${Math.round(arrowX)}px`,
-    );
-    elements.floating.style.setProperty(
-      '--ds-popover-arrow-y',
-      `${Math.round(arrowY)}px`,
-    );
+    elements.floating.style.setProperty('--ds-popover-arrow-x', arrowX);
+    elements.floating.style.setProperty('--ds-popover-arrow-y', arrowY);
     return data;
   },
 };

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -172,18 +172,30 @@ const arrowPseudoElement = {
   fn(data: MiddlewareState) {
     const { elements, rects, placement } = data;
 
-    const arrowX = rects.reference.width / 2 + rects.reference.x - data.x;
-    const arrowY = rects.reference.height / 2 + rects.reference.y - data.y;
+    let arrowX = `${Math.round(
+      rects.reference.width / 2 + rects.reference.x - data.x,
+    )}px`;
+    let arrowY = `${Math.round(
+      rects.reference.height / 2 + rects.reference.y - data.y,
+    )}px`;
 
-    elements.floating.setAttribute('data-placement', placement);
-    elements.floating.style.setProperty(
-      '--ds-tooltip-arrow-x',
-      `${Math.round(arrowX)}px`,
-    );
-    elements.floating.style.setProperty(
-      '--ds-tooltip-arrow-y',
-      `${Math.round(arrowY)}px`,
-    );
+    switch (placement) {
+      case 'top':
+        arrowY = '100%';
+        break;
+      case 'right':
+        arrowX = '0';
+        break;
+      case 'bottom':
+        arrowY = '0';
+        break;
+      case 'left':
+        arrowX = '100%';
+        break;
+    }
+
+    elements.floating.style.setProperty('--ds-tooltip-arrow-x', arrowX);
+    elements.floating.style.setProperty('--ds-tooltip-arrow-y', arrowY);
     return data;
   },
 };


### PR DESCRIPTION
Steamlines so we only use css vars for placement, and all the arrow placement is now done in JS, not JS+CSS.

Was debating wether `${Math.round(...}px` should be a util, but decided not to do it, since it is so far only used in these two components.