### PR TITLE
chore: add missing changeset for `Details` rename

### DIFF
--- a/.changeset/silver-penguins-occur.md
+++ b/.changeset/silver-penguins-occur.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+Rename `Accordion` to `Details`

--- a/.changeset/silver-penguins-occur.md
+++ b/.changeset/silver-penguins-occur.md
@@ -1,5 +1,6 @@
 ---
 "@digdir/designsystemet-react": patch
+"@digdir/designsystemet-css": patch
 ---
 
 Rename `Accordion` to `Details`

--- a/packages/react/src/components/Details/Details.mdx
+++ b/packages/react/src/components/Details/Details.mdx
@@ -25,12 +25,24 @@ Med `Details` kan du presentere mye innhold på liten plass i en eller flere rad
 ## Bruk
 
 ```tsx
+/* Uten ramme */
 import { Details } from '@digdir/designsystemet-react';
 
 <Details>
   <Details.Summary>Details heading text</Details.Summary>
   <Details.Content>Details content</Details.Content>
 </Details>
+
+/* Med ramme */
+
+import { Details, Card } from '@digdir/designsystemet-react';
+
+<Card>
+  <Details>
+    <Details.Summary>Details heading text</Details.Summary>
+    <Details.Content>Details content</Details.Content>
+  </Details>
+</Card>
 ```
 
 ## Eksempler

--- a/packages/react/src/components/form/Fieldset/Fieldset.stories.tsx
+++ b/packages/react/src/components/form/Fieldset/Fieldset.stories.tsx
@@ -1,6 +1,13 @@
 import type { Meta, StoryFn } from '@storybook/react';
 
-import { Field, Fieldset, Input, Label, Textarea } from '../..';
+import {
+  Field,
+  Fieldset,
+  Input,
+  Label,
+  Textarea,
+  ValidationMessage,
+} from '../..';
 
 type Story = StoryFn<typeof Fieldset>;
 
@@ -19,6 +26,7 @@ export const Preview: Story = (args) => (
       <Field>
         <Label>Kort beskrivelse</Label>
         <Input />
+        <ValidationMessage>Feilmelding</ValidationMessage>
       </Field>
       <Field>
         <Label>Lang beskrivelse</Label>

--- a/packages/react/src/components/form/Fieldset/Fieldset.stories.tsx
+++ b/packages/react/src/components/form/Fieldset/Fieldset.stories.tsx
@@ -1,13 +1,6 @@
 import type { Meta, StoryFn } from '@storybook/react';
 
-import {
-  Field,
-  Fieldset,
-  Input,
-  Label,
-  Textarea,
-  ValidationMessage,
-} from '../..';
+import { Field, Fieldset, Input, Label, Textarea } from '../..';
 
 type Story = StoryFn<typeof Fieldset>;
 
@@ -26,7 +19,6 @@ export const Preview: Story = (args) => (
       <Field>
         <Label>Kort beskrivelse</Label>
         <Input />
-        <ValidationMessage>Feilmelding</ValidationMessage>
       </Field>
       <Field>
         <Label>Lang beskrivelse</Label>


### PR DESCRIPTION
We forgot to add a changeset in #2824, this PR adds one.