### PR TITLE
refactor: :fire: Remove unnecessary `ds.typography` CSS layer

### DIFF
--- a/packages/css/src/index.css
+++ b/packages/css/src/index.css
@@ -4,10 +4,10 @@
 
 /** Import order defines ordinal specificity for layers */
 @import url('./base.css') layer(ds.base);
-@import url('./heading.css') layer(ds.components);
-@import url('./label.css') layer(ds.components);
-@import url('./paragraph.css') layer(ds.components);
-@import url('./validation-message.css') layer(ds.components);
+@import url('./heading.css') layer(ds.base);
+@import url('./label.css') layer(ds.base);
+@import url('./paragraph.css') layer(ds.base);
+@import url('./validation-message.css') layer(ds.base);
 @import url('./button.css') layer(ds.components);
 @import url('./field.css') layer(ds.components);
 @import url('./input.css') layer(ds.components);

--- a/packages/css/src/index.css
+++ b/packages/css/src/index.css
@@ -1,13 +1,13 @@
 @charset 'UTF-8';
 
-@layer ds.base, ds.typography, ds.theme, ds.components;
+@layer ds.base, ds.theme, ds.components;
 
 /** Import order defines ordinal specificity for layers */
 @import url('./base.css') layer(ds.base);
-@import url('./heading.css') layer(ds.typography);
-@import url('./label.css') layer(ds.typography);
-@import url('./paragraph.css') layer(ds.typography);
-@import url('./validation-message.css') layer(ds.typography);
+@import url('./heading.css') layer(ds.components);
+@import url('./label.css') layer(ds.components);
+@import url('./paragraph.css') layer(ds.components);
+@import url('./validation-message.css') layer(ds.components);
 @import url('./button.css') layer(ds.components);
 @import url('./field.css') layer(ds.components);
 @import url('./input.css') layer(ds.components);


### PR DESCRIPTION
Remove unnecessary `ds.typography` CSS layer now that they just reflect the component. Reduce complexity and avoid confusion with `ds.theme.typography`