### PR TITLE
fix(css): breadcrumbs media query

### DIFF
--- a/packages/css/breadcrumbs.css
+++ b/packages/css/breadcrumbs.css
@@ -39,13 +39,13 @@
     rotate: 180deg;
   }
 
-  @media (max-width: 650px) {
+  @media (width < 650px) {
     & > :is(ol, ul):not(:only-child) {
       display: none; /* Hide list when mobile and having back link */
     }
   }
 
-  @media (min-width: 651px) {
+  @media (width >= 650px) {
     & > :is(:not(ol, ul)):not(:only-child) {
       display: none; /* Hide back link when desktop and having list */
     }

--- a/packages/css/breadcrumbs.css
+++ b/packages/css/breadcrumbs.css
@@ -45,7 +45,7 @@
     }
   }
 
-  @media (width >= 650px) {
+  @media (min-width: 650px) {
     & > :is(:not(ol, ul)):not(:only-child) {
       display: none; /* Hide back link when desktop and having list */
     }


### PR DESCRIPTION
Change meda query for breadcrumbs. Allow coverage for all view ports. Including values between 650px and 651px