### PR TITLE
fix: :bug: Fix missing selector on "default" color

### DIFF
--- a/packages/cli/src/tokens/build.ts
+++ b/packages/cli/src/tokens/build.ts
@@ -69,10 +69,13 @@ const buildConfigs = {
   },
 } satisfies Record<string, BuildConfig>;
 
-export async function buildTokens(buildOptions: Options): Promise<void> {
-  const { dry } = buildOptions;
-  const tokensDir = buildOptions.tokens;
-  const targetDir = path.resolve(buildOptions.outDir);
+export async function buildTokens(options: Options): Promise<void> {
+  const { dry } = options;
+  const tokensDir = options.tokens;
+  const targetDir = path.resolve(options.outDir);
+
+  /** For sharing build options in other files */
+  buildOptions = options;
 
   /*
    * Build the themes


### PR DESCRIPTION
Found a bug when building that first color did not get `:root, [data-color-scheme],` selector. This was due to `buildOptions` not being defined. 

Fixing this for now, but we should rewrite this to avoid hidden globals. All functions should be pure functions, so that its clear for maintaners where dependencies/parameters come from and avoid side-effects.