### PR TITLE
chore: fix storybook cache vite error

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,5 +21,6 @@ export default defineConfig({
       usePolling: true,
     },
   },
+  // Temporary "fix" https://github.com/storybookjs/storybook/issues/28542
   optimizeDeps: { exclude: ['apps/storybook/node_modules/.cache/storybook'] },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,4 +21,5 @@ export default defineConfig({
       usePolling: true,
     },
   },
+  optimizeDeps: { exclude: ['apps/storybook/node_modules/.cache/storybook'] },
 });


### PR DESCRIPTION
Fix vite complaining about missing random cache files from storybook. 

<img width="1212" alt="image" src="https://github.com/user-attachments/assets/6e135cd5-88cd-4c04-a243-41a1b27baeff">
