### PR TITLE
feat(cli,react): generate data-color typings based on tokens

### DIFF
--- a/.changeset/loud-dragons-build.md
+++ b/.changeset/loud-dragons-build.md
@@ -1,0 +1,6 @@
+---
+"@digdir/designsystemet-theme": minor
+"@digdir/designsystemet": minor
+---
+
+CLI: `tokens build` command now generates a `colors.d.ts` file which enables type safety for the `data-color` attribute when included in your `tsconfig.json`. The `@digdir/designsystemet-theme` package has been updated to include types for those themes.

--- a/.changeset/mean-penguins-sing.md
+++ b/.changeset/mean-penguins-sing.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": minor
+---
+
+`data-color` prop now supports type safety based on the token structure which was used to generate the theme CSS. Instructions for enabling this has been added to the README. An optional `react-types.d.ts` has also been added, which adds type hints for `data-color` and `data-size` to all HTML elements.

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ next-env.d.ts
 
 # jest/vitest test reports
 test-report.xml
+
+packages/cli/test-tokens-create
+packages/cli/test-tokens-build

--- a/README.md
+++ b/README.md
@@ -107,6 +107,67 @@ import { Button } from '@digdir/designsystemet-react';
 
 `@digdir/designsystemet-theme` and `@digdir/designsystemet-css` only needs to be imported once.
 
+### 4. Add TypeScript types for colors
+
+Because color names depend on which theme is being used, you have to add the following to your `tsconfig.json` to
+use all your colors in the components which have a `data-color` prop:
+
+#### When using `@digdir/designsystemet-theme`
+
+```jsonc
+{
+  // ...other settings
+  "compilerOptions": {
+    // ...other compilerOptions
+    "types": [
+      // ...other types
+      "@digdir/designsystemet-theme/colors.d.ts"
+      ]
+  },
+}
+```
+
+#### When using a custom theme
+The CLI `designsystemet tokens build` command will output a `colors.d.ts` file to your chosen output directory.
+In the example, replace `<your-path>` with the actual path you used when running the command.
+
+```jsonc
+{
+  // ...other settings
+  "compilerOptions": {
+    // ...other compilerOptions
+    "types": [
+      // ...other types
+      "<your-path>/colors.d.ts"
+      ]
+  },
+}
+```
+
+### 5. Add editor hints for data-color & data-size on HTML elements (optional)
+
+You may want editor hints for `data-color` and `data-size` attributes on HTML elements
+like `<span>` or `<div>`, since these attributes can affect components nested within
+these elements.
+
+This requires augmenting React's built-in types, and is therefore opt-in. If you want this,
+add the following to your `tsconfig.json`:
+
+```jsonc
+{
+  // ...other settings
+  "compilerOptions": {
+    // ...other compilerOptions
+    "types": [
+      // ...other types
+      "@digdir/designsystemet-react/react-types.d.ts"
+      ]
+  },
+}
+```
+
+
+
 ## 🫶 Contributing
 
 Learn how you can contribute to this project by reading our [Code of Conduct](./CODE_OF_CONDUCT.md) and [Contributing Guide](./CONTRIBUTING.md).

--- a/apps/_components/tsconfig.json
+++ b/apps/_components/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./tsc-build",
     "declarationDir": "./dist/types",

--- a/apps/storybook/docs-components/tsconfig.json
+++ b/apps/storybook/docs-components/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.json",
+  "extends": "../../../tsconfig.base.json",
   "include": ["declarations.d.ts", "./**/*", "*.module.css"],
   "compilerOptions": {
     "emitDeclarationOnly": false,

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -1,4 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "include": [".", "./.storybook/**/*", "../../packages/css/postcss.config.js"]
 }

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["../../packages/theme/brand/colors.d.ts"]
+  },
   "include": [".", "./.storybook/**/*", "../../packages/css/postcss.config.js"]
 }

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -16,7 +16,8 @@
       "design-tokens/**/*",
       "apps/storefront/tokens/**",
       "**/dist/**/*",
-      "packages/theme/**/*.css"
+      "packages/theme/**/*.css",
+      "**/tsconfig.*.json" // https://github.com/biomejs/biome/issues/1151
     ]
   },
   "formatter": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "chromatic": "^11.11.0",
     "copyfiles": "^2.4.1",
     "storybook-addon-pseudo-states": "^4.0.2",
+    "tsconfck": "^3.1.4",
     "typescript": "^5.5.4",
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^5.3.6",

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,2 +1,0 @@
-test-tokens-create
-test-tokens-build

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "./",
     "outDir": "./dist",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,10 +22,10 @@
     "dist/**"
   ],
   "scripts": {
-    "build": "yarn run clean && tsc -p tsconfig.build.json && rollup -c --bundleConfigAsCjs",
-    "clean": "rimraf dist && rimraf tsc-build",
+    "build": "yarn run clean && tsc -b tsconfig.lib.json --emitDeclarationOnly false && rollup -c --bundleConfigAsCjs",
+    "clean": "rimraf dist && rimraf tsc-build && rimraf --glob \"*.tsbuildinfo\"",
     "copy-css-to-build": "copyfiles -u 1 ./src/**/*.css ./tsc-build/",
-    "types": "tsc --noEmit"
+    "types": "tsc -b"
   },
   "peerDependencies": {
     "react": ">=18.3.1",
@@ -56,6 +56,7 @@
     "react-dom": "^18.3.1",
     "rimraf": "^6.0.1",
     "rollup": "^4.22.4",
+    "rollup-plugin-copy": "^3.5.0",
     "typescript": "^5.5.4"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -15,6 +15,12 @@
       "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
+    },
+    "./colors": {
+      "types": "./dist/types/colors.d.ts"
+    },
+    "./react-types.d.ts": {
+      "types": "./dist/react-types.d.ts"
     }
   },
   "sideEffects": false,

--- a/packages/react/react-types.d.ts
+++ b/packages/react/react-types.d.ts
@@ -1,0 +1,11 @@
+import type { Size } from '@digdir/designsystemet-react';
+import type { Color } from '@digdir/designsystemet-react/colors';
+
+declare global {
+  namespace React {
+    interface HTMLAttributes<T> {
+      'data-size'?: Size | (string & {});
+      'data-color'?: Color | (string & {});
+    }
+  }
+}

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -57,6 +57,9 @@ export default [
         flatten: false,
       }),
       moveFiles('./dist/tsc-build', './dist/types'),
+      copy({
+        targets: [{ src: './react-types.d.ts', dest: './dist' }],
+      }),
     ],
   },
 ];

--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -1,5 +1,7 @@
+import fs from 'node:fs';
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
+import copy from 'rollup-plugin-copy';
 import pkg from './package.json';
 
 // These are dependencies, but are not in our package.json
@@ -42,6 +44,32 @@ export default [
       },
     ],
     external: [...dependencies, ...dependenciesSubmodules],
-    plugins: [resolve(), commonjs()],
+    plugins: [
+      resolve(),
+      commonjs(),
+      copy({
+        targets: [
+          {
+            src: './tsc-build/**/*.d.ts*',
+            dest: './dist',
+          },
+        ],
+        flatten: false,
+      }),
+      moveFiles('./dist/tsc-build', './dist/types'),
+    ],
   },
 ];
+
+function moveFiles(from, to) {
+  return {
+    name: 'move-files',
+    generateBundle() {
+      const log = (msg) => console.log('\x1b[36m%s\x1b[0m', msg);
+      if (fs.existsSync(from)) {
+        log(`move: ${from} → ${to}`);
+        fs.renameSync(from, to);
+      }
+    },
+  };
+}

--- a/packages/react/src/colors.ts
+++ b/packages/react/src/colors.ts
@@ -1,5 +1,14 @@
+/**
+ * Base interface for available colors in the design system.
+ * The CLI will generate augmentations of this interface to allow
+ * type safety of custom color names.
+ */
+
+// biome-ignore lint/suspicious/noEmptyInterface: used for interface augmentation
+export interface MainAndSupportColors {}
+
 export type SeverityColors = 'info' | 'success' | 'warning' | 'danger';
 
-export type CustomColors = 'neutral' | (string & {});
+export type CustomColors = 'neutral' | keyof MainAndSupportColors;
 
 export type Color = CustomColors | SeverityColors;

--- a/packages/react/src/components/Tag/Tag.stories.tsx
+++ b/packages/react/src/components/Tag/Tag.stories.tsx
@@ -40,7 +40,7 @@ export const Sizes: StoryFn<typeof Tag> = ({ ...rest }): JSX.Element => {
   );
 };
 
-const colors: TagProps['color'][] = [
+const colors: TagProps['data-color'][] = [
   'neutral',
   'success',
   'warning',

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -9,3 +9,4 @@ export {
   getPrevFocusableValue,
   omit,
 } from './utilities';
+export type { Size } from './types';

--- a/packages/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.ts
+++ b/packages/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.ts
@@ -1,6 +1,7 @@
 import { useMergeRefs } from '@floating-ui/react';
 import { useEffect, useId, useRef, useState } from 'react';
 import type { ChangeEvent, ReactNode } from 'react';
+import type { CheckboxProps } from '../../../components';
 
 export type UseCheckboxGroupProps = {
   /**
@@ -46,7 +47,7 @@ export type UseCheckboxGroupProps = {
  * remove anything that comes from the group itself.
  */
 export type GetCheckboxProps = Omit<
-  React.InputHTMLAttributes<HTMLInputElement>,
+  CheckboxProps,
   | 'prefix'
   | 'role'
   | 'type'

--- a/packages/react/src/utilities/hooks/useDebounceCallback/useDebounceCallback.ts
+++ b/packages/react/src/utilities/hooks/useDebounceCallback/useDebounceCallback.ts
@@ -6,7 +6,7 @@ export function useDebounceCallback<T>(
   callback: DebounceFunction<T>,
   delay = 50,
 ) {
-  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const timeoutRef = useRef<number | null>(null);
 
   useEffect(() => {
     // Cleanup the previous timeout on re-render
@@ -22,7 +22,7 @@ export function useDebounceCallback<T>(
       clearTimeout(timeoutRef.current);
     }
 
-    timeoutRef.current = setTimeout(() => {
+    timeoutRef.current = window.setTimeout(() => {
       callback(...args);
     }, delay);
   };

--- a/packages/react/src/utilities/hooks/useRadioGroup/useRadioGroup.ts
+++ b/packages/react/src/utilities/hooks/useRadioGroup/useRadioGroup.ts
@@ -1,6 +1,7 @@
 import { useMergeRefs } from '@floating-ui/react';
 import { useEffect, useId, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
+import type { RadioProps } from '../../../components';
 
 export type UseRadioGroupProps = {
   /** Set disabled state of all radios */
@@ -28,7 +29,7 @@ export type UseRadioGroupProps = {
  * remove anything that comes from the group itself.
  */
 export type GetRadioProps = Omit<
-  React.InputHTMLAttributes<HTMLInputElement>,
+  RadioProps,
   | 'prefix'
   | 'role'
   | 'type'

--- a/packages/react/tsconfig.build.json
+++ b/packages/react/tsconfig.build.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "exclude": [
-    "src/**/*.stories.ts*",
-    "src/**/*.test.ts*",
-    "stories",
-    "scripts/"
-  ]
-}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,19 +1,13 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "./tsc-build",
-    "declarationDir": "./dist/types",
-    "emitDeclarationOnly": false,
-    "composite": false,
-    "allowSyntheticDefaultImports": true,
-    "noEmit": false,
-    "incremental": true
+    "noEmit": true,
+    "types": []
   },
-  "include": [
-    "./src",
-    "./stories",
-    "declarations.d.ts",
-    "../../apps/storybook/story-utils/type-extensions.d.ts"
+  "references": [
+    { "path": "./tsconfig.lib.json" },
+    { "path": "./tsconfig.stories.json" },
+    { "path": "./tsconfig.tests.json" }
   ],
-  "rootDir": "./src"
+  "files": [],
+  "include": []
 }

--- a/packages/react/tsconfig.lib.json
+++ b/packages/react/tsconfig.lib.json
@@ -8,7 +8,7 @@
     "noEmit": false,
     "emitDeclarationOnly": true,
     "incremental": true,
-    "types": ["./declarations.d.ts"]
+    "types": ["./declarations.d.ts", "./react-types.d.ts"]
   },
   "include": ["src"],
   "exclude": ["src/**/*.stories.ts*", "src/**/*.test.ts*", "stories"]

--- a/packages/react/tsconfig.lib.json
+++ b/packages/react/tsconfig.lib.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./tsc-build",
+    "allowSyntheticDefaultImports": true,
+    "composite": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "incremental": true,
+    "types": ["./declarations.d.ts"]
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.stories.ts*", "src/**/*.test.ts*", "stories"]
+}

--- a/packages/react/tsconfig.stories.json
+++ b/packages/react/tsconfig.stories.json
@@ -10,6 +10,8 @@
     "incremental": true,
     "types": [
       "./declarations.d.ts",
+      "./react-types.d.ts",
+      "../theme/brand/colors.d.ts",
       "../../apps/storybook/story-utils/type-extensions.d.ts"
     ]
   },

--- a/packages/react/tsconfig.stories.json
+++ b/packages/react/tsconfig.stories.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./",
+    "outDir": "./tsc-build",
+    "allowSyntheticDefaultImports": true,
+    "composite": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "incremental": true,
+    "types": [
+      "./declarations.d.ts",
+      "../../apps/storybook/story-utils/type-extensions.d.ts"
+    ]
+  },
+  "include": ["stories", "src/**/*.stories.ts*"],
+  "references": [{ "path": "tsconfig.lib.json" }]
+}

--- a/packages/react/tsconfig.tests.json
+++ b/packages/react/tsconfig.tests.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./tsc-build",
+    "allowSyntheticDefaultImports": true,
+    "composite": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "incremental": true,
+    "types": [
+      "@testing-library/jest-dom",
+      "vitest/globals",
+      "./declarations.d.ts"
+    ]
+  },
+  "include": ["src/**/*.test.ts*"],
+  "references": [{ "path": "tsconfig.lib.json" }]
+}

--- a/packages/react/tsconfig.tests.json
+++ b/packages/react/tsconfig.tests.json
@@ -11,7 +11,8 @@
     "types": [
       "@testing-library/jest-dom",
       "vitest/globals",
-      "./declarations.d.ts"
+      "./declarations.d.ts",
+      "./react-types.d.ts"
     ]
   },
   "include": ["src/**/*.test.ts*"],

--- a/packages/react/vitest.config.mjs
+++ b/packages/react/vitest.config.mjs
@@ -1,0 +1,23 @@
+import { resolve } from 'node:path';
+import { parse } from 'tsconfck';
+/// <reference types="vitest" />
+import { defineProject } from 'vitest/config';
+
+// Resolve the test-specific tsconfig file, including "extends".
+// This is necessary because Vitest doesn't support specifying which tsconfig to use when
+// setting esbuild options, as `test.typecheck.tsconfig` is only used for type testing
+const { tsconfig } = await parse(
+  resolve(import.meta.dirname, 'tsconfig.tests.json'),
+);
+
+export default defineProject({
+  esbuild: {
+    tsconfigRaw: JSON.stringify(tsconfig),
+  },
+  test: {
+    typecheck: { tsconfig: 'tsconfig.tests.json' },
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: '../../test/vitest.setup.ts',
+  },
+});

--- a/packages/theme/brand/colors.d.ts
+++ b/packages/theme/brand/colors.d.ts
@@ -1,0 +1,10 @@
+import type { MainAndSupportColors as BaseCustomColors } from '@digdir/designsystemet-react/colors';
+
+declare module '@digdir/designsystemet-react/colors' {
+  export interface MainAndSupportColors extends BaseCustomColors {
+    accent: never;
+    brand1: never;
+    brand2: never;
+    brand3: never;
+  }
+}

--- a/plugins/figma/tsconfig.json
+++ b/plugins/figma/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "useDefineForClassFields": true,
     "isolatedModules": false,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,7 +10,10 @@
       ],
       "@assets/*": ["apps/storybook/assets/*"],
       // Prevent imports from e.g. 'packages/react', which will not work for consumers
-      "packages/*": ["this/dir/does/not/exist/*"]
+      "packages/*": ["this/dir/does/not/exist/*"],
+      // Paths matching package.json exports section in @digdir/designsystem-react
+      "@digdir/designsystemet-react": ["packages/react/src/index.ts"],
+      "@digdir/designsystemet-react/colors": ["packages/react/src/colors.ts"]
     },
     "target": "ES2022",
     "module": "ESNext",
@@ -45,9 +48,6 @@
     "noEmit": true,
     "incremental": true,
     "isolatedModules": true,
-
-    // globals for vitest
-    "types": ["vitest/globals", "@testing-library/jest-dom"]
-  },
-  "references": [{ "path": "./tsconfig.node.json" }]
+    "types": []
+  }
 }

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -3,9 +3,6 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: ['./test/vitest.setup.ts'],
     reporters: [
       'default',
       ['junit', { suiteName: 'Unit tests', addFileAttribute: true }],

--- a/vitest.workspace.js
+++ b/vitest.workspace.js
@@ -1,3 +1,3 @@
 import { defineWorkspace } from 'vitest/config';
 
-export default defineWorkspace(['./vitest.config.mjs']);
+export default defineWorkspace(['packages/*/vitest.config.mjs']);

--- a/yarn.lock
+++ b/yarn.lock
@@ -15818,6 +15818,7 @@ __metadata:
     chromatic: "npm:^11.11.0"
     copyfiles: "npm:^2.4.1"
     storybook-addon-pseudo-states: "npm:^4.0.2"
+    tsconfck: "npm:^3.1.4"
     typescript: "npm:^5.5.4"
     typescript-plugin-css-modules: "npm:^5.1.0"
     vite: "npm:^5.3.6"
@@ -17163,6 +17164,20 @@ __metadata:
   version: 9.6.0
   resolution: "ts-toolbelt@npm:9.6.0"
   checksum: 10/2c2dea2631dbd7372a79cccc6d09a377a6ca2f319f767fd239d2e312cd1d9165a90f8c1777a047227bfdcda6aeba3addbadce88fdfc7f43caf4534d385a43c82
+  languageName: node
+  linkType: hard
+
+"tsconfck@npm:^3.1.4":
+  version: 3.1.4
+  resolution: "tsconfck@npm:3.1.4"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    tsconfck: bin/tsconfck.js
+  checksum: 10/4fb02e75ff374a82052b4800970bebe4466b5a6e7193d74e7b875cc8225acb5037fb4e7dcd4a5cd751c22129360cb13b4d5536897eae131d69c1a20fb18a99b4
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1727,6 +1727,7 @@ __metadata:
     react-dom: "npm:^18.3.1"
     rimraf: "npm:^6.0.1"
     rollup: "npm:^4.22.4"
+    rollup-plugin-copy: "npm:^3.5.0"
     typescript: "npm:^5.5.4"
   peerDependencies:
     react: ">=18.3.1"
@@ -5100,7 +5101,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/glob@npm:^7.1.3":
+"@types/fs-extra@npm:^8.0.1":
+  version: 8.1.5
+  resolution: "@types/fs-extra@npm:8.1.5"
+  dependencies:
+    "@types/node": "npm:*"
+  checksum: 10/565d9e55cd05064b3ab272b8748ed512b8fa5cddc23fd32b0d5f147f9ea3a45981577c4478b5060cae7b3d914c508bd2ea97eb84d9c1fa6f967982c892e4ab26
+  languageName: node
+  linkType: hard
+
+"@types/glob@npm:^7.1.1, @types/glob@npm:^7.1.3":
   version: 7.2.0
   resolution: "@types/glob@npm:7.2.0"
   dependencies:
@@ -7126,6 +7136,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"colorette@npm:^1.1.0":
+  version: 1.4.0
+  resolution: "colorette@npm:1.4.0"
+  checksum: 10/c8d6c8c3ef5a99acfc3dd9a68f48019f1479ec347551387e4a1762e40f69e98ce19d4dc321ffb4919d1f28a7bdc90c39d4e9a901f4c474fd2124ad93a00c0454
+  languageName: node
+  linkType: hard
+
 "colorjs.io@npm:^0.4.3":
   version: 0.4.3
   resolution: "colorjs.io@npm:0.4.3"
@@ -8956,7 +8973,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.2":
+"fast-glob@npm:^3.0.3, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.2":
   version: 3.3.2
   resolution: "fast-glob@npm:3.3.2"
   dependencies:
@@ -9642,6 +9659,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"globby@npm:10.0.1":
+  version: 10.0.1
+  resolution: "globby@npm:10.0.1"
+  dependencies:
+    "@types/glob": "npm:^7.1.1"
+    array-union: "npm:^2.1.0"
+    dir-glob: "npm:^3.0.1"
+    fast-glob: "npm:^3.0.3"
+    glob: "npm:^7.1.3"
+    ignore: "npm:^5.1.1"
+    merge2: "npm:^1.2.3"
+    slash: "npm:^3.0.0"
+  checksum: 10/ea724a820d7d4eafc5aa3882d667a7ef3505b3018652b2658185d58752f122b75d3370086e4d4a7b1bbcdf8c2e700e5709a48db189a930df37005e1b3c86c256
+  languageName: node
+  linkType: hard
+
 "globby@npm:^11.0.0, globby@npm:^11.1.0":
   version: 11.1.0
   resolution: "globby@npm:11.1.0"
@@ -10162,6 +10195,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ignore@npm:^5.1.1":
+  version: 5.3.2
+  resolution: "ignore@npm:5.3.2"
+  checksum: 10/cceb6a457000f8f6a50e1196429750d782afce5680dd878aa4221bd79972d68b3a55b4b1458fc682be978f4d3c6a249046aa0880637367216444ab7b014cfc98
+  languageName: node
+  linkType: hard
+
 "ignore@npm:^5.2.0, ignore@npm:^5.2.4":
   version: 5.2.4
   resolution: "ignore@npm:5.2.4"
@@ -10520,6 +10560,13 @@ __metadata:
   dependencies:
     isobject: "npm:^3.0.1"
   checksum: 10/2a401140cfd86cabe25214956ae2cfee6fbd8186809555cd0e84574f88de7b17abacb2e477a6a658fa54c6083ecbda1e6ae404c7720244cd198903848fca70ca
+  languageName: node
+  linkType: hard
+
+"is-plain-object@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "is-plain-object@npm:3.0.1"
+  checksum: 10/d13fe75db350d4ac669595cdfe0242ae87fcecddf2bca858d2dd443a6ed6eb1f69951fac8c2fa85b16106c6b0d7738fea86c2aca2ecee7fd61de15c1574f2cc5
   languageName: node
   linkType: hard
 
@@ -12324,7 +12371,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge2@npm:^1.3.0, merge2@npm:^1.4.1":
+"merge2@npm:^1.2.3, merge2@npm:^1.3.0, merge2@npm:^1.4.1":
   version: 1.4.1
   resolution: "merge2@npm:1.4.1"
   checksum: 10/7268db63ed5169466540b6fb947aec313200bcf6d40c5ab722c22e242f651994619bcd85601602972d3c85bd2cc45a358a4c61937e9f11a061919a1da569b0c2
@@ -15554,6 +15601,19 @@ __metadata:
   bin:
     rimraf: ./bin.js
   checksum: 10/756419f2fa99aa119c46a9fc03e09d84ecf5421a80a72d1944c5088c9e4671e77128527a900a313ed9d3fdbdd37e2ae05486cd7e9116d5812d8c31f2399d7c86
+  languageName: node
+  linkType: hard
+
+"rollup-plugin-copy@npm:^3.5.0":
+  version: 3.5.0
+  resolution: "rollup-plugin-copy@npm:3.5.0"
+  dependencies:
+    "@types/fs-extra": "npm:^8.0.1"
+    colorette: "npm:^1.1.0"
+    fs-extra: "npm:^8.1.0"
+    globby: "npm:10.0.1"
+    is-plain-object: "npm:^3.0.0"
+  checksum: 10/706ba6bd2052b95d1037f12963ff4b50749730f18aefad10544f9574aff7c035c88c5dd9ae1f0c0408cf09862e595a0ea4d68e13c2717addaea2bda3ade0d0e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Most importantly**, `data-color` now has type safety based on the token structure which is used to generate the theme CSS. Instructions for enabling this for consumers has been added. An optional `react-types.d.ts` has also been added, which adds type hints for `data-color` and `data-size` to all HTML elements.

Closes #2655 

## Other changes

### tsconfig restructuring

Restructures the React library's TypeScript config into test, stories & lib-specific configs, with a common `tsconfig.json` that just references all three. This allows individual settings, e.g. only including vitest types in the `.test.ts*` files or only allowing ALL colors in `.stories.ts*` (`tsconfig.lib.json` only allows colors that we know exist regardless the theme in use).

This gives the following structure under `packages/react`, with each sub-config defining a composite project which supports incremental compilation:
```mermaid
graph LR;
    tsconfig.json --> tsconfig.lib.json;
    tsconfig.json --> tsconfig.stories.json;
    tsconfig.json --> tsconfig.tests.json;
    tsconfig.stories.json --> tsconfig.lib.json;
    tsconfig.tests.json --> tsconfig.lib.json;
```

The updated config also fixes a weird issue with interface declaration merging which didn't work. Not sure why, but it was fixed by outputting `.js` and `.d.ts` files from `tsc` to the same directory (which is the default). This complicates the Rollup config a tiny bit, but not much.

The root `tsconfig.json` has been renamed to `tsconfig.base.json` to make it clear that it is not an actual project config, but only a base config.

### vitest workspace config

Test config specific to `@digdir/designsystemet-react` has been moved to `packages/react/vitest.config.mjs`, and the root workspace config has been updated to look for projects under `packages/*`. This is good practice in a monorepo, allowing us to have test config specific to projects, e.g. if we want to add unit tests to `cli` which don't need `jsdom`.

This was also necessary to allow vitest to resolve the correct `tsconfig.tests.json` file for the React library.