### PR TITLE
fix(Link): missing underline when using Tailwind

### DIFF
--- a/.changeset/fair-gorillas-pay.md
+++ b/.changeset/fair-gorillas-pay.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+Link: Fix missing underline when using Tailwind

--- a/packages/css/src/link.css
+++ b/packages/css/src/link.css
@@ -11,6 +11,7 @@
 
   color: var(--dsc-link-color);
   outline: none;
+  text-decoration-line: underline;
   text-decoration-style: solid;
   text-decoration-thickness: var(--dsc-link-text-decoration-thickness);
   text-underline-offset: 0.27em; /* 5px ish */


### PR DESCRIPTION
Fix: Link `underline` when using Tailwind