### PR TITLE
fix(ValidationMessage): use data-color instead of data-error

### DIFF
--- a/packages/css/src/validation-message.css
+++ b/packages/css/src/validation-message.css
@@ -7,7 +7,7 @@
   position: relative;
 
   /* Only render error icon if the ValidationMessage actually contains an error message */
-  &[data-error]:not(:empty) {
+  &:not([data-color='success']):not(:empty) {
     color: var(--ds-color-danger-text-subtle);
     padding-inline-start: calc(var(--dsc-validation-message-icon-size) + var(--dsc-validation-message-gap));
 

--- a/packages/react/src/components/ValidationMessage/ValidationMessage.tsx
+++ b/packages/react/src/components/ValidationMessage/ValidationMessage.tsx
@@ -8,8 +8,11 @@ import type { MergeRight } from '../../utilities';
 export type ValidationMessageProps = MergeRight<
   Omit<DefaultProps, 'data-color'> & HTMLAttributes<HTMLParagraphElement>,
   {
-    /** Toggle error color */
-    error?: boolean;
+    /**
+     * Sets color and icon.
+     * @default 'danger'
+     */
+    'data-color'?: 'danger' | 'success';
     /**
      * Change the default rendered element for the one passed as a child, merging their props and behavior.
      * @default false
@@ -22,16 +25,12 @@ export type ValidationMessageProps = MergeRight<
 export const ValidationMessage = forwardRef<
   HTMLParagraphElement,
   ValidationMessageProps
->(function ValidationMessage(
-  { className, asChild, error = true, ...rest },
-  ref,
-) {
+>(function ValidationMessage({ className, asChild, ...rest }, ref) {
   const Component = asChild ? Slot : 'div';
 
   return (
     <Component
       className={cl('ds-validation-message', className)}
-      data-error={error || undefined}
       data-field='validation'
       ref={ref}
       {...rest}


### PR DESCRIPTION
- Use `data-color` instead of `data-error`
- Set `danger` as default through CSS so it is easier to use in HTML/other frameworks
- Fixes https://designsystemet.slack.com/archives/C07K7NEKXEW/p1733217765654359