### PR TITLE
fix(react): don't inline React prop types

### DIFF
--- a/.changeset/popular-parrots-begin.md
+++ b/.changeset/popular-parrots-begin.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+Fixes issue where all React prop types were inlined instead of referenced

--- a/packages/react/src/utilities/types.ts
+++ b/packages/react/src/utilities/types.ts
@@ -1,8 +1,5 @@
-/** Simplify a type signature to help with readability in editor hints, error messages etc */
-export type Simplify<T> = { [Key in keyof T]: T[Key] } & {};
-
 /**
  * Create a new type with the properties of the first type merged with the properties of the second type.
  * If a key exists in both types, the property from the *second* type will be used.
  */
-export type MergeRight<T1, T2> = Simplify<Omit<T1, keyof T2> & T2>;
+export type MergeRight<T1, T2> = Omit<T1, keyof T2> & T2;


### PR DESCRIPTION
Before:
<img width="935" alt="Screenshot 2024-12-17 at 10 20 44" src="https://github.com/user-attachments/assets/4a02ece0-613e-40b7-8c13-381d67423ad0" />

After:
<img width="1032" alt="Screenshot 2024-12-17 at 10 26 21" src="https://github.com/user-attachments/assets/6d38a443-878f-4424-837b-aceb167eb2ba" />
