### PR TITLE
fix(Input): readonly toggles as disabled

### DIFF
--- a/.changeset/green-jokes-battle.md
+++ b/.changeset/green-jokes-battle.md
@@ -1,0 +1,6 @@
+---
+"@digdir/designsystemet-css": patch
+"@digdir/designsystemet-react": patch
+---
+
+Input: Setting `readonly` also sets `disabled` for radio and checkbox

--- a/.changeset/little-shoes-rest.md
+++ b/.changeset/little-shoes-rest.md
@@ -1,0 +1,6 @@
+---
+"@digdir/designsystemet-css": patch
+"@digdir/designsystemet-react": patch
+---
+
+Select: Setting `readonly` also sets `disabled`

--- a/packages/css/src/field.css
+++ b/packages/css/src/field.css
@@ -11,7 +11,7 @@
   /**
    * States
    */
-  &:has(:is(:disabled, [aria-disabled='true']):not(label, [readonly])) > * {
+  &:has(.ds-input:is(:disabled, [aria-disabled='true']):not([readonly])) > * {
     cursor: not-allowed;
     opacity: var(--ds-disabled-opacity);
   }

--- a/packages/css/src/field.css
+++ b/packages/css/src/field.css
@@ -11,7 +11,7 @@
   /**
    * States
    */
-  &:has([aria-disabled='true'], :disabled) > * {
+  &:has(:is(:disabled, [aria-disabled='true']):not(label, [readonly])) > * {
     cursor: not-allowed;
     opacity: var(--ds-disabled-opacity);
   }

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -91,8 +91,8 @@
     --dsc-input-color: var(--dsc-input-color--checked);
   }
 
-  &:disabled,
-  &[aria-disabled='true'] {
+  /* Only style when not readonly, allowing combining readonly and disabled for checkbox and radio inputs */
+  &:is(:disabled, [aria-disabled='true']):not([readonly]) {
     cursor: not-allowed;
     opacity: var(--ds-disabled-opacity);
   }

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -108,6 +108,7 @@
     --dsc-input-background: var(--dsc-input-background--readonly);
     --dsc-input-border-color: var(--dsc-input-border-color--readonly);
     --dsc-input-color: var(--dsc-input-color--readonly);
+    opacity: 1; /* Overwrite Chrome user agent CSS `select:disabled { opacity: 0.7 }` */
   }
 
   /**

--- a/packages/react/src/components/form/Input/Input.tsx
+++ b/packages/react/src/components/form/Input/Input.tsx
@@ -39,19 +39,17 @@ export type InputProps = MergeRight<
  * ```
  */
 export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
-  { type = 'text', className, onChange, onClick, ...rest },
+  { type = 'text', className, ...rest },
   ref,
 ) {
+  const isToggle = type === 'checkbox' || type === 'radio';
+
   return (
     <input
       className={cl(`ds-input`, className)}
+      disabled={rest.disabled || (isToggle && rest.readOnly)}
       ref={ref}
       type={type}
-      onChange={(event) => rest.readOnly || onChange?.(event)} // Make readonly work for checkbox / radio / switch
-      onClick={(event) => {
-        if (rest.readOnly) event.preventDefault(); // Make readonly work for checkbox / radio / switch
-        onClick?.(event);
-      }}
       {...rest}
     />
   );

--- a/packages/react/src/components/form/Input/Input.tsx
+++ b/packages/react/src/components/form/Input/Input.tsx
@@ -39,7 +39,7 @@ export type InputProps = MergeRight<
  * ```
  */
 export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
-  { type = 'text', className, ...rest },
+  { type = 'text', className, disabled, ...rest },
   ref,
 ) {
   const isToggle = type === 'checkbox' || type === 'radio';
@@ -47,7 +47,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
   return (
     <input
       className={cl(`ds-input`, className)}
-      disabled={rest.disabled || (isToggle && rest.readOnly)}
+      disabled={disabled || (isToggle && rest.readOnly)}
       ref={ref}
       type={type}
       {...rest}

--- a/packages/react/src/components/form/Select/Select.stories.tsx
+++ b/packages/react/src/components/form/Select/Select.stories.tsx
@@ -55,6 +55,27 @@ Disabled.args = {
   disabled: true,
 };
 
+export const ReadOnly: StoryFn<typeof Select> = (args) => (
+  <Field>
+    <Label>Velg et fjell</Label>
+    <Select {...args}>
+      <Select.Option value='blank'>Velg &hellip;</Select.Option>
+      <Select.Option value='everest'>Mount Everest</Select.Option>
+      <Select.Option value='aconcagua'>Aconcagua</Select.Option>
+      <Select.Option value='denali'>Denali</Select.Option>
+      <Select.Option value='kilimanjaro'>Kilimanjaro</Select.Option>
+      <Select.Option value='elbrus'>Elbrus</Select.Option>
+      <Select.Option value='vinson'>Mount Vinson</Select.Option>
+      <Select.Option value='puncakjaya'>Puncak Jaya</Select.Option>
+      <Select.Option value='kosciuszko'>Mount Kosciuszko</Select.Option>
+    </Select>
+  </Field>
+);
+
+ReadOnly.args = {
+  readOnly: true,
+};
+
 export const WithError: StoryFn<typeof Select> = (args) => (
   <Field>
     <Label>Velg et fjell</Label>

--- a/packages/react/src/components/form/Select/Select.tsx
+++ b/packages/react/src/components/form/Select/Select.tsx
@@ -19,20 +19,12 @@ export type SelectProps = MergeRight<
 >;
 
 export const Select = forwardRef<HTMLSelectElement, SelectProps>(
-  function Select({ className, onKeyDown, onMouseDown, ...rest }, ref) {
+  function Select({ className, ...rest }, ref) {
     return (
       <select
         className={cl('ds-input', className)}
+        disabled={rest.disabled || rest.readOnly}
         ref={ref}
-        onKeyDown={(event) => {
-          if (event.key === 'Tab') return;
-          if (rest.readOnly) event.preventDefault(); // Make readonly work for select
-          onKeyDown?.(event);
-        }}
-        onMouseDown={(event) => {
-          if (rest.readOnly) event.preventDefault(); // Make readonly work for select
-          onMouseDown?.(event);
-        }}
         {...rest}
       />
     );

--- a/packages/react/src/components/form/Select/Select.tsx
+++ b/packages/react/src/components/form/Select/Select.tsx
@@ -19,11 +19,11 @@ export type SelectProps = MergeRight<
 >;
 
 export const Select = forwardRef<HTMLSelectElement, SelectProps>(
-  function Select({ className, ...rest }, ref) {
+  function Select({ className, disabled, ...rest }, ref) {
     return (
       <select
         className={cl('ds-input', className)}
-        disabled={rest.disabled || rest.readOnly}
+        disabled={disabled || rest.readOnly}
         ref={ref}
         {...rest}
       />


### PR DESCRIPTION
- Not all input types natively supports `readonly`
- Today, we attach javascript event listeners to emulate `readonly` for `checkbox`, `radio` and `select`
- This makes it harder to replicate when moving Designsystemet to pure HTML, or other JS-frameworks
- Instead of adding event listeners, we can combine `readonly` with `disabled`, and make sure the `disabled`-styling is only activated when not reaonly
- This fixes so text of inputs still can be selected, but appear to be `readonly` without any need for extra JS