### PR TITLE
fix(Alert): changes to type

### DIFF
--- a/packages/react/src/components/Alert/Alert.tsx
+++ b/packages/react/src/components/Alert/Alert.tsx
@@ -1,5 +1,5 @@
 import cl from 'clsx/lite';
-import type { HTMLAttributes } from 'react';
+import type { HTMLAttributes, ReactNode } from 'react';
 import { forwardRef } from 'react';
 import type { DefaultProps } from '../../types';
 
@@ -9,6 +9,8 @@ export type AlertProps = {
    * @default info
    */
   color?: 'info' | 'warning' | 'success' | 'danger';
+  /** Tekst eller markup for Alert-komponenten */
+  children: ReactNode;
 } & HTMLAttributes<HTMLDivElement> &
   DefaultProps;
 


### PR DESCRIPTION
Changed Alert's children type to ReactNode. Prop-list in Storybook indicated that children was of type 'string'. That is not correct. And it is somewhat confusing and not consistent that children in other components not are listed in Storybook's prop-list. Chip for example has children, but it's not listed in the prop-list.