### PR TITLE
chore(Modal): make button always `neutral`

### DIFF
--- a/packages/react/src/components/Modal/Modal.tsx
+++ b/packages/react/src/components/Modal/Modal.tsx
@@ -94,7 +94,7 @@ export const Modal = forwardRef<HTMLDialogElement, ModalProps>(function Modal(
           <Button
             aria-label={closeButton}
             autoFocus
-            color='neutral'
+            data-color='neutral'
             icon
             name='close'
             type='submit'


### PR DESCRIPTION
this button should always be neutral and not follow data-color inheritance