### PR TITLE
fix: improve blog design on smaller screens

### DIFF
--- a/apps/storefront/components/MdxContent/MdxContent.module.css
+++ b/apps/storefront/components/MdxContent/MdxContent.module.css
@@ -181,3 +181,17 @@
     }
   }
 }
+
+@media screen and (max-width: 740px) {
+  .content {
+    margin-left: inherit;
+    margin-right: inherit;
+  }
+}
+@media screen and (max-width: 860px) {
+    .content video,
+    .content [data-iframe-video] {
+      width: auto;
+      margin-left: initial !important;
+    }
+}


### PR DESCRIPTION
On smaller screens the video and text may overflow outside of the screen. To
handle this add some breakpoints to contain those elements in.
