### PR TITLE
chore: rename & conform color types

### DIFF
--- a/apps/theme/app/page.tsx
+++ b/apps/theme/app/page.tsx
@@ -4,7 +4,7 @@ import type { CssColor } from '@adobe/leonardo-contrast-colors';
 import { Button, Heading, Paragraph } from '@digdir/designsystemet-react';
 import type {
   ColorInfo,
-  ColorMode,
+  ColorScheme,
   ContrastMode,
   ThemeInfo,
 } from '@digdir/designsystemet/color';
@@ -110,7 +110,7 @@ export default function Home() {
     contrastMode,
   }: {
     colors?: ThemeInfo;
-    theme?: ColorMode;
+    theme?: ColorScheme;
     borderRadius?: string;
     contrastMode?: ContrastMode;
   }) => {

--- a/apps/theme/app/test/page.tsx
+++ b/apps/theme/app/test/page.tsx
@@ -3,16 +3,16 @@ import { Container } from '@repo/components';
 
 import {
   type ThemeInfo,
-  generateThemeForColor,
+  generateColorSchemes,
 } from '@digdir/designsystemet/color';
 import classes from './page.module.css';
 
 export default function Home() {
-  const oldAccentTheme = generateThemeForColor('#0062BA');
-  const oldNeutralTheme = generateThemeForColor('#1E2B3C');
-  const oldBrand1Theme = generateThemeForColor('#F45F63');
-  const oldBrand2Theme = generateThemeForColor('#E5AA20');
-  const oldBrand3Theme = generateThemeForColor('#1E98F5');
+  const oldAccentTheme = generateColorSchemes('#0062BA');
+  const oldNeutralTheme = generateColorSchemes('#1E2B3C');
+  const oldBrand1Theme = generateColorSchemes('#F45F63');
+  const oldBrand2Theme = generateColorSchemes('#E5AA20');
+  const oldBrand3Theme = generateColorSchemes('#1E98F5');
 
   type RowType = {
     oldTheme: ThemeInfo;

--- a/apps/theme/app/testside/page.tsx
+++ b/apps/theme/app/testside/page.tsx
@@ -2,7 +2,7 @@
 
 import { Heading } from '@digdir/designsystemet-react';
 import type { ColorInfo, CssColor } from '@digdir/designsystemet/color';
-import { generateThemeForColor } from '@digdir/designsystemet/color';
+import { generateColorSchemes } from '@digdir/designsystemet/color';
 import { Container } from '@repo/components';
 import cl from 'clsx/lite';
 
@@ -106,25 +106,25 @@ const Row = (title: string, colors: ColorInfo[], whiteText = false) => {
 };
 
 export default function Dev() {
-  const theme1 = generateThemeForColor('#0062BA');
-  const theme2 = generateThemeForColor('#1E98F5');
-  const theme3 = generateThemeForColor('#E5AA20');
-  const theme4 = generateThemeForColor('#f3e02e');
-  const theme5 = generateThemeForColor('#DE251B');
-  const theme6 = generateThemeForColor('#F45F63');
-  const theme7 = generateThemeForColor('#054449');
-  const theme8 = generateThemeForColor('#7befb2');
-  const theme9 = generateThemeForColor('#410464');
-  const theme10 = generateThemeForColor('#A845E1');
-  const theme11 = generateThemeForColor('#109E96');
-  const theme12 = generateThemeForColor('#243142');
+  const theme1 = generateColorSchemes('#0062BA');
+  const theme2 = generateColorSchemes('#1E98F5');
+  const theme3 = generateColorSchemes('#E5AA20');
+  const theme4 = generateColorSchemes('#f3e02e');
+  const theme5 = generateColorSchemes('#DE251B');
+  const theme6 = generateColorSchemes('#F45F63');
+  const theme7 = generateColorSchemes('#054449');
+  const theme8 = generateColorSchemes('#7befb2');
+  const theme9 = generateColorSchemes('#410464');
+  const theme10 = generateColorSchemes('#A845E1');
+  const theme11 = generateColorSchemes('#109E96');
+  const theme12 = generateColorSchemes('#243142');
 
-  const themeGlobalBlue = generateThemeForColor(Settings.blueBaseColor);
-  const themeGlobalGreen = generateThemeForColor(Settings.greenBaseColor);
-  const themeGlobalOrange = generateThemeForColor(Settings.orangeBaseColor);
-  const themeGlobalRed = generateThemeForColor(Settings.redBaseColor);
-  const themeGlobalPurple = generateThemeForColor(Settings.purpleBaseColor);
-  const themeGlobalYellow = generateThemeForColor(Settings.yellowBaseColor);
+  const themeGlobalBlue = generateColorSchemes(Settings.blueBaseColor);
+  const themeGlobalGreen = generateColorSchemes(Settings.greenBaseColor);
+  const themeGlobalOrange = generateColorSchemes(Settings.orangeBaseColor);
+  const themeGlobalRed = generateColorSchemes(Settings.redBaseColor);
+  const themeGlobalPurple = generateColorSchemes(Settings.purpleBaseColor);
+  const themeGlobalYellow = generateColorSchemes(Settings.yellowBaseColor);
 
   return (
     <div className={classes.page}>

--- a/apps/theme/app/themebuilder/_utils/useThemeParams.tsx
+++ b/apps/theme/app/themebuilder/_utils/useThemeParams.tsx
@@ -1,7 +1,7 @@
 import {
   type ColorScheme,
   type CssColor,
-  generateThemeForColor,
+  generateColorSchemes,
 } from '@digdir/designsystemet/color';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
@@ -47,7 +47,7 @@ export const useThemeParams = () => {
         newColors.neutral = [
           {
             name: 'neutral',
-            colors: generateThemeForColor(neutralColor as CssColor),
+            colors: generateColorSchemes(neutralColor as CssColor),
           },
         ];
     }
@@ -96,6 +96,6 @@ export const useThemeParams = () => {
 function createColorsFromQuery(colors: string) {
   return colors.split(' ').map((color) => {
     const [name, hex] = color.split(':');
-    return { name, colors: generateThemeForColor(hex as CssColor) };
+    return { name, colors: generateColorSchemes(hex as CssColor) };
   });
 }

--- a/apps/theme/app/themebuilder/_utils/useThemeParams.tsx
+++ b/apps/theme/app/themebuilder/_utils/useThemeParams.tsx
@@ -1,5 +1,5 @@
 import {
-  type ColorMode,
+  type ColorScheme,
   type CssColor,
   generateThemeForColor,
 } from '@digdir/designsystemet/color';
@@ -26,7 +26,7 @@ export const useThemeParams = () => {
 
     if (query.get('appearance')) {
       useThemeStore.setState({
-        appearance: query.get('appearance') as ColorMode,
+        appearance: query.get('appearance') as ColorScheme,
       });
     }
 

--- a/apps/theme/app/themebuilder/page.tsx
+++ b/apps/theme/app/themebuilder/page.tsx
@@ -85,7 +85,7 @@ export default function Home() {
               <div className={classes.panelToggle}>
                 <div>
                   <div className={classes.colorsContainer}>
-                    <Colors  />
+                    <Colors />
                   </div>
                 </div>
 

--- a/apps/theme/app/themebuilder/page.tsx
+++ b/apps/theme/app/themebuilder/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { ColorMode } from '@digdir/designsystemet';
+import type { ColorScheme } from '@digdir/designsystemet';
 import { Heading } from '@digdir/designsystemet-react';
 
 import { useRouter } from 'next/navigation';
@@ -72,7 +72,7 @@ export default function Home() {
                   ]}
                   onChange={(value) => {
                     const val = value;
-                    setAppearance(val as ColorMode);
+                    setAppearance(val as ColorScheme);
                   }}
                 />
               </div>
@@ -85,7 +85,7 @@ export default function Home() {
               <div className={classes.panelToggle}>
                 <div>
                   <div className={classes.colorsContainer}>
-                    <Colors themeMode='light' />
+                    <Colors  />
                   </div>
                 </div>
 

--- a/apps/theme/components/ColorContrasts/ColorContrasts.tsx
+++ b/apps/theme/components/ColorContrasts/ColorContrasts.tsx
@@ -1,6 +1,6 @@
 import {
   type ColorInfo,
-  generateThemeForColor,
+  generateColorSchemes,
   getColorNameFromNumber,
   getContrastFromHex,
 } from '@digdir/designsystemet';
@@ -16,7 +16,7 @@ import { useThemeStore } from '../../store';
 import classes from './ColorContrasts.module.css';
 
 export const ColorContrasts = () => {
-  const theme = generateThemeForColor('#0062BA');
+  const theme = generateColorSchemes('#0062BA');
   const indexOne = [1, 2, 3, 4, 5];
   const indexTwo = [6, 7, 8, 12, 13];
   const [reducedLight, setReducedLight] = useState({

--- a/apps/theme/components/Colors/Colors.tsx
+++ b/apps/theme/components/Colors/Colors.tsx
@@ -1,14 +1,12 @@
-import type { ColorMode } from '@digdir/designsystemet/color';
+
 
 import { useThemeStore } from '../../store';
 import { Scale } from '../Scale/Scale';
 import classes from './Colors.module.css';
 
-type ScalesProps = {
-  themeMode: ColorMode;
-};
 
-export const Colors = ({ themeMode }: ScalesProps) => {
+
+export const Colors = () => {
   const colors = useThemeStore((state) => state.colors);
   return (
     <div className={classes.rows}>
@@ -19,7 +17,6 @@ export const Colors = ({ themeMode }: ScalesProps) => {
             colorScale={color.colors}
             showHeader={index === 0}
             showColorMeta={false}
-            themeMode={themeMode}
           />
         </div>
       ))}
@@ -30,7 +27,6 @@ export const Colors = ({ themeMode }: ScalesProps) => {
           <Scale
             colorScale={color.colors}
             showColorMeta={false}
-            themeMode={themeMode}
           />
         </div>
       ))}
@@ -41,7 +37,6 @@ export const Colors = ({ themeMode }: ScalesProps) => {
           <Scale
             colorScale={color.colors}
             showColorMeta={false}
-            themeMode={themeMode}
           />
         </div>
       ))}

--- a/apps/theme/components/Colors/Colors.tsx
+++ b/apps/theme/components/Colors/Colors.tsx
@@ -1,10 +1,6 @@
-
-
 import { useThemeStore } from '../../store';
 import { Scale } from '../Scale/Scale';
 import classes from './Colors.module.css';
-
-
 
 export const Colors = () => {
   const colors = useThemeStore((state) => state.colors);
@@ -24,20 +20,14 @@ export const Colors = () => {
       {colors.neutral.map((color, index) => (
         <div key={index} className={classes.row}>
           <div className={classes.scaleLabel}>{color.name}</div>
-          <Scale
-            colorScale={color.colors}
-            showColorMeta={false}
-          />
+          <Scale colorScale={color.colors} showColorMeta={false} />
         </div>
       ))}
       <div className={classes.separator}></div>
       {colors.support.map((color, index) => (
         <div key={index} className={classes.row}>
           <div className={classes.scaleLabel}>{color.name}</div>
-          <Scale
-            colorScale={color.colors}
-            showColorMeta={false}
-          />
+          <Scale colorScale={color.colors} showColorMeta={false} />
         </div>
       ))}
     </div>

--- a/apps/theme/components/ContrastChart/ContrastChart.tsx
+++ b/apps/theme/components/ContrastChart/ContrastChart.tsx
@@ -1,6 +1,6 @@
 import {
   type ColorInfo,
-  generateThemeForColor,
+  generateColorSchemes,
   getColorNameFromNumber,
   getContrastFromHex,
 } from '@digdir/designsystemet';
@@ -13,7 +13,7 @@ type ContrastChartProps = {
 };
 
 export const ContrastChart = ({ type = 'light' }: ContrastChartProps) => {
-  const theme = generateThemeForColor('#0062BA');
+  const theme = generateColorSchemes('#0062BA');
   const includedColorIndexes = [1, 2, 3, 4, 5, 6, 7, 8, 12, 13];
   const reducedLight = theme.light.filter((color) =>
     includedColorIndexes.includes(color.number),

--- a/apps/theme/components/Scale/Scale.tsx
+++ b/apps/theme/components/Scale/Scale.tsx
@@ -1,6 +1,5 @@
 import { RovingFocusRoot } from '@digdir/designsystemet-react';
 import type { ThemeInfo } from '@digdir/designsystemet/color';
-import type { modeType } from '../../types';
 import { Group } from '../Group/Group';
 
 import classes from './Scale.module.css';
@@ -9,14 +8,12 @@ type ScaleProps = {
   colorScale: ThemeInfo;
   showHeader?: boolean;
   showColorMeta?: boolean;
-  themeMode: modeType;
 };
 
 export const Scale = ({
   colorScale,
   showHeader,
   showColorMeta,
-  themeMode,
 }: ScaleProps) => {
   return (
     <div className={classes.themes}>

--- a/apps/theme/components/Sidebar/ColorPage/ColorPage.tsx
+++ b/apps/theme/components/Sidebar/ColorPage/ColorPage.tsx
@@ -1,4 +1,4 @@
-import { generateThemeForColor } from '@digdir/designsystemet';
+import { generateColorSchemes } from '@digdir/designsystemet';
 import { Button, Heading, Paragraph } from '@digdir/designsystemet-react';
 import type { CssColor } from '@digdir/designsystemet/color';
 import { PlusIcon } from '@navikt/aksel-icons';
@@ -30,12 +30,12 @@ export const ColorPage = ({ onPrevClick, onNextClick }: ColorPageProps) => {
   const [open, setOpen] = useState(false);
 
   const addNewColor = (color: string, name: string) => {
-    const theme = generateThemeForColor(color as CssColor);
+    const theme = generateColorSchemes(color as CssColor);
     addColor({ name: name, colors: theme }, colorType);
   };
 
   const updateExistingColor = (color: string, name: string) => {
-    const theme = generateThemeForColor(color as CssColor);
+    const theme = generateColorSchemes(color as CssColor);
     updateColor({ name: name, colors: theme }, index, colorType);
   };
 

--- a/apps/theme/store.ts
+++ b/apps/theme/store.ts
@@ -1,6 +1,6 @@
 import {
   type ColorInfo,
-  type ColorMode,
+  type ColorScheme,
   type ThemeInfo,
   generateThemeForColor,
 } from '@digdir/designsystemet/color';
@@ -40,8 +40,8 @@ type ColorStore = {
   setSelectedColor: (color: ColorInfo, name: string) => void;
   borderRadius: BorderRadiusGroup;
   setBorderRadius: (radius: BorderRadiusGroup) => void;
-  appearance: ColorMode;
-  setAppearance: (appearance: ColorMode) => void;
+  appearance: ColorScheme;
+  setAppearance: (appearance: ColorScheme) => void;
   themePreview: 'one' | 'two' | 'three';
   setThemePreview: (theme: 'one' | 'two' | 'three') => void;
 };

--- a/apps/theme/store.ts
+++ b/apps/theme/store.ts
@@ -2,7 +2,7 @@ import {
   type ColorInfo,
   type ColorScheme,
   type ThemeInfo,
-  generateThemeForColor,
+  generateColorSchemes,
 } from '@digdir/designsystemet/color';
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
@@ -62,12 +62,12 @@ export const useThemeStore = create(
     appearance: 'light',
     themePreview: 'one',
     colors: {
-      main: [{ name: 'accent', colors: generateThemeForColor('#0062BA') }],
-      neutral: [{ name: 'neutral', colors: generateThemeForColor('#1E2B3C') }],
+      main: [{ name: 'accent', colors: generateColorSchemes('#0062BA') }],
+      neutral: [{ name: 'neutral', colors: generateColorSchemes('#1E2B3C') }],
       support: [
-        { name: 'brand1', colors: generateThemeForColor('#F45F63') },
-        { name: 'brand2', colors: generateThemeForColor('#E5AA20') },
-        { name: 'brand3', colors: generateThemeForColor('#1E98F5') },
+        { name: 'brand1', colors: generateColorSchemes('#F45F63') },
+        { name: 'brand2', colors: generateColorSchemes('#E5AA20') },
+        { name: 'brand3', colors: generateColorSchemes('#1E98F5') },
       ],
     },
     themeName: 'theme',

--- a/apps/theme/types.ts
+++ b/apps/theme/types.ts
@@ -1,6 +1,5 @@
 import type { CssColor } from '@digdir/designsystemet/color';
 
-export type modeType = 'light' | 'dark' | 'contrast';
 export type ThemeColors = 'accent' | 'neutral' | 'brand1' | 'brand2' | 'brand3';
 
 export type colorType = {

--- a/packages/cli/src/colors/theme.ts
+++ b/packages/cli/src/colors/theme.ts
@@ -5,8 +5,8 @@ import chroma from 'chroma-js';
 import { luminance } from './luminance.js';
 import type {
   ColorInfo,
-  ColorMode,
   ColorNumber,
+  ColorScheme,
   GeneratedColorTheme,
   GlobalColors,
   ThemeGenType,
@@ -29,7 +29,7 @@ export const baseColors: Record<GlobalColors, CssColor> = {
  * @param color The base color that is used to generate the color scale
  * @param colorScheme The color scheme to generate a scale for
  */
-export const generateScaleForColor = (color: CssColor, colorScheme: ColorMode): ColorInfo[] => {
+export const generateScaleForColor = (color: CssColor, colorScheme: ColorScheme): ColorInfo[] => {
   const baseColors = getBaseColors(color, colorScheme);
   const luminanceValues = luminance[colorScheme];
 
@@ -100,7 +100,7 @@ export const generateGlobalColors = (): Record<GlobalColors, ThemeInfo> => {
  * @param colorScheme The color scheme to generate the base colors for
  * @returns
  */
-const getBaseColors = (color: CssColor, colorScheme: ColorMode) => {
+const getBaseColors = (color: CssColor, colorScheme: ColorScheme) => {
   let colorLightness = getLightnessFromHex(color);
   if (colorScheme !== 'light') {
     colorLightness = colorLightness <= 30 ? 70 : 100 - colorLightness;

--- a/packages/cli/src/colors/theme.ts
+++ b/packages/cli/src/colors/theme.ts
@@ -20,7 +20,7 @@ export const baseColors: Record<GlobalColors, CssColor> = {
  * @param color The base color that is used to generate the color scale
  * @param colorScheme The color scheme to generate a scale for
  */
-export const generateScaleForColor = (color: CssColor, colorScheme: ColorScheme): ColorInfo[] => {
+export const generateColorScale = (color: CssColor, colorScheme: ColorScheme): ColorInfo[] => {
   const baseColors = getBaseColors(color, colorScheme);
   const luminanceValues = luminance[colorScheme];
 
@@ -57,10 +57,10 @@ export const generateScaleForColor = (color: CssColor, colorScheme: ColorScheme)
  *
  * @param color The base color that is used to generate the color schemes
  */
-export const generateThemeForColor = (color: CssColor): ThemeInfo => ({
-  light: generateScaleForColor(color, 'light'),
-  dark: generateScaleForColor(color, 'dark'),
-  contrast: generateScaleForColor(color, 'contrast'),
+export const generateColorSchemes = (color: CssColor): ThemeInfo => ({
+  light: generateColorScale(color, 'light'),
+  dark: generateColorScale(color, 'dark'),
+  contrast: generateColorScale(color, 'contrast'),
 });
 
 /**

--- a/packages/cli/src/colors/theme.ts
+++ b/packages/cli/src/colors/theme.ts
@@ -1,17 +1,8 @@
-import * as R from 'ramda';
 import type { CssColor } from './types.js';
 
 import chroma from 'chroma-js';
 import { luminance } from './luminance.js';
-import type {
-  ColorInfo,
-  ColorNumber,
-  ColorScheme,
-  GeneratedColorTheme,
-  GlobalColors,
-  ThemeGenType,
-  ThemeInfo,
-} from './types.js';
+import type { ColorInfo, ColorNumber, ColorScheme, GlobalColors, ThemeInfo } from './types.js';
 import { getColorNameFromNumber, getLightnessFromHex, getLuminanceFromLightness } from './utils.js';
 
 export const baseColors: Record<GlobalColors, CssColor> = {
@@ -41,7 +32,7 @@ export const generateScaleForColor = (color: CssColor, colorScheme: ColorScheme)
   }));
 
   // Create the special colors with HSLuv lightness rather than relative luminance for better color perception
-  const specialColors = [
+  const specialColors: Omit<ColorInfo, 'name'>[] = [
     { hex: baseColors.baseDefault, number: 9 },
     { hex: baseColors.baseHover, number: 10 },
     { hex: baseColors.baseActive, number: 11 },
@@ -52,9 +43,9 @@ export const generateScaleForColor = (color: CssColor, colorScheme: ColorScheme)
   // Add the special colors to the output array
   for (const { hex, number } of specialColors) {
     outputArray[number - 1] = {
-      hex: hex as CssColor,
-      number: number as ColorNumber,
-      name: getColorNameFromNumber(number as ColorNumber),
+      hex,
+      number,
+      name: getColorNameFromNumber(number),
     };
   }
 
@@ -62,36 +53,15 @@ export const generateScaleForColor = (color: CssColor, colorScheme: ColorScheme)
 };
 
 /**
- * Generates a color theme based on a base color. Light, Dark and Contrast scales are included.
+ * Generates color schemes based on a base color. Light, Dark and Contrast scales are included.
  *
- * @param color The base color that is used to generate the color theme
+ * @param color The base color that is used to generate the color schemes
  */
 export const generateThemeForColor = (color: CssColor): ThemeInfo => ({
   light: generateScaleForColor(color, 'light'),
   dark: generateScaleForColor(color, 'dark'),
   contrast: generateScaleForColor(color, 'contrast'),
 });
-
-/**
- * Generates a complete theme for a set of colors.
- *
- * @param colors Which colors to generate the theme for
- * @param contrastMode The contrast mode to use
- * @returns
- */
-export const generateColorTheme = ({ colors }: ThemeGenType): GeneratedColorTheme => ({
-  main: R.map(generateThemeForColor, colors.main),
-  support: R.map(generateThemeForColor, colors.support),
-  neutral: generateThemeForColor(colors.neutral),
-});
-
-/**
- * Generates a color theme for the global colors. Light, Dark and Contrast scales are included.
- *
- */
-export const generateGlobalColors = (): Record<GlobalColors, ThemeInfo> => {
-  return R.mapObjIndexed(generateThemeForColor, baseColors);
-};
 
 /**
  * Returns the base colors for a color and color scheme.
@@ -125,7 +95,7 @@ const getBaseColors = (color: CssColor, colorScheme: ColorScheme) => {
  *
  * @param baseColor The base color
  */
-export const getContrastDefault = (color: CssColor) =>
+export const getContrastDefault = (color: CssColor): CssColor =>
   chroma.contrast(color, '#ffffff') >= chroma.contrast(color, '#000000') ? '#ffffff' : '#000000';
 
 /**
@@ -133,14 +103,14 @@ export const getContrastDefault = (color: CssColor) =>
  *
  * @param color The base color
  */
-export const getContrastSubtle = (color: CssColor): string => {
+export const getContrastSubtle = (color: CssColor): CssColor => {
   const contrastWhite = chroma.contrast(color, '#ffffff');
   const contrastBlack = chroma.contrast(color, '#000000');
   const lightness = getLightnessFromHex(color);
   const modifier = lightness <= 40 || lightness >= 60 ? 60 : 50;
   const targetLightness = contrastWhite >= contrastBlack ? lightness + modifier : lightness - modifier;
 
-  return chroma(color).luminance(getLuminanceFromLightness(targetLightness)).hex();
+  return chroma(color).luminance(getLuminanceFromLightness(targetLightness)).hex() as CssColor;
 };
 
 /**

--- a/packages/cli/src/colors/types.ts
+++ b/packages/cli/src/colors/types.ts
@@ -1,6 +1,6 @@
 import type { Colors } from '../tokens/types';
 
-export type ColorMode = 'light' | 'dark' | 'contrast';
+export type ColorScheme = 'light' | 'dark' | 'contrast';
 export type ContrastMode = 'aa' | 'aaa';
 export type ColorNumber = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15;
 export type GlobalColors = 'red' | 'blue' | 'green' | 'orange' | 'purple' | 'yellow';

--- a/packages/cli/src/colors/types.ts
+++ b/packages/cli/src/colors/types.ts
@@ -1,5 +1,3 @@
-import type { Colors } from '../tokens/types';
-
 export type ColorScheme = 'light' | 'dark' | 'contrast';
 export type ContrastMode = 'aa' | 'aaa';
 export type ColorNumber = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15;
@@ -16,17 +14,6 @@ export type ThemeInfo = {
   light: ColorInfo[];
   dark: ColorInfo[];
   contrast: ColorInfo[];
-};
-
-export type GeneratedColorTheme = {
-  main: Record<string, ThemeInfo>;
-  support: Record<string, ThemeInfo>;
-  neutral: ThemeInfo;
-};
-
-export type ThemeGenType = {
-  colors: Colors;
-  contrastMode?: ContrastMode;
 };
 
 /**

--- a/packages/cli/src/tokens/create.ts
+++ b/packages/cli/src/tokens/create.ts
@@ -1,5 +1,5 @@
 import * as R from 'ramda';
-import { baseColors, generateScaleForColor } from '../colors/index.js';
+import { baseColors, generateColorScale } from '../colors/index.js';
 import type { ColorInfo, ColorScheme } from '../colors/types.js';
 import type { Colors, Tokens, Tokens1ary, TokensSet, Typography } from './types.js';
 
@@ -60,9 +60,9 @@ const generateTypographyTokens = (themeName: string, { fontFamily }: Typography)
 };
 
 const generateThemeTokens = (themeName: string, colorScheme: ColorScheme, colors: Colors): TokensSet => {
-  const main = R.map((color) => createColorTokens(generateScaleForColor(color, colorScheme)), colors.main);
-  const support = R.map((color) => createColorTokens(generateScaleForColor(color, colorScheme)), colors.support);
-  const neutral = createColorTokens(generateScaleForColor(colors.neutral, colorScheme));
+  const main = R.map((color) => createColorTokens(generateColorScale(color, colorScheme)), colors.main);
+  const support = R.map((color) => createColorTokens(generateColorScale(color, colorScheme)), colors.support);
+  const neutral = createColorTokens(generateColorScale(colors.neutral, colorScheme));
 
   return {
     [themeName]: {
@@ -74,12 +74,12 @@ const generateThemeTokens = (themeName: string, colorScheme: ColorScheme, colors
 };
 
 const generateGlobalTokens = (colorScheme: ColorScheme) => {
-  const blueScale = generateScaleForColor(baseColors.blue, colorScheme);
-  const greenScale = generateScaleForColor(baseColors.green, colorScheme);
-  const orangeScale = generateScaleForColor(baseColors.orange, colorScheme);
-  const purpleScale = generateScaleForColor(baseColors.purple, colorScheme);
-  const redScale = generateScaleForColor(baseColors.red, colorScheme);
-  const yellowScale = generateScaleForColor(baseColors.yellow, colorScheme);
+  const blueScale = generateColorScale(baseColors.blue, colorScheme);
+  const greenScale = generateColorScale(baseColors.green, colorScheme);
+  const orangeScale = generateColorScale(baseColors.orange, colorScheme);
+  const purpleScale = generateColorScale(baseColors.purple, colorScheme);
+  const redScale = generateColorScale(baseColors.red, colorScheme);
+  const yellowScale = generateColorScale(baseColors.yellow, colorScheme);
 
   return {
     global: {

--- a/packages/cli/src/tokens/create.ts
+++ b/packages/cli/src/tokens/create.ts
@@ -1,6 +1,6 @@
 import * as R from 'ramda';
 import { baseColors, generateScaleForColor } from '../colors/index.js';
-import type { ColorInfo, ColorMode } from '../colors/types.js';
+import type { ColorInfo, ColorScheme } from '../colors/types.js';
 import type { Colors, Tokens, Tokens1ary, TokensSet, Typography } from './types.js';
 
 export const colorCliOptions = {
@@ -59,10 +59,10 @@ const generateTypographyTokens = (themeName: string, { fontFamily }: Typography)
   };
 };
 
-const generateThemeTokens = (themeName: string, theme: ColorMode, colors: Colors): TokensSet => {
-  const main = R.map((color) => createColorTokens(generateScaleForColor(color, theme)), colors.main);
-  const support = R.map((color) => createColorTokens(generateScaleForColor(color, theme)), colors.support);
-  const neutral = createColorTokens(generateScaleForColor(colors.neutral, theme));
+const generateThemeTokens = (themeName: string, colorScheme: ColorScheme, colors: Colors): TokensSet => {
+  const main = R.map((color) => createColorTokens(generateScaleForColor(color, colorScheme)), colors.main);
+  const support = R.map((color) => createColorTokens(generateScaleForColor(color, colorScheme)), colors.support);
+  const neutral = createColorTokens(generateScaleForColor(colors.neutral, colorScheme));
 
   return {
     [themeName]: {
@@ -73,13 +73,13 @@ const generateThemeTokens = (themeName: string, theme: ColorMode, colors: Colors
   };
 };
 
-const generateGlobalTokens = (theme: ColorMode) => {
-  const blueScale = generateScaleForColor(baseColors.blue, theme);
-  const greenScale = generateScaleForColor(baseColors.green, theme);
-  const orangeScale = generateScaleForColor(baseColors.orange, theme);
-  const purpleScale = generateScaleForColor(baseColors.purple, theme);
-  const redScale = generateScaleForColor(baseColors.red, theme);
-  const yellowScale = generateScaleForColor(baseColors.yellow, theme);
+const generateGlobalTokens = (colorScheme: ColorScheme) => {
+  const blueScale = generateScaleForColor(baseColors.blue, colorScheme);
+  const greenScale = generateScaleForColor(baseColors.green, colorScheme);
+  const orangeScale = generateScaleForColor(baseColors.orange, colorScheme);
+  const purpleScale = generateScaleForColor(baseColors.purple, colorScheme);
+  const redScale = generateScaleForColor(baseColors.red, colorScheme);
+  const yellowScale = generateScaleForColor(baseColors.yellow, colorScheme);
 
   return {
     global: {

--- a/packages/cli/src/tokens/write.ts
+++ b/packages/cli/src/tokens/write.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import type { ThemeObject } from '@tokens-studio/types';
 import chalk from 'chalk';
 import * as R from 'ramda';
-import type { ColorMode } from '../colors/types.js';
+import type { ColorScheme } from '../colors/types.js';
 import semanticColorBaseFile from './design-tokens/template/semantic/color-base-file.json' with { type: 'json' };
 import customColorTemplate from './design-tokens/template/semantic/modes/category-color/category-color-template.json' with {
   type: 'json',
@@ -24,8 +24,8 @@ const TEMPLATE_FILES_PATH = path.join(DIRNAME, './design-tokens/template/');
 
 export const stringify = (data: unknown) => JSON.stringify(data, null, 2);
 
-const generateColorSchemeFile = (folder: ColorMode, name: Collection, tokens: TokensSet, outPath: string): File => {
-  const path = `${outPath}/primitives/modes/color-scheme/${folder}`;
+const generateColorSchemeFile = (scheme: ColorScheme, name: Collection, tokens: TokensSet, outPath: string): File => {
+  const path = `${outPath}/primitives/modes/color-scheme/${scheme}`;
   return {
     data: stringify(tokens),
     path,

--- a/packages/cli/src/tokens/write/generate$metadata.ts
+++ b/packages/cli/src/tokens/write/generate$metadata.ts
@@ -1,22 +1,22 @@
-import type { ColorMode } from '../../colors/types.js';
+import type { ColorScheme } from '../../colors/types.js';
 import type { Colors } from '../types.js';
 
-type ColorModes = Array<ColorMode>;
+type ColorSchemes = Array<ColorScheme>;
 
 type Metadata = {
   tokenSetOrder: string[];
 };
 
-export function generateMetadataJson(modes: ColorModes, themes: string[], colors: Colors): Metadata {
+export function generateMetadataJson(schemes: ColorSchemes, themes: string[], colors: Colors): Metadata {
   return {
     tokenSetOrder: [
       'primitives/globals',
       'primitives/size/default',
       ...themes.map((theme) => `primitives/modes/typography/primary/${theme}`),
       ...themes.map((theme) => `primitives/modes/typography/secondary/${theme}`),
-      ...modes.flatMap((mode) => [
-        `primitives/modes/color-scheme/${mode}/global`,
-        ...themes.map((theme) => `primitives/modes/color-scheme/${mode}/${theme}`),
+      ...schemes.flatMap((scheme) => [
+        `primitives/modes/color-scheme/${scheme}/global`,
+        ...themes.map((theme) => `primitives/modes/color-scheme/${scheme}/${theme}`),
       ]),
       ...themes.map((theme) => `themes/${theme}`),
       'semantic/color',

--- a/packages/cli/src/tokens/write/generate$themes.ts
+++ b/packages/cli/src/tokens/write/generate$themes.ts
@@ -2,14 +2,14 @@ import crypto from 'node:crypto';
 
 import { type ThemeObject, TokenSetStatus } from '@tokens-studio/types';
 
-import type { ColorMode } from '../../colors/types.js';
+import type { ColorScheme } from '../../colors/types.js';
 import type { Colors } from '../types.js';
 
 const capitalize = (word: string) => word.charAt(0).toUpperCase() + word.slice(1);
 
 const createHash = (text: string) => crypto.hash('sha1', text);
 
-type ColorSchemes = Array<ColorMode>;
+type ColorSchemes = Array<ColorScheme>;
 
 type ThemeObject_ = ThemeObject & {
   $figmaCollectionId?: string;
@@ -42,7 +42,7 @@ function generateSizeGroup(): ThemeObject_[] {
   ];
 }
 
-const colorSchemeDefaults: Record<ColorMode, ThemeObject_> = {
+const colorSchemeDefaults: Record<ColorScheme, ThemeObject_> = {
   light: {
     name: 'Light',
     selectedTokenSets: {},

--- a/plugins/figma/src/ui/pages/Theme/Theme.tsx
+++ b/plugins/figma/src/ui/pages/Theme/Theme.tsx
@@ -14,7 +14,7 @@ import { getDummyTheme } from '@common/dummyTheme';
 import { colorCliOptions } from '@digdir/designsystemet';
 import {
   type CssColor,
-  generateThemeForColor,
+  generateColorSchemes,
 } from '@digdir/designsystemet/color';
 import { type ColorTheme, useThemeStore } from '../../../common/store';
 import { themeToFigmaFormat } from '../../../common/utils';
@@ -119,11 +119,11 @@ function Theme() {
       ...newArray[themeIndex],
       colors: {
         ...newArray[themeIndex].colors,
-        accent: themeToFigmaFormat(generateThemeForColor(accent)),
-        neutral: themeToFigmaFormat(generateThemeForColor(neutral)),
-        brand1: themeToFigmaFormat(generateThemeForColor(brand1)),
-        brand2: themeToFigmaFormat(generateThemeForColor(brand2)),
-        brand3: themeToFigmaFormat(generateThemeForColor(brand3)),
+        accent: themeToFigmaFormat(generateColorSchemes(accent)),
+        neutral: themeToFigmaFormat(generateColorSchemes(neutral)),
+        brand1: themeToFigmaFormat(generateColorSchemes(brand1)),
+        brand2: themeToFigmaFormat(generateColorSchemes(brand2)),
+        brand3: themeToFigmaFormat(generateColorSchemes(brand3)),
       },
     };
 


### PR DESCRIPTION
resolves #2805

- Renamed `ColorMode` to `ColorScheme`.
- `themeMode` to `colorScheme` or `scheme` depending on usage.
- Fixed & removed other duplicate types so that the same type is used everywhere