### PR TITLE
fix(Modal): expose event in onClose

### DIFF
--- a/.changeset/old-sheep-dress.md
+++ b/.changeset/old-sheep-dress.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+Modal: Expose native close event object to onClose callback

--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -21,7 +21,7 @@ export type ModalProps = {
   /**
    * Callback that is called when the modal is closed.
    */
-  onClose?: () => void;
+  onClose?: (event: Event) => void;
   asChild?: boolean;
 } & DialogHTMLAttributes<HTMLDialogElement>;
 
@@ -76,7 +76,7 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>(function Modal(
 
   /* handle closing */
   useEffect(() => {
-    const handleClose = () => onClose?.();
+    const handleClose = (event: Event) => onClose?.(event);
 
     modalRef.current?.addEventListener('close', handleClose);
     return () => modalRef.current?.removeEventListener('close', handleClose);


### PR DESCRIPTION
Expose native `event` in Modal `onClose` handler