### PR TITLE
fix: icon abandoning parent

### DIFF
--- a/.changeset/blue-stingrays-heal.md
+++ b/.changeset/blue-stingrays-heal.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+Accordion: Fix chevron abandoning parent in scroll container

--- a/.changeset/slow-impalas-vanish.md
+++ b/.changeset/slow-impalas-vanish.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+Label: Fix icon abandoning parent in scroll container

--- a/packages/css/accordion.css
+++ b/packages/css/accordion.css
@@ -76,6 +76,7 @@
     gap: var(--dsc-accordion-chevron-gap);
     outline: none;
     padding: var(--dsc-accordion-padding);
+    position: relative;
 
     @composes ds-focus from './base/base.css';
 

--- a/packages/css/label.css
+++ b/packages/css/label.css
@@ -6,6 +6,7 @@
 
   font-weight: var(--ds-font-weight-medium);
   padding-inline-start: var(--dsc-label--readonly) calc(var(--dsc-label-icon-size) + var(--dsc-label-gap));
+  position: relative;
 
   &::before {
     background: currentcolor;

--- a/packages/react/src/components/form/Search/Search.test.tsx
+++ b/packages/react/src/components/form/Search/Search.test.tsx
@@ -13,7 +13,7 @@ describe('Search', () => {
     expect(screen.getByDisplayValue('test')).toBeDefined();
   });
 
-  test('has correct label when label is hidden', () => {
+  test('has correct aria-label when hiding label', () => {
     render({ label: 'label', hideLabel: true });
 
     expect(screen.getByLabelText('label')).toBeDefined();
@@ -48,14 +48,14 @@ describe('Search', () => {
 
   it('Focuses on search field when label is clicked and id is not given', async () => {
     const label = 'Lorem ipsum';
-    const { user } = render({ label });
+    const { user } = render({ label, hideLabel: false });
     await act(async () => await user.click(screen.getByText(label)));
     expect(screen.getByRole('searchbox')).toHaveFocus();
   });
 
   it('Focuses on search field when label is clicked and id is given', async () => {
     const label = 'Lorem ipsum';
-    const { user } = render({ id: 'some-unique-id', label });
+    const { user } = render({ id: 'some-unique-id', label, hideLabel: false });
     await act(async () => await user.click(screen.getByText(label)));
     expect(screen.getByRole('searchbox')).toHaveFocus();
   });

--- a/packages/react/src/components/form/Search/Search.tsx
+++ b/packages/react/src/components/form/Search/Search.tsx
@@ -7,7 +7,6 @@ import { forwardRef, useCallback, useRef, useState } from 'react';
 import type { DefaultProps } from '../../../types';
 import { omit } from '../../../utilities';
 import { Button } from '../../Button/Button';
-import { Label } from '../../Label';
 import { Paragraph } from '../../Paragraph';
 import type { FormFieldProps } from '../useFormField';
 
@@ -114,17 +113,6 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
             className,
           )}
         >
-          {label && (
-            <Label
-              data-size={size}
-              weight='medium'
-              htmlFor={inputProps.id}
-              className={cl('ds-search__label', hideLabel && 'ds-sr-only')}
-            >
-              <span>{label}</span>
-            </Label>
-          )}
-
           <div className={'ds-search__field'}>
             <div className={cl('ds-search__field', `ds-search--${size}`)}>
               {isSimple && (
@@ -148,6 +136,7 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
                 {...omit(['size', 'error', 'errorId', 'readOnly'], rest)}
                 {...inputProps}
                 onChange={handleChange}
+                aria-label={label?.toString()}
               />
               {showClearButton && (
                 <button

--- a/packages/react/src/components/form/Search/Search.tsx
+++ b/packages/react/src/components/form/Search/Search.tsx
@@ -7,6 +7,7 @@ import { forwardRef, useCallback, useRef, useState } from 'react';
 import type { DefaultProps } from '../../../types';
 import { omit } from '../../../utilities';
 import { Button } from '../../Button/Button';
+import { Label } from '../../Label';
 import { Paragraph } from '../../Paragraph';
 import type { FormFieldProps } from '../useFormField';
 
@@ -113,6 +114,17 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
             className,
           )}
         >
+          {!hideLabel && (
+            <Label
+              data-size={size}
+              weight='medium'
+              htmlFor={inputProps.id}
+              className={cl('ds-search__label', hideLabel && 'ds-sr-only')}
+            >
+              <span>{label}</span>
+            </Label>
+          )}
+
           <div className={'ds-search__field'}>
             <div className={cl('ds-search__field', `ds-search--${size}`)}>
               {isSimple && (
@@ -136,7 +148,7 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
                 {...omit(['size', 'error', 'errorId', 'readOnly'], rest)}
                 {...inputProps}
                 onChange={handleChange}
-                aria-label={label?.toString()}
+                aria-label={hideLabel ? label?.toString() : undefined}
               />
               {showClearButton && (
                 <button


### PR DESCRIPTION
resolves #2696

This PR makes `hideLabel` work weird in some form components. This will be looked at when we refactor these, as this has not been done yet. The position relative we added makes our `sr-only` class not set its position absolute.