### PR TITLE
refactor(Field): :recycle: merge `CharacterCounter` into `Field`

### DIFF
--- a/packages/react/src/components/form/Field/Field.mdx
+++ b/packages/react/src/components/form/Field/Field.mdx
@@ -15,3 +15,7 @@ Du skal **ikke** bruke disse alene, siden skjermlesere ikke leser dem opp.
 Det er viktig at samme informasjon som vises i prefixet eller suffixet også er inkludert i ledeteksten.
 
 <Canvas of={FieldStories.Adornments} />
+
+## Antall tegn
+
+<Canvas of={FieldStories.Counter} />

--- a/packages/react/src/components/form/Field/Field.stories.tsx
+++ b/packages/react/src/components/form/Field/Field.stories.tsx
@@ -117,6 +117,6 @@ export const Counter: Story = () => (
   <Field>
     <Label>Legg til en beskrivelse</Label>
     <Textarea rows={2} />
-    <Field.Counter maxCount={10} />
+    <Field.Counter limit={10} />
   </Field>
 );

--- a/packages/react/src/components/form/Field/Field.stories.tsx
+++ b/packages/react/src/components/form/Field/Field.stories.tsx
@@ -112,3 +112,11 @@ export const Adornments: Story = () => (
     </Field>
   </div>
 );
+
+export const Counter: Story = () => (
+  <Field>
+    <Label>Legg til en beskrivelse</Label>
+    <Textarea rows={2} />
+    <Field.Counter maxCount={10} />
+  </Field>
+);

--- a/packages/react/src/components/form/Field/FieldCounter.tsx
+++ b/packages/react/src/components/form/Field/FieldCounter.tsx
@@ -1,5 +1,11 @@
-import { useMergeRefs } from '@floating-ui/react';
-import { forwardRef, useEffect, useRef, useState } from 'react';
+import {
+  type HTMLAttributes,
+  forwardRef,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import type { DefaultProps } from '../../../types';
 import { ValidationMessage } from '../../ValidationMessage';
 
 export type FieldCounterProps = {
@@ -13,18 +19,19 @@ export type FieldCounterProps = {
   under?: string;
   /** The maximum allowed characters. */
   limit: number;
-};
+} & HTMLAttributes<HTMLParagraphElement> &
+  DefaultProps;
 
 const label = (text: string, count: number) =>
   text.replace('%d', Math.abs(count).toString());
 
-export const FieldCounter = forwardRef<HTMLSpanElement, FieldCounterProps>(
+export const FieldCounter = forwardRef<HTMLParagraphElement, FieldCounterProps>(
   function FieldCounter(
-    { limit, under = '%d tegn igjen', over = '%d tegn for mye' },
+    { limit, under = '%d tegn igjen', over = '%d tegn for mye', ...rest },
     ref,
   ) {
     const [count, setCount] = useState(0);
-    const counterRef = useRef<HTMLSpanElement>(null);
+    const counterRef = useRef<HTMLDivElement>(null);
     const hasExceededLimit = count > limit;
     const remainder = limit - count;
 
@@ -42,9 +49,7 @@ export const FieldCounter = forwardRef<HTMLSpanElement, FieldCounterProps>(
 
       field?.addEventListener('input', onInput);
 
-      return () => {
-        field?.removeEventListener('input', onInput);
-      };
+      return () => field?.removeEventListener('input', onInput);
     }, [setCount]);
 
     return (
@@ -53,11 +58,11 @@ export const FieldCounter = forwardRef<HTMLSpanElement, FieldCounterProps>(
           data-field='description'
           className='ds-sr-only'
           aria-live={'polite'}
-          ref={useMergeRefs([ref, counterRef])}
+          ref={ref}
         >
           {hasExceededLimit && label(over, remainder)}
         </div>
-        <ValidationMessage error={hasExceededLimit}>
+        <ValidationMessage error={hasExceededLimit} ref={ref} {...rest}>
           {label(hasExceededLimit ? over : under, remainder)}
         </ValidationMessage>
       </>

--- a/packages/react/src/components/form/Field/FieldCounter.tsx
+++ b/packages/react/src/components/form/Field/FieldCounter.tsx
@@ -27,12 +27,6 @@ export const FieldCounter = ({
   const hasExceededLimit = count > maxCount;
   const currentCount = maxCount - count;
 
-  console.log('FieldCounter', {
-    count,
-    maxCount,
-    hasExceededLimit,
-    currentCount,
-  });
   useEffect(() => {
     const onChange = (e: Event) => {
       const element = e.target as HTMLInputElement | HTMLTextAreaElement;

--- a/packages/react/src/components/form/Field/FieldCounter.tsx
+++ b/packages/react/src/components/form/Field/FieldCounter.tsx
@@ -12,7 +12,7 @@ export type FieldCounterProps = {
    */
   under?: string;
   /** The maximum allowed characters. */
-  maxCount: number;
+  limit: number;
 };
 
 const label = (text: string, count: number) =>
@@ -20,39 +20,45 @@ const label = (text: string, count: number) =>
 
 export const FieldCounter = forwardRef<HTMLSpanElement, FieldCounterProps>(
   function FieldCounter(
-    { maxCount, under = '%d tegn igjen', over = '%d tegn for mye' },
+    { limit, under = '%d tegn igjen', over = '%d tegn for mye' },
     ref,
   ) {
     const [count, setCount] = useState(0);
     const counterRef = useRef<HTMLSpanElement>(null);
-    const hasExceededLimit = count > maxCount;
-    const currentCount = maxCount - count;
+    const hasExceededLimit = count > limit;
+    const currentCount = limit - count;
 
     useEffect(() => {
-      const onChange = (e: Event) => {
-        const element = e.target as HTMLInputElement | HTMLTextAreaElement;
-        setCount(element.value.length);
+      const onInput = ({ target }: Event) => {
+        if (
+          target instanceof HTMLInputElement ||
+          target instanceof HTMLTextAreaElement
+        ) {
+          setCount(target.value.length);
+        }
       };
 
       const field = counterRef.current?.closest('.ds-field');
-      field?.addEventListener('input', onChange);
+
+      field?.addEventListener('input', onInput);
 
       return () => {
-        field?.removeEventListener('input', onChange);
+        field?.removeEventListener('input', onInput);
       };
     }, [setCount]);
 
     return (
       <>
-        <span
+        <div
+          data-field='description'
           className='ds-sr-only'
           aria-live={'polite'}
           ref={useMergeRefs([ref, counterRef])}
         >
-          {hasExceededLimit && label(over, count)}
-        </span>
+          {hasExceededLimit && label(over, currentCount)}
+        </div>
         <ValidationMessage asChild error={hasExceededLimit}>
-          <span>{label(hasExceededLimit ? over : under, currentCount)}</span>
+          <div>{label(hasExceededLimit ? over : under, currentCount)}</div>
         </ValidationMessage>
       </>
     );

--- a/packages/react/src/components/form/Field/FieldCounter.tsx
+++ b/packages/react/src/components/form/Field/FieldCounter.tsx
@@ -1,12 +1,8 @@
+import { forwardRef, useEffect, useRef, useState } from 'react';
 import {
-  type HTMLAttributes,
-  forwardRef,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
-import type { DefaultProps } from '../../../types';
-import { ValidationMessage } from '../../ValidationMessage';
+  ValidationMessage,
+  type ValidationMessageProps,
+} from '../../ValidationMessage';
 
 export type FieldCounterProps = {
   /** Label template for when `maxCount` is exceeded
@@ -19,8 +15,7 @@ export type FieldCounterProps = {
   under?: string;
   /** The maximum allowed characters. */
   limit: number;
-} & HTMLAttributes<HTMLParagraphElement> &
-  DefaultProps;
+} & ValidationMessageProps;
 
 const label = (text: string, count: number) =>
   text.replace('%d', Math.abs(count).toString());
@@ -58,7 +53,7 @@ export const FieldCounter = forwardRef<HTMLParagraphElement, FieldCounterProps>(
           data-field='description'
           className='ds-sr-only'
           aria-live={'polite'}
-          ref={ref}
+          ref={counterRef}
         >
           {hasExceededLimit && label(over, remainder)}
         </div>

--- a/packages/react/src/components/form/Field/FieldCounter.tsx
+++ b/packages/react/src/components/form/Field/FieldCounter.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { ValidationMessage } from '../../ValidationMessage';
 
-type CharacterCounterProps = {
+export type FieldCounterProps = {
   /** Label template for when `maxCount` is exceeded
    * @default '%d tegn for mye'
    */

--- a/packages/react/src/components/form/Field/FieldCounter.tsx
+++ b/packages/react/src/components/form/Field/FieldCounter.tsx
@@ -17,11 +17,11 @@ type CharacterCounterProps = {
 const label = (text: string, count: number) =>
   text.replace('%d', Math.abs(count).toString());
 
-export const FieldCounter = ({
+export const FieldCounter = forwardRef<HTMLSpanElement, FieldCounterProps>({
   maxCount,
   under = '%d tegn igjen',
   over = '%d tegn for mye',
-}: CharacterCounterProps): JSX.Element => {
+}, ref) {
   const [count, setCount] = useState(0);
   const counterRef = useRef<HTMLSpanElement>(null);
   const hasExceededLimit = count > maxCount;

--- a/packages/react/src/components/form/Field/FieldCounter.tsx
+++ b/packages/react/src/components/form/Field/FieldCounter.tsx
@@ -26,7 +26,7 @@ export const FieldCounter = forwardRef<HTMLSpanElement, FieldCounterProps>(
     const [count, setCount] = useState(0);
     const counterRef = useRef<HTMLSpanElement>(null);
     const hasExceededLimit = count > limit;
-    const currentCount = limit - count;
+    const remainder = limit - count;
 
     useEffect(() => {
       const onInput = ({ target }: Event) => {
@@ -55,10 +55,10 @@ export const FieldCounter = forwardRef<HTMLSpanElement, FieldCounterProps>(
           aria-live={'polite'}
           ref={useMergeRefs([ref, counterRef])}
         >
-          {hasExceededLimit && label(over, currentCount)}
+          {hasExceededLimit && label(over, remainder)}
         </div>
-        <ValidationMessage asChild error={hasExceededLimit}>
-          <div>{label(hasExceededLimit ? over : under, currentCount)}</div>
+        <ValidationMessage error={hasExceededLimit}>
+          {label(hasExceededLimit ? over : under, remainder)}
         </ValidationMessage>
       </>
     );

--- a/packages/react/src/components/form/Field/FieldCounter.tsx
+++ b/packages/react/src/components/form/Field/FieldCounter.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState } from 'react';
+import { useMergeRefs } from '@floating-ui/react';
+import { forwardRef, useEffect, useRef, useState } from 'react';
 import { ValidationMessage } from '../../ValidationMessage';
 
 export type FieldCounterProps = {
@@ -17,40 +18,43 @@ export type FieldCounterProps = {
 const label = (text: string, count: number) =>
   text.replace('%d', Math.abs(count).toString());
 
-export const FieldCounter = forwardRef<HTMLSpanElement, FieldCounterProps>({
-  maxCount,
-  under = '%d tegn igjen',
-  over = '%d tegn for mye',
-}, ref) {
-  const [count, setCount] = useState(0);
-  const counterRef = useRef<HTMLSpanElement>(null);
-  const hasExceededLimit = count > maxCount;
-  const currentCount = maxCount - count;
+export const FieldCounter = forwardRef<HTMLSpanElement, FieldCounterProps>(
+  function FieldCounter(
+    { maxCount, under = '%d tegn igjen', over = '%d tegn for mye' },
+    ref,
+  ) {
+    const [count, setCount] = useState(0);
+    const counterRef = useRef<HTMLSpanElement>(null);
+    const hasExceededLimit = count > maxCount;
+    const currentCount = maxCount - count;
 
-  useEffect(() => {
-    const onChange = (e: Event) => {
-      const element = e.target as HTMLInputElement | HTMLTextAreaElement;
-      setCount(element.value.length);
-    };
+    useEffect(() => {
+      const onChange = (e: Event) => {
+        const element = e.target as HTMLInputElement | HTMLTextAreaElement;
+        setCount(element.value.length);
+      };
 
-    const field = counterRef.current?.closest('.ds-field');
-    field?.addEventListener('input', onChange);
+      const field = counterRef.current?.closest('.ds-field');
+      field?.addEventListener('input', onChange);
 
-    return () => {
-      field?.removeEventListener('input', onChange);
-    };
-  }, [setCount]);
+      return () => {
+        field?.removeEventListener('input', onChange);
+      };
+    }, [setCount]);
 
-  return (
-    <>
-      <span className='ds-sr-only' aria-live={'polite'} ref={counterRef}>
-        {hasExceededLimit && label(over, count)}
-      </span>
-      <ValidationMessage asChild error={hasExceededLimit}>
-        <span>{label(hasExceededLimit ? over : under, currentCount)}</span>
-      </ValidationMessage>
-    </>
-  );
-};
-
-FieldCounter.displayName = 'Field.Counter';
+    return (
+      <>
+        <span
+          className='ds-sr-only'
+          aria-live={'polite'}
+          ref={useMergeRefs([ref, counterRef])}
+        >
+          {hasExceededLimit && label(over, count)}
+        </span>
+        <ValidationMessage asChild error={hasExceededLimit}>
+          <span>{label(hasExceededLimit ? over : under, currentCount)}</span>
+        </ValidationMessage>
+      </>
+    );
+  },
+);

--- a/packages/react/src/components/form/Field/FieldCounter.tsx
+++ b/packages/react/src/components/form/Field/FieldCounter.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState } from 'react';
+import { ValidationMessage } from '../../ValidationMessage';
+
+type CharacterCounterProps = {
+  /** Label template for when `maxCount` is exceeded
+   * @default '%d tegn for mye'
+   */
+  over?: string;
+  /** Label template for count
+   * @default '%d tegn igjen'
+   */
+  under?: string;
+  /** The maximum allowed characters. */
+  maxCount: number;
+};
+
+const label = (text: string, count: number) =>
+  text.replace('%d', Math.abs(count).toString());
+
+export const FieldCounter = ({
+  maxCount,
+  under = '%d tegn igjen',
+  over = '%d tegn for mye',
+}: CharacterCounterProps): JSX.Element => {
+  const [count, setCount] = useState(0);
+  const counterRef = useRef<HTMLSpanElement>(null);
+  const hasExceededLimit = count > maxCount;
+  const currentCount = maxCount - count;
+
+  console.log('FieldCounter', {
+    count,
+    maxCount,
+    hasExceededLimit,
+    currentCount,
+  });
+  useEffect(() => {
+    const onChange = (e: Event) => {
+      const element = e.target as HTMLInputElement | HTMLTextAreaElement;
+      setCount(element.value.length);
+    };
+
+    const field = counterRef.current?.closest('.ds-field');
+    field?.addEventListener('input', onChange);
+
+    return () => {
+      field?.removeEventListener('input', onChange);
+    };
+  }, [setCount]);
+
+  return (
+    <>
+      <span className='ds-sr-only' aria-live={'polite'} ref={counterRef}>
+        {hasExceededLimit && label(over, count)}
+      </span>
+      <ValidationMessage asChild error={hasExceededLimit}>
+        <span>{label(hasExceededLimit ? over : under, currentCount)}</span>
+      </ValidationMessage>
+    </>
+  );
+};
+
+FieldCounter.displayName = 'Field.Counter';

--- a/packages/react/src/components/form/Field/index.ts
+++ b/packages/react/src/components/form/Field/index.ts
@@ -24,6 +24,7 @@ Field.AffixWrapper.displayName = 'Field.AffixWrapper';
 Field.Affix.displayName = 'Field.Affix';
 Field.Counter.displayName = 'Field.Counter';
 
+export type { FieldCounterProps } from './FieldCounter';
 export type {
   FieldAffixProps,
   FieldAffixWrapperProps,

--- a/packages/react/src/components/form/Field/index.ts
+++ b/packages/react/src/components/form/Field/index.ts
@@ -31,4 +31,4 @@ export type {
 } from './FieldAffix';
 export type { FieldProps } from './Field';
 export type { FieldDescriptionProps } from './FieldDescription';
-export { Field, FieldDescription, FieldAffix, FieldAffixWrapper };
+export { Field, FieldDescription, FieldAffix, FieldAffixWrapper, FieldCounter };

--- a/packages/react/src/components/form/Field/index.ts
+++ b/packages/react/src/components/form/Field/index.ts
@@ -1,5 +1,6 @@
 import { Field as FieldParent } from './Field';
 import { FieldAffix, FieldAffixWrapper } from './FieldAffix';
+import { FieldCounter } from './FieldCounter';
 import { FieldDescription } from './FieldDescription';
 
 /**
@@ -15,11 +16,13 @@ const Field = Object.assign(FieldParent, {
   Description: FieldDescription,
   AffixWrapper: FieldAffixWrapper,
   Affix: FieldAffix,
+  Counter: FieldCounter,
 });
 
 Field.Description.displayName = 'Field.Description';
 Field.AffixWrapper.displayName = 'Field.AffixWrapper';
 Field.Affix.displayName = 'Field.Affix';
+Field.Counter.displayName = 'Field.Counter';
 
 export type {
   FieldAffixProps,


### PR DESCRIPTION
- Created new `Field.Counter` to replace `CharacterCounter`
- Will delete old `CharacterCounter` in #2710 when use is replaced with `Field.Counter` there
- [Example story](https://pr-2717.storybook.designsystemet.no/?path=/story/komponenter-field--counter)