### PR TITLE
feat(cli): :triangular_flag_on_post: disable contrast color-scheme in tokens create script

### DIFF
--- a/.changeset/long-countries-check.md
+++ b/.changeset/long-countries-check.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet": patch
+---
+
+feat: Disable contrast color-scheme in tokens create script

--- a/.changeset/long-countries-check.md
+++ b/.changeset/long-countries-check.md
@@ -2,4 +2,4 @@
 "@digdir/designsystemet": patch
 ---
 
-feat: Disable contrast color-scheme in tokens create script
+Disable contrast color-scheme in tokens create script

--- a/packages/cli/src/tokens/create.ts
+++ b/packages/cli/src/tokens/create.ts
@@ -103,10 +103,10 @@ export const createTokens = (opts: CreateTokensOptions) => {
         global: generateGlobalTokens('light'),
       },
       dark: { [name]: generateThemeTokens(name, 'dark', colors), global: generateGlobalTokens('dark') },
-      contrast: {
-        [name]: generateThemeTokens(name, 'contrast', colors),
-        global: generateGlobalTokens('contrast'),
-      },
+      // contrast: {
+      //   [name]: generateThemeTokens(name, 'contrast', colors),
+      //   global: generateGlobalTokens('contrast'),
+      // },
     },
     typography: {
       primary: generateTypographyTokens(name, typography),

--- a/packages/cli/src/tokens/types.ts
+++ b/packages/cli/src/tokens/types.ts
@@ -19,7 +19,7 @@ export type Tokens = {
   colors: {
     light: ColorModeTokens;
     dark: ColorModeTokens;
-    contrast: ColorModeTokens;
+    contrast?: ColorModeTokens;
   };
   typography: {
     primary: TokensSet;

--- a/packages/cli/src/tokens/write.ts
+++ b/packages/cli/src/tokens/write.ts
@@ -77,8 +77,8 @@ export const writeTokens = async (options: WriteTokensOptions) => {
   console.log(`Themes: ${chalk.blue(themes.join(', '))}`);
 
   // Create metadata and themes json for Token Studio and build script
-  const $theme = generateThemesJson(['light', 'dark', 'contrast'], themes, colors);
-  const $metadata = generateMetadataJson(['light', 'dark', 'contrast'], themes, colors);
+  const $theme = generateThemesJson(['light', 'dark'], themes, colors);
+  const $metadata = generateMetadataJson(['light', 'dark'], themes, colors);
 
   await fs.writeFile($themesPath, stringify($theme));
   await fs.writeFile($metadataPath, stringify($metadata));
@@ -199,8 +199,8 @@ export const writeTokens = async (options: WriteTokensOptions) => {
     generateColorSchemeFile('light', 'global', tokens.colors.light.global, targetDir),
     generateColorSchemeFile('dark', themeName, tokens.colors.dark[themeName], targetDir),
     generateColorSchemeFile('dark', 'global', tokens.colors.dark.global, targetDir),
-    generateColorSchemeFile('contrast', themeName, tokens.colors.contrast[themeName], targetDir),
-    generateColorSchemeFile('contrast', 'global', tokens.colors.contrast.global, targetDir),
+    // generateColorSchemeFile('contrast', themeName, tokens.colors.contrast[themeName], targetDir),
+    // generateColorSchemeFile('contrast', 'global', tokens.colors.contrast.global, targetDir),
     generateTypographyFile('primary', themeName, tokens.typography.primary, targetDir),
     generateTypographyFile('secondary', themeName, tokens.typography.primary, targetDir),
   ];


### PR DESCRIPTION
resolves #2787

Just did the minimum to disable the design-tokens generation for contrast color-scheme. 
We need to do some renaming of types etc, that will be done in #2805 