### PR TITLE
fix(React): use package type module

### DIFF
--- a/.changeset/ninety-jeans-punch.md
+++ b/.changeset/ninety-jeans-punch.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+React: Set `"type": "module"` in `package.json`

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@digdir/designsystemet-react",
+  "type": "module",
   "version": "1.0.0-next.39",
   "description": "React components for Designsystemet",
   "author": "Designsystemet team",


### PR DESCRIPTION
- Set `"type": "module"` in React package to indicate we are building with modern ESM features