### PR TITLE
fix(Table): footer divider and sortable button styling

### DIFF
--- a/.changeset/five-mails-pull.md
+++ b/.changeset/five-mails-pull.md
@@ -1,0 +1,8 @@
+---
+"@digdir/designsystemet-css": patch
+"@digdir/designsystemet-react": patch
+---
+
+Table:
+- Correct footer styling
+- Automatic focus styling for sorting buttons

--- a/packages/css/src/table.css
+++ b/packages/css/src/table.css
@@ -95,6 +95,8 @@
       text-align: inherit;
       width: 100%;
 
+      @composes ds-focus from './base.css';
+
       &:focus-visible {
         position: relative; /* Place on top when painting focus border */
       }

--- a/packages/css/src/table.css
+++ b/packages/css/src/table.css
@@ -38,10 +38,15 @@
     border-bottom: var(--dsc-table-header-divider);
   }
 
-  & > tfoot > tr > :is(th, td) {
-    background: var(--dsc-table-background);
+  /* No border on last tbody row if followed by tfoot */
+  & > tbody:has(+ tfoot) > tr:last-child > :is(th, td) {
     border-bottom: none;
-    border-top: var(--dsc-table-border);
+  }
+
+  & > tfoot > tr > :is(th, td) {
+    background: var(--dsc-table-header-background);
+    border-bottom: none;
+    border-top: var(--dsc-table-header-divider);
   }
 
   & caption {

--- a/packages/react/src/components/Table/TableHeaderCell.tsx
+++ b/packages/react/src/components/Table/TableHeaderCell.tsx
@@ -15,13 +15,7 @@ export const TableHeaderCell = forwardRef<
 >(function TableHeaderCell({ sort, children, ...rest }, ref) {
   return (
     <th aria-sort={sort} ref={ref} {...rest}>
-      {sort ? (
-        <button type='button' className='ds-focus'>
-          {children}
-        </button>
-      ) : (
-        children
-      )}
+      {sort ? <button type='button'>{children}</button> : children}
     </th>
   );
 });


### PR DESCRIPTION
- Fixes silly border styling error for table footer divider
- Fixes need for add `ds-focus` on sortable button 
- Question; should `table-header-background | divider` be user for `tfoot`? 🤔 