### PR TITLE
fix(cli): type declarations in build output were incorrectly placed

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,11 +17,9 @@
   "bin": "dist/bin/designsystemet.js",
   "exports": {
     "./color": {
-      "types": "./dist/types/src/colors/index.d.ts",
       "import": "./dist/src/colors/index.js"
     },
     "./tokens/*": {
-      "types": "./dist/types/src/tokens/*",
       "import": "./dist/src/tokens/*"
     }
   },

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./dist/build",
-    "declarationDir": "./dist/types",
+    "rootDir": "./",
+    "outDir": "./dist",
     "composite": false,
     "allowSyntheticDefaultImports": true,
     "emitDeclarationOnly": false,
@@ -14,6 +14,5 @@
     "sourceMap": false,
     "incremental": false
   },
-  "rootDir": "./src",
   "include": ["./src", "./bin/", "./declarations.d.ts"]
 }


### PR DESCRIPTION
- Fixed `rootDir`, so the tsc output is no longer `<outDir>/packages/cli/...`
- Set output of type declarations to be the same as the ESM build, so we no longer require a separate `"types"` field in `package.json`
   
   <img src="https://github.com/user-attachments/assets/60266c2e-c910-4e0c-bbbf-b871a2bc85c8" alt="Resulting folder structure" width="400px"/>
