### PR TITLE
fix(figma-plugin): update color regex

### DIFF
--- a/plugins/figma/manifest.json
+++ b/plugins/figma/manifest.json
@@ -8,5 +8,11 @@
   "enableProposedApi": false,
   "editorType": ["figma"],
   "documentAccess": "dynamic-page",
-  "networkAccess": { "allowedDomains": ["https://api.github.com"] }
+  "networkAccess": {
+    "allowedDomains": [
+      "https://api.github.com",
+      "https://fonts.googleapis.com",
+      "https://fonts.gstatic.com"
+    ]
+  }
 }

--- a/plugins/figma/manifest.json
+++ b/plugins/figma/manifest.json
@@ -9,10 +9,6 @@
   "editorType": ["figma"],
   "documentAccess": "dynamic-page",
   "networkAccess": {
-    "allowedDomains": [
-      "https://api.github.com",
-      "https://fonts.googleapis.com",
-      "https://fonts.gstatic.com"
-    ]
+    "allowedDomains": ["https://api.github.com", "https://altinncdn.no"]
   }
 }

--- a/plugins/figma/package.json
+++ b/plugins/figma/package.json
@@ -1,7 +1,7 @@
 {
   "name": "figma-plugin",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "scripts": {
     "dev": "run-s watch",

--- a/plugins/figma/src/plugin/figma/themes.ts
+++ b/plugins/figma/src/plugin/figma/themes.ts
@@ -5,13 +5,13 @@ import type { StoreThemes } from '../../common/store';
 export const getThemes = async () => {
   const collections = await figma.variables.getLocalVariableCollectionsAsync();
   const modeColModes = collections.find(
-    (collection) => collection.name === 'Mode',
+    (collection) => collection.name === 'Color scheme',
   )?.modes;
   const themeModes = collections.find(
     (collection) => collection.name === 'Theme',
   )?.modes;
   const modeColId = collections.find(
-    (collection) => collection.name === 'Mode',
+    (collection) => collection.name === 'Color scheme',
   )?.id;
 
   const variables = await figma.variables.getLocalVariablesAsync('COLOR');

--- a/plugins/figma/src/plugin/figma/updateVariables.ts
+++ b/plugins/figma/src/plugin/figma/updateVariables.ts
@@ -62,7 +62,7 @@ const updateColors = (
 
 export const updateVariables = async (themes: StoreThemes) => {
   const collections = await figma.variables.getLocalVariableCollectionsAsync();
-  const modeCollection = collections.find((col) => col.name === 'Mode');
+  const modeCollection = collections.find((col) => col.name === 'Color scheme');
   const themeCollection = collections.find((col) => col.name === 'Theme');
 
   console.log('themes', themes);

--- a/plugins/figma/src/ui/App.css
+++ b/plugins/figma/src/ui/App.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap');
-
 * {
   font-feature-settings: 'cv05' 1;
   box-sizing: border-box;

--- a/plugins/figma/src/ui/index.html
+++ b/plugins/figma/src/ui/index.html
@@ -1,5 +1,17 @@
-<div id="root"></div>
-<script
-  type="module"
-  src="./main.tsx"
-></script>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <link
+      rel="stylesheet"
+      href="https://altinncdn.no/fonts/inter/inter.css"
+    />
+  </head>
+
+  <body>
+    <div id="root"></div>
+    <script
+      type="module"
+      src="./main.tsx"
+    ></script>
+  </body>
+</html>

--- a/plugins/figma/src/ui/pages/Theme/Theme.tsx
+++ b/plugins/figma/src/ui/pages/Theme/Theme.tsx
@@ -103,7 +103,7 @@ function Theme() {
 
     if (!accent || !brand1 || !brand2 || !brand3) {
       setCodeSnippetError(
-        'Koden du limte inn er ikke gyldig. Prøv å lim inn på nytt.',
+        'I denne versjonen av pluginen må du ha fargene accent, brand1, brand2 og brand3',
       );
       return;
     }


### PR DESCRIPTION
this updates the currently broken color regex, and adds future support for multiple colors in `main-colors` and `support-colors`.
Currently it just checks that we have accent and brandX - to match the "current" functionality