### PR TITLE
fix(theme): skip link should link to main content

### DIFF
--- a/apps/theme/app/page.tsx
+++ b/apps/theme/app/page.tsx
@@ -162,7 +162,7 @@ export default function Home() {
         colorModalRef={colorModalRef}
       />
 
-      <main className={classes.main}>
+      <main className={classes.main} id='main'>
         <Container>
           <div className={classes.header}>
             <Paragraph data-size='lg'>Designsystemet sin temabygger</Paragraph>


### PR DESCRIPTION
If the id is not set or does not match what the SkipLink component uses then the
"skip to content" link does not work. Adding it is a quick fix and makes the
site easier to use for keyboard users.
