### PR TITLE
fix(Select): add width auto option

### DIFF
--- a/.changeset/wicked-plants-eat.md
+++ b/.changeset/wicked-plants-eat.md
@@ -1,0 +1,6 @@
+---
+"@digdir/designsystemet-css": patch
+"@digdir/designsystemet-react": patch
+---
+
+Select: Add `width="auto"` option and default to full width

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -102,7 +102,7 @@
     }
   }
 
-  &:not([size], [cols], select) {
+  &:not([size], [cols], select[data-width='auto']) {
     width: 100%;
   }
 

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -102,7 +102,8 @@
     }
   }
 
-  &:not([size], [cols], select[data-width='auto']) {
+  /* Using select:where() to decrease specificity */
+  &:not([size], [cols], select:where([data-width='auto'])) {
     width: 100%;
   }
 

--- a/packages/react/src/components/Select/Select.stories.tsx
+++ b/packages/react/src/components/Select/Select.stories.tsx
@@ -30,6 +30,7 @@ export const Preview: StoryFn<typeof Select> = (args) => (
 Preview.args = {
   'aria-invalid': false,
   'data-size': 'md',
+  width: 'full',
   disabled: false,
   readOnly: false,
 };

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -6,23 +6,25 @@ import type { MergeRight } from '../../utilities';
 
 export type SelectProps = MergeRight<
   Omit<DefaultProps, 'data-color'> &
-    Omit<SelectHTMLAttributes<HTMLSelectElement>, 'multiple'>,
+    Omit<SelectHTMLAttributes<HTMLSelectElement>, 'multiple' | 'size'>, // Also Omit size as this sets amount of visible options in multiselect
   {
     /** Defines if the select is readOnly
      * @default false
      */
     readOnly?: boolean;
-    /** Defines the width of Select in count of characters.
+    /** Defines the width of Select, where "auto" matches the content width.
+     * @default full
      */
-    size?: number;
+    width?: 'full' | 'auto';
   }
 >;
 
 export const Select = forwardRef<HTMLSelectElement, SelectProps>(
-  function Select({ className, onKeyDown, onMouseDown, ...rest }, ref) {
+  function Select({ className, onKeyDown, onMouseDown, width, ...rest }, ref) {
     return (
       <select
         className={cl('ds-input', className)}
+        data-width={width}
         ref={ref}
         onKeyDown={(event) => {
           if (event.key === 'Tab') return;


### PR DESCRIPTION
- As discussed https://designsystemet.slack.com/archives/C05U1MNKYCX/p1733498017147069
- `<Select>` follows the width of its widest content, but `<Input>` is automatically full width unless `size` is set
- To make this consistent, we make `<Select>` automatically full width, unless setting `data-width="auto"`
- We're using `data-width="auto"` to avoid conflict with native `<select multiselect size="3">` and `data-size` styling