### PR TITLE
chore: rename sizing & spacing CSS variables to size

### DIFF
--- a/.changeset/perfect-shoes-juggle.md
+++ b/.changeset/perfect-shoes-juggle.md
@@ -1,5 +1,4 @@
 ---
-"@digdir/designsystemet-theme": minor
 "@digdir/designsystemet-css": minor
 ---
 

--- a/.changeset/perfect-shoes-juggle.md
+++ b/.changeset/perfect-shoes-juggle.md
@@ -1,5 +1,0 @@
----
-"@digdir/designsystemet-css": minor
----
-
-Removed CSS variables `--ds-spacing-*` & `--ds-sizing-*`, use `--ds-size-*`

--- a/.changeset/perfect-shoes-juggle.md
+++ b/.changeset/perfect-shoes-juggle.md
@@ -1,0 +1,6 @@
+---
+"@digdir/designsystemet-theme": minor
+"@digdir/designsystemet-css": minor
+---
+
+Removed CSS variables `--ds-spacing-*` & `--ds-sizing-*`, use `--ds-size-*`

--- a/.changeset/rotten-tomatoes-run.md
+++ b/.changeset/rotten-tomatoes-run.md
@@ -1,5 +1,4 @@
 ---
-"@digdir/designsystemet-theme": minor
 "@digdir/designsystemet-css": minor
 ---
 

--- a/.changeset/rotten-tomatoes-run.md
+++ b/.changeset/rotten-tomatoes-run.md
@@ -1,0 +1,6 @@
+---
+"@digdir/designsystemet-theme": minor
+"@digdir/designsystemet-css": minor
+---
+
+New CSS variables for sizes, `--ds-size-*`

--- a/apps/_components/src/CodeSnippet/CodeSnippet.module.css
+++ b/apps/_components/src/CodeSnippet/CodeSnippet.module.css
@@ -8,7 +8,7 @@
 }
 
 .codeSnippet > pre {
-  padding-right: var(--ds-spacing-18) !important;
+  padding-right: var(--ds-size-18) !important;
   background-color: var(--ds-color-neutral-background-subtle) !important;
 }
 
@@ -22,6 +22,6 @@
 
 .copyButton {
   position: absolute;
-  top: var(--ds-spacing-2);
-  right: var(--ds-spacing-2);
+  top: var(--ds-size-2);
+  right: var(--ds-size-2);
 }

--- a/apps/_components/src/Footer/Footer.module.css
+++ b/apps/_components/src/Footer/Footer.module.css
@@ -6,19 +6,19 @@
 .container {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(min(100%, 320px), 1fr));
-  gap: var(--ds-spacing-10);
+  gap: var(--ds-size-10);
 }
 
 .title {
-  margin-bottom: var(--ds-spacing-4);
+  margin-bottom: var(--ds-size-4);
 }
 
 .logos {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: var(--ds-spacing-8);
-  margin-top: var(--ds-spacing-8);
+  gap: var(--ds-size-8);
+  margin-top: var(--ds-size-8);
 }
 
 .links {
@@ -28,7 +28,7 @@
 
 .links li {
   list-style: none;
-  margin-bottom: var(--ds-spacing-5);
+  margin-bottom: var(--ds-size-5);
 }
 
 .links li:last-child {
@@ -68,7 +68,7 @@
 .footer .logos svg {
   height: 26px;
   width: auto;
-  margin-right: var(--ds-spacing-2);
+  margin-right: var(--ds-size-2);
 
   &.udir {
     height: 32px;
@@ -76,20 +76,20 @@
 }
 
 .top {
-  padding: var(--ds-spacing-18) 0;
+  padding: var(--ds-size-18) 0;
 }
 
 .bottom {
   background-color: var(--ds-color-neutral-background-default);
-  padding: var(--ds-spacing-7) 0;
+  padding: var(--ds-size-7) 0;
 }
 
 .button {
   --dsc-button-color: var(--ds-color-neutral-text-default);
-  --dsc-button-padding-block: var(--ds-spacing-4);
-  --dsc-button-padding-inline: var(--ds-spacing-5);
+  --dsc-button-padding-block: var(--ds-size-4);
+  --dsc-button-padding-inline: var(--ds-size-5);
 
   border: 2px dashed var(--ds-color-neutral-border-strong);
   width: fit-content;
-  margin-top: var(--ds-spacing-8);
+  margin-top: var(--ds-size-8);
 }

--- a/apps/_components/src/Header/Header.module.css
+++ b/apps/_components/src/Header/Header.module.css
@@ -21,7 +21,7 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: 0 var(--ds-spacing-8);
+  padding: 0 var(--ds-size-8);
 }
 
 .container nav {
@@ -35,7 +35,7 @@
 .logoContainer {
   display: flex;
   align-items: center;
-  gap: var(--ds-spacing-4);
+  gap: var(--ds-size-4);
 }
 
 .logo {
@@ -76,14 +76,14 @@
 
 .item {
   list-style: none;
-  margin-left: var(--ds-spacing-7);
+  margin-left: var(--ds-size-7);
 }
 
 .link {
   color: inherit;
   text-decoration: none;
   border-bottom: 3px solid transparent;
-  padding-bottom: var(--ds-spacing-2);
+  padding-bottom: var(--ds-size-2);
   transition: 0.1s border-color ease-out;
 }
 
@@ -93,17 +93,17 @@
 }
 
 .itemIcon {
-  margin-left: var(--ds-spacing-1);
+  margin-left: var(--ds-size-1);
 }
 
 .firstIcon {
-  margin-left: var(--ds-spacing-8);
+  margin-left: var(--ds-size-8);
 }
 
 .linkIcon {
   display: grid;
   place-items: center;
-  padding: 0 var(--ds-spacing-2);
+  padding: 0 var(--ds-size-2);
 }
 
 .linkIcon > svg {
@@ -142,7 +142,7 @@
   }
 
   & nav {
-    gap: var(--ds-spacing-1);
+    gap: var(--ds-size-1);
   }
 
   .menu {

--- a/apps/_components/src/Showcase/Showcase.module.css
+++ b/apps/_components/src/Showcase/Showcase.module.css
@@ -2,7 +2,7 @@
   width: 100%;
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  gap: var(--ds-spacing-8);
+  gap: var(--ds-size-8);
   margin: 0 auto;
   background-color: var(--ds-color-neutral-background-default);
   border-radius: var(--ds-border-radius-md);
@@ -159,5 +159,5 @@
 .toggleCombo {
   display: flex;
   flex-direction: column;
-  gap: var(--ds-spacing-2);
+  gap: var(--ds-size-2);
 }

--- a/apps/_components/src/Showcase/Showcase.tsx
+++ b/apps/_components/src/Showcase/Showcase.tsx
@@ -207,10 +207,10 @@ export function Showcase({ className, ...props }: ShowcaseProps) {
         </div>
       </div>
       <div className={cl(classes.card, classes.switches)}>
-        <Heading style={{ marginBottom: 'var(--ds-spacing-2)' }}>
+        <Heading style={{ marginBottom: 'var(--ds-size-2)' }}>
           Innstillinger
         </Heading>
-        <Paragraph style={{ marginBottom: 'var(--ds-spacing-2)' }}>
+        <Paragraph style={{ marginBottom: 'var(--ds-size-2)' }}>
           Her kan du justere på innstillingene dine
         </Paragraph>
         <div className={classes.switchGroup}>
@@ -221,10 +221,10 @@ export function Showcase({ className, ...props }: ShowcaseProps) {
         </div>
       </div>
       <div className={cl(classes.card, classes.combobox)}>
-        <Heading style={{ marginBottom: 'var(--ds-spacing-2)' }}>
+        <Heading style={{ marginBottom: 'var(--ds-size-2)' }}>
           Hvor er du fra?
         </Heading>
-        <Paragraph style={{ marginBottom: 'var(--ds-spacing-2)' }}>
+        <Paragraph style={{ marginBottom: 'var(--ds-size-2)' }}>
           Svar under så finner vi flyreise
         </Paragraph>
         <div className={classes.toggleCombo}>

--- a/apps/storefront/app/bloggen/(frontpage)/layout.module.css
+++ b/apps/storefront/app/bloggen/(frontpage)/layout.module.css
@@ -2,8 +2,8 @@
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
-  gap: var(--ds-spacing-8);
-  padding-top: var(--ds-spacing-18) !important;
+  gap: var(--ds-size-8);
+  padding-top: var(--ds-size-18) !important;
   padding-bottom: var(--page-spacing-bottom) !important;
 
   [data-color-scheme='dark'] &,
@@ -15,8 +15,8 @@
 .main {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
-  gap: var(--ds-spacing-18);
-  column-gap: var(--ds-spacing-12);
+  gap: var(--ds-size-18);
+  column-gap: var(--ds-size-12);
 }
 
 .main [data-featured='true'] {

--- a/apps/storefront/app/bloggen/_components/Card/BlogCard.module.css
+++ b/apps/storefront/app/bloggen/_components/Card/BlogCard.module.css
@@ -12,7 +12,7 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    padding: var(--ds-spacing-8) var(--ds-spacing-10);
+    padding: var(--ds-size-8) var(--ds-size-10);
   }
 }
 
@@ -31,7 +31,7 @@
 
 .meta {
   display: flex;
-  gap: var(--ds-spacing-3);
+  gap: var(--ds-size-3);
   color: var(--ds-color-neutral-text-subtle);
   font-size: 14px !important;
 }

--- a/apps/storefront/app/bloggen/_components/Contributors/Contributors.module.css
+++ b/apps/storefront/app/bloggen/_components/Contributors/Contributors.module.css
@@ -6,10 +6,10 @@
   justify-content: center;
   align-items: center;
   max-width: 640px;
-  gap: var(--ds-spacing-4);
+  gap: var(--ds-size-4);
   margin: 0 auto;
-  margin-top: var(--ds-spacing-18);
-  padding: var(--ds-spacing-10);
+  margin-top: var(--ds-size-18);
+  padding: var(--ds-size-10);
   border-radius: var(--ds-border-radius-lg);
   border: 1px solid var(--ds-color-neutral-border-subtle);
 }
@@ -46,7 +46,7 @@
   flex-wrap: wrap;
   text-wrap: nowrap;
   justify-content: center;
-  gap: var(--ds-spacing-3);
+  gap: var(--ds-size-3);
   color: var(--ds-color-neutral-text-subtle);
 }
 

--- a/apps/storefront/app/bloggen/_components/PostLayout/PostLayout.module.css
+++ b/apps/storefront/app/bloggen/_components/PostLayout/PostLayout.module.css
@@ -7,7 +7,7 @@
 }
 
 .page {
-  margin-top: var(--ds-spacing-18);
+  margin-top: var(--ds-size-18);
   margin-bottom: var(--page-spacing-bottom);
 }
 
@@ -17,10 +17,10 @@
   display: flex;
   flex-wrap: wrap;
   flex-direction: column;
-  gap: var(--ds-spacing-5);
+  gap: var(--ds-size-5);
   text-align: center;
   margin: 0 auto;
-  margin-top: var(--ds-spacing-12);
+  margin-top: var(--ds-size-12);
 }
 
 .ingress {
@@ -30,8 +30,8 @@
 .meta {
   display: flex;
   justify-content: center;
-  margin-top: var(--ds-spacing-1);
-  gap: var(--ds-spacing-3);
+  margin-top: var(--ds-size-1);
+  gap: var(--ds-size-3);
   color: var(--ds-color-neutral-text-subtle);
 }
 
@@ -47,7 +47,7 @@
 .main {
   display: flex;
   flex-direction: column;
-  gap: var(--ds-spacing-18);
+  gap: var(--ds-size-18);
 }
 
 .content {
@@ -60,7 +60,7 @@
 .content img {
   display: block;
   width: 860px;
-  margin: var(--ds-spacing-12) 0;
+  margin: var(--ds-size-12) 0;
   margin-left: calc((100% - 860px) / 2) !important;
   background-color: var(--ds-color-neutral-background-subtle);
 }
@@ -83,19 +83,19 @@
 }
 
 .content:last-child {
-  margin-bottom: var(--ds-spacing-12);
+  margin-bottom: var(--ds-size-12);
 }
 
 .wantToWrite {
-  margin-top: var(--ds-spacing-12);
+  margin-top: var(--ds-size-12);
   border-radius: var(--ds-border-radius-lg);
   background: var(--ds-color-brand1-surface-default);
   color: var(--ds-color-brand1-text-default);
-  padding: var(--ds-spacing-8);
+  padding: var(--ds-size-8);
   display: flex;
   flex-wrap: wrap;
   flex-direction: column;
-  gap: var(--ds-spacing-4);
+  gap: var(--ds-size-4);
 }
 
 .wantToWrite p a {

--- a/apps/storefront/app/komponenter/layout.module.css
+++ b/apps/storefront/app/komponenter/layout.module.css
@@ -1,9 +1,9 @@
 .page {
-  padding-bottom: var(--ds-spacing-18);
+  padding-bottom: var(--ds-size-18);
 }
 
 .grid {
-  padding-top: var(--ds-spacing-12);
+  padding-top: var(--ds-size-12);
   display: grid;
   grid-row-gap: 32px;
   grid-column-gap: 32px;

--- a/apps/storefront/app/not-found.module.css
+++ b/apps/storefront/app/not-found.module.css
@@ -1,6 +1,6 @@
 .content {
   height: 100%;
-  padding: var(--ds-spacing-14) 0;
+  padding: var(--ds-size-14) 0;
 }
 
 .container {
@@ -8,7 +8,7 @@
   align-items: center;
   justify-content: center;
   flex-wrap: wrap;
-  gap: var(--ds-spacing-14);
+  gap: var(--ds-size-14);
   margin: 0 auto;
 }
 

--- a/apps/storefront/components/Banner/Banner.module.css
+++ b/apps/storefront/components/Banner/Banner.module.css
@@ -4,13 +4,13 @@
   width: 100%;
   display: flex;
   justify-content: center;
-  padding: var(--ds-spacing-14);
-  padding-top: var(--ds-spacing-4);
+  padding: var(--ds-size-14);
+  padding-top: var(--ds-size-4);
   align-items: center;
   flex-wrap: wrap;
   flex-direction: column;
   background-color: var(--ds-color-neutral-background-default);
-  gap: var(--ds-spacing-4);
+  gap: var(--ds-size-4);
 
   [data-color-scheme='dark'] &,
   [data-color-scheme='auto'] & {
@@ -32,8 +32,8 @@
   transform: rotate(45deg);
   background-color: var(--ds-color-brand2-border-subtle);
   border-radius: 3px;
-  margin-top: var(--ds-spacing-2);
-  margin-bottom: var(--ds-spacing-2);
+  margin-top: var(--ds-size-2);
+  margin-bottom: var(--ds-size-2);
 }
 
 .icon > svg {
@@ -69,7 +69,7 @@
   }
 
   .icon {
-    margin-left: var(--ds-spacing-2);
+    margin-left: var(--ds-size-2);
   }
 
   .logo {

--- a/apps/storefront/components/ComponentCard/ComponentCard.module.css
+++ b/apps/storefront/components/ComponentCard/ComponentCard.module.css
@@ -3,7 +3,7 @@
   text-align: center;
   background-color: var(--ds-color-neutral-background-default);
   color: var(--ds-color-neutral-text-default);
-  padding: var(--ds-spacing-10);
+  padding: var(--ds-size-10);
   border-radius: var(--ds-border-radius-md);
   box-shadow: var(--ds-shadow-xs);
   text-decoration: none;
@@ -21,7 +21,7 @@
 }
 
 .title {
-  margin-top: var(--ds-spacing-3);
+  margin-top: var(--ds-size-3);
   text-decoration: underline;
   text-underline-offset: 7px;
 }

--- a/apps/storefront/components/Grid/Grid.module.css
+++ b/apps/storefront/components/Grid/Grid.module.css
@@ -2,7 +2,7 @@
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: var(--grid-gap);
-  margin: var(--ds-spacing-7) 0;
+  margin: var(--ds-size-7) 0;
 }
 
 @media (max-width: 1200px) {

--- a/apps/storefront/components/Image/Image.module.css
+++ b/apps/storefront/components/Image/Image.module.css
@@ -1,10 +1,10 @@
 .container {
   display: flex;
   max-width: var(--media-max-width);
-  margin: var(--ds-spacing-7) 0;
+  margin: var(--ds-size-7) 0;
   border-radius: var(--ds-border-radius-md);
   flex-wrap: wrap;
-  gap: var(--ds-spacing-4);
+  gap: var(--ds-size-4);
 }
 
 .image {

--- a/apps/storefront/components/ImageBanner/ImageBanner.module.css
+++ b/apps/storefront/components/ImageBanner/ImageBanner.module.css
@@ -50,7 +50,7 @@
 }
 
 .title {
-  margin-bottom: var(--ds-spacing-4);
+  margin-bottom: var(--ds-size-4);
 }
 
 .tag {
@@ -75,8 +75,8 @@
   color: inherit;
   display: flex;
   flex-wrap: wrap;
-  gap: var(--ds-spacing-5);
-  margin-top: var(--ds-spacing-5);
+  gap: var(--ds-size-5);
+  margin-top: var(--ds-size-5);
 }
 
 @media (max-width: 480px) {
@@ -88,14 +88,14 @@
 .link {
   display: flex;
   align-items: center;
-  margin-top: var(--ds-spacing-5);
+  margin-top: var(--ds-size-5);
   font-size: 18px;
   font-weight: 500;
   width: fit-content;
 }
 
 .link svg {
-  margin-right: var(--ds-spacing-2);
+  margin-right: var(--ds-size-2);
 }
 
 .fallbackImg {

--- a/apps/storefront/components/MdxContent/MdxContent.module.css
+++ b/apps/storefront/components/MdxContent/MdxContent.module.css
@@ -8,7 +8,7 @@
   }
 
   & p {
-    margin-bottom: var(--ds-spacing-4);
+    margin-bottom: var(--ds-size-4);
 
     & > strong {
       margin: 0 !important;
@@ -27,8 +27,8 @@
   & > h2,
   & > h3,
   & > h4 {
-    margin-top: var(--ds-spacing-10);
-    margin-bottom: var(--ds-spacing-3);
+    margin-top: var(--ds-size-10);
+    margin-bottom: var(--ds-size-3);
   }
 
   /* Anchor link styling */
@@ -80,7 +80,7 @@
 
   & > ul > li > ol,
   & > ol > li > ul {
-    margin-top: var(--ds-spacing-1);
+    margin-top: var(--ds-size-1);
   }
 
   & > p > a:hover,
@@ -93,24 +93,24 @@
   & > h1 + p {
     font: var(--ds-body-long-md-font-size);
     margin-top: 0;
-    margin-bottom: var(--ds-spacing-8);
+    margin-bottom: var(--ds-size-8);
   }
 
   & > iframe {
     box-shadow: var(--ds-shadow-md);
-    margin: var(--ds-spacing-5);
+    margin: var(--ds-size-5);
     border-radius: var(--ds-border-radius-md);
   }
 
   & > table {
     width: 100%;
-    margin: var(--ds-spacing-7) 0;
+    margin: var(--ds-size-7) 0;
     border-collapse: collapse;
   }
 
   & > img {
     width: 100%;
-    margin: var(--ds-spacing-5) 0;
+    margin: var(--ds-size-5) 0;
     border-radius: var(--ds-border-radius-md);
     box-shadow: var(--ds-shadow-md);
   }
@@ -132,13 +132,13 @@
   & > pre,
   & > p pre {
     background-color: var(--ds-color-neutral-background-subtle);
-    padding: var(--ds-spacing-5);
-    margin: var(--ds-spacing-7) 0;
+    padding: var(--ds-size-5);
+    margin: var(--ds-size-7) 0;
     border-radius: var(--ds-border-radius-md);
   }
 
   & > div + p {
-    margin-top: var(--ds-spacing-5);
+    margin-top: var(--ds-size-5);
   }
 
   & *[data-unstyled] {
@@ -156,7 +156,7 @@
 
     & img {
       width: 100%;
-      margin: var(--ds-spacing-5) 0;
+      margin: var(--ds-size-5) 0;
       border-radius: var(--ds-border-radius-md);
       box-shadow: var(--ds-shadow-md);
     }
@@ -164,7 +164,7 @@
     &:is(strong),
     & strong {
       display: inline-block;
-      margin-top: var(--ds-spacing-1);
+      margin-top: var(--ds-size-1);
       font-weight: 500;
     }
   }

--- a/apps/storefront/components/NavigationCard/NavigationCard.module.css
+++ b/apps/storefront/components/NavigationCard/NavigationCard.module.css
@@ -28,8 +28,8 @@
   border-radius: var(--ds-border-radius-sm);
   transform: rotate(45deg);
   margin: 0 auto;
-  margin-bottom: calc(var(--ds-spacing-3) + 11px);
-  margin-top: var(--ds-spacing-3);
+  margin-bottom: calc(var(--ds-size-3) + 11px);
+  margin-top: var(--ds-size-3);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -75,8 +75,8 @@
 }
 
 .title {
-  margin-top: var(--ds-spacing-4);
-  margin-bottom: var(--ds-spacing-4);
+  margin-top: var(--ds-size-4);
+  margin-bottom: var(--ds-size-4);
   text-align: center;
   text-decoration: underline;
   text-underline-offset: 7px;

--- a/apps/storefront/components/ResponsiveIframe/ResponsiveIframe.module.css
+++ b/apps/storefront/components/ResponsiveIframe/ResponsiveIframe.module.css
@@ -3,8 +3,8 @@
   overflow: hidden;
   width: 100%;
   border-radius: 4px;
-  margin-top: var(--ds-spacing-10);
-  margin-bottom: var(--ds-spacing-10);
+  margin-top: var(--ds-size-10);
+  margin-bottom: var(--ds-size-10);
   aspect-ratio: 16 / 9;
 }
 

--- a/apps/storefront/components/Section/Section.module.css
+++ b/apps/storefront/components/Section/Section.module.css
@@ -1,6 +1,6 @@
 .section {
   background-color: var(--ds-color-neutral-background-subtle);
-  padding: calc(var(--ds-spacing-14) + var(--ds-spacing-2)) 0 var(--ds-spacing-18) 0;
+  padding: calc(var(--ds-size-14) + var(--ds-size-2)) 0 var(--ds-size-18) 0;
 }
 
 .white {
@@ -12,7 +12,7 @@
 }
 
 .header {
-  margin-bottom: var(--ds-spacing-8);
+  margin-bottom: var(--ds-size-8);
   text-align: center;
 }
 
@@ -24,8 +24,8 @@
 }
 
 .detail {
-  margin-top: var(--ds-spacing-4);
-  height: var(--ds-spacing-7);
+  margin-top: var(--ds-size-4);
+  height: var(--ds-size-7);
 }
 
 .separator {

--- a/apps/storefront/components/SidebarMenu/SidebarMenu.module.css
+++ b/apps/storefront/components/SidebarMenu/SidebarMenu.module.css
@@ -1,6 +1,6 @@
 .title {
   font-weight: 600;
-  margin-bottom: var(--ds-spacing-5);
+  margin-bottom: var(--ds-size-5);
 }
 
 .list {
@@ -9,12 +9,12 @@
 }
 
 .listGroup {
-  margin-bottom: var(--ds-spacing-5);
+  margin-bottom: var(--ds-size-5);
   list-style: none;
 }
 
 .listGroupCompact {
-  margin-bottom: var(--ds-spacing-4);
+  margin-bottom: var(--ds-size-4);
 }
 
 .innerList {
@@ -39,7 +39,7 @@
 .link {
   color: inherit;
   text-decoration: none;
-  padding: var(--ds-spacing-1) var(--ds-spacing-4);
+  padding: var(--ds-size-1) var(--ds-size-4);
   display: block;
   line-height: 1.3em;
   position: relative;
@@ -87,12 +87,12 @@
 @media (max-width: 958.98px) {
   .menu {
     display: none;
-    margin-top: var(--ds-spacing-7);
+    margin-top: var(--ds-size-7);
   }
 
   .toggleBtn {
     display: block;
-    margin-bottom: var(--ds-spacing-2);
+    margin-bottom: var(--ds-size-2);
   }
 
   .activeMenu {

--- a/apps/storefront/components/TeaserCard/TeaserCard.module.css
+++ b/apps/storefront/components/TeaserCard/TeaserCard.module.css
@@ -25,7 +25,7 @@
 }
 
 .title {
-  margin-bottom: var(--ds-spacing-2);
+  margin-bottom: var(--ds-size-2);
 }
 
 .desc {

--- a/apps/storefront/components/Tokens/TokenList/TokenList.module.css
+++ b/apps/storefront/components/Tokens/TokenList/TokenList.module.css
@@ -37,7 +37,7 @@
   grid-column-gap: 16px;
   grid-row-gap: 22px;
   grid-template-columns: repeat(3, 1fr);
-  margin-top: var(--ds-spacing-3);
+  margin-top: var(--ds-size-3);
 }
 
 .cards2 {
@@ -66,7 +66,7 @@
   align-items: flex-start;
   align-items: center;
   display: flex;
-  gap: var(--ds-spacing-3);
+  gap: var(--ds-size-3);
 }
 
 .preview {
@@ -98,7 +98,7 @@
 .package {
   display: flex;
   align-items: center;
-  gap: var(--ds-spacing-2);
+  gap: var(--ds-size-2);
   font-weight: 600;
 }
 

--- a/apps/storefront/components/VersionBanner/VersionBanner.module.css
+++ b/apps/storefront/components/VersionBanner/VersionBanner.module.css
@@ -4,7 +4,7 @@
   display: grid;
   place-items: center;
   width: 100%;
-  height: var(--ds-sizing-12);
+  height: var(--ds-size-12);
   position: relative;
   z-index: 100;
 }

--- a/apps/storefront/globals.css
+++ b/apps/storefront/globals.css
@@ -8,9 +8,9 @@
   /* Spacing for page and grid */
   --grid-max-width: 1400px;
   --grid-padding: clamp(1rem, calc(0.27rem + 3.64vw), 3rem); /* 48px-16px */
-  --grid-gap: var(--ds-spacing-8);
-  --page-spacing-top: var(--ds-spacing-14);
-  --page-spacing-bottom: var(--ds-spacing-14);
+  --grid-gap: var(--ds-size-8);
+  --page-spacing-top: var(--ds-size-14);
+  --page-spacing-bottom: var(--ds-size-14);
   --media-max-width: 800px;
 }
 
@@ -27,7 +27,7 @@ body {
 
 .ds-link > :is(img, svg) {
   height: 70%;
-  margin-right: var(--ds-spacing-1);
+  margin-right: var(--ds-size-1);
 }
 
 .root {

--- a/apps/storefront/layouts/MenuPageLayout/MenuPageLayout.module.css
+++ b/apps/storefront/layouts/MenuPageLayout/MenuPageLayout.module.css
@@ -2,8 +2,8 @@
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
-  gap: var(--ds-spacing-10);
-  margin-top: var(--ds-spacing-8);
+  gap: var(--ds-size-10);
+  margin-top: var(--ds-size-8);
   margin-bottom: var(--page-spacing-bottom);
 }
 
@@ -24,8 +24,8 @@
   align-items: center;
   position: relative;
   overflow: hidden;
-  margin-bottom: var(--ds-spacing-6);
-  padding: var(--ds-spacing-10);
+  margin-bottom: var(--ds-size-6);
+  padding: var(--ds-size-10);
   width: 100%;
   border-radius: var(--ds-border-radius-lg);
   background-color: var(--ds-color-neutral-background-subtle);
@@ -37,7 +37,7 @@
 }
 
 .date {
-  margin-top: var(--ds-spacing-3);
+  margin-top: var(--ds-size-3);
 }
 
 .iconContainer {
@@ -88,13 +88,13 @@
 }
 
 .content {
-  padding: var(--ds-spacing-4) var(--ds-spacing-10) 0 var(--ds-spacing-10);
+  padding: var(--ds-size-4) var(--ds-size-10) 0 var(--ds-size-10);
   height: fit-content;
 }
 
 .githubLink {
   display: inline-block;
-  margin-top: var(--ds-spacing-12);
+  margin-top: var(--ds-size-12);
 }
 
 @media (max-width: 1200px) {

--- a/apps/storefront/layouts/NavMenuPageLayout/NavMenuPageLayout.module.css
+++ b/apps/storefront/layouts/NavMenuPageLayout/NavMenuPageLayout.module.css
@@ -2,7 +2,7 @@
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
-  gap: var(--ds-spacing-10);
+  gap: var(--ds-size-10);
   margin-top: var(--page-spacing-top);
   margin-bottom: var(--page-spacing-bottom);
 }

--- a/apps/storefront/layouts/NavPageLayout/NavPageLayout.module.css
+++ b/apps/storefront/layouts/NavPageLayout/NavPageLayout.module.css
@@ -1,6 +1,6 @@
 .content {
-  padding-bottom: var(--ds-spacing-12);
-  padding-top: var(--ds-spacing-12);
+  padding-bottom: var(--ds-size-12);
+  padding-top: var(--ds-size-12);
 
   [data-color-scheme='dark'] &,
   [data-color-scheme='auto'] & {

--- a/apps/storefront/layouts/PageLayout/PageLayout.module.css
+++ b/apps/storefront/layouts/PageLayout/PageLayout.module.css
@@ -5,13 +5,13 @@
 
 .header {
   background-color: var(--ds-color-brand3-surface-default);
-  padding-top: var(--ds-spacing-7);
+  padding-top: var(--ds-size-7);
 }
 
 .headerContent {
   max-width: 780px;
   margin: 0 auto;
-  padding-bottom: var(--ds-spacing-18);
+  padding-bottom: var(--ds-size-18);
 }
 
 .headerContent h1,
@@ -26,7 +26,7 @@
 }
 
 .backBtn {
-  margin-bottom: var(--ds-spacing-10);
+  margin-bottom: var(--ds-size-10);
   color: inherit;
 }
 
@@ -35,19 +35,19 @@
 }
 
 .backBtn svg {
-  margin-right: var(--ds-spacing-2);
+  margin-right: var(--ds-size-2);
 }
 
 .separator {
-  margin: 0 var(--ds-spacing-2);
+  margin: 0 var(--ds-size-2);
 }
 
 .meta {
   display: flex;
   text-align: center;
   justify-content: center;
-  margin-bottom: var(--ds-spacing-3);
-  margin-top: var(--ds-spacing-8);
+  margin-bottom: var(--ds-size-3);
+  margin-top: var(--ds-size-8);
 }
 
 .content {
@@ -67,7 +67,7 @@
   .meta {
     flex-direction: column;
     text-align: left;
-    gap: var(--ds-spacing-1);
+    gap: var(--ds-size-1);
   }
 
   .separator {

--- a/apps/storefront/mdx-components.tsx
+++ b/apps/storefront/mdx-components.tsx
@@ -36,7 +36,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
         level={1}
         data-size='xl'
         style={{
-          marginBottom: 'var(--ds-spacing-4)',
+          marginBottom: 'var(--ds-size-4)',
         }}
       />
     ),

--- a/apps/storybook/.storybook/manager-head.html
+++ b/apps/storybook/.storybook/manager-head.html
@@ -69,7 +69,7 @@
     align-items: center;
     justify-content: space-between;
     width: 100%;
-    padding: 0 var(--ds-spacing-7);
+    padding: 0 var(--ds-size-7);
   }
 
   .header__logo {
@@ -96,14 +96,14 @@
 
   .header__item {
     list-style: none;
-    margin-left: var(--ds-spacing-7);
+    margin-left: var(--ds-size-7);
   }
 
   .header__link {
     color: inherit;
     text-decoration: none;
     border-bottom: 3px solid transparent;
-    padding-bottom: var(--ds-spacing-2);
+    padding-bottom: var(--ds-size-2);
     transition: 0.1s border-color ease-out;
   }
 
@@ -117,17 +117,17 @@
   }
 
   .header__itemIcon {
-    margin-left: var(--ds-spacing-1);
+    margin-left: var(--ds-size-1);
   }
 
   .header__firstIcon {
-    margin-left: var(--ds-spacing-7);
+    margin-left: var(--ds-size-7);
   }
 
   .header__linkIcon {
     display: grid;
     place-items: center;
-    padding: 0 var(--ds-spacing-2);
+    padding: 0 var(--ds-size-2);
   }
 
   .header__linkIcon > svg {

--- a/apps/storybook/docs-components/DoAndDont/DoAndDont.module.css
+++ b/apps/storybook/docs-components/DoAndDont/DoAndDont.module.css
@@ -4,10 +4,10 @@
   box-sizing: border-box;
   background-color: var(--ds-color-neutral-background-subtle);
   padding: 24px;
-  width: calc(50% - (var(--ds-spacing-4) / 2));
+  width: calc(50% - (var(--ds-size-4) / 2));
   height: 100%;
   border-bottom: 10px solid var(--color);
-  border-radius: var(--ds-spacing-1);
+  border-radius: var(--ds-size-1);
   box-shadow: var(--ds-shadow-md);
   margin: 0;
 }
@@ -54,7 +54,7 @@
 
 .description {
   color: var(--ds-color-neutral-text-default);
-  margin: var(--ds-spacing-4) 0;
+  margin: var(--ds-size-4) 0;
 }
 
 .imageWrapper {

--- a/apps/storybook/docs-components/Stack/Stack.tsx
+++ b/apps/storybook/docs-components/Stack/Stack.tsx
@@ -4,7 +4,7 @@ import classes from './Stack.module.css';
 
 export const Stack = ({
   style,
-  gap = 'var(--ds-spacing-4)',
+  gap = 'var(--ds-size-4)',
   direction = 'row',
   wrap = 'wrap',
   ...rest

--- a/apps/storybook/stories/showcase.module.css
+++ b/apps/storybook/stories/showcase.module.css
@@ -2,12 +2,12 @@
   display: grid;
   grid-template-columns: repeat(3, auto);
   grid-template-rows: auto;
-  gap: var(--ds-spacing-4);
-  padding-bottom: var(--ds-spacing-2);
+  gap: var(--ds-size-4);
+  padding-bottom: var(--ds-size-2);
   align-items: baseline;
 }
 
 .controls code {
   background: var(--ds-color-neutral-background-subtle);
-  padding: var(--ds-spacing-1);
+  padding: var(--ds-size-1);
 }

--- a/apps/theme/app/page.module.css
+++ b/apps/theme/app/page.module.css
@@ -20,15 +20,15 @@ div[data-color-scheme='dark'][data-theme='two'] .main {
   width: 600px;
   margin: 0 auto;
   text-align: center;
-  margin-top: var(--ds-spacing-8);
+  margin-top: var(--ds-size-8);
 }
 
 .heading {
-  margin-top: var(--ds-spacing-1);
+  margin-top: var(--ds-size-1);
 }
 
 .desc {
-  margin-top: var(--ds-spacing-5);
+  margin-top: var(--ds-size-5);
 }
 
 .btnGroup {
@@ -36,7 +36,7 @@ div[data-color-scheme='dark'][data-theme='two'] .main {
   gap: 20px;
   align-items: center;
   justify-content: center;
-  margin-top: var(--ds-spacing-7);
+  margin-top: var(--ds-size-7);
 }
 
 .headerText {

--- a/apps/theme/components/BorderRadius/BorderRadius.module.css
+++ b/apps/theme/components/BorderRadius/BorderRadius.module.css
@@ -5,7 +5,7 @@
   margin-top: 16px;
 
   & > *:first-child {
-    margin-bottom: var(--ds-spacing-6);
+    margin-bottom: var(--ds-size-6);
   }
 }
 .item {

--- a/apps/theme/components/ColorPicker/ColorPicker.module.css
+++ b/apps/theme/components/ColorPicker/ColorPicker.module.css
@@ -47,7 +47,7 @@
 }
 
 .label {
-  margin-bottom: var(--ds-spacing-2);
+  margin-bottom: var(--ds-size-2);
   font-size: 18px;
   font-weight: 500;
   display: flex;

--- a/apps/theme/components/TokenModal/TokenModal.module.css
+++ b/apps/theme/components/TokenModal/TokenModal.module.css
@@ -11,29 +11,29 @@
 
 .leftSection {
   border-right: 1px solid var(--ds-color-neutral-border-subtle);
-  padding-right: var(--ds-spacing-8);
+  padding-right: var(--ds-size-8);
 }
 
 .rightSection {
   display: flex;
   flex-direction: column;
-  gap: var(--ds-spacing-4);
+  gap: var(--ds-size-4);
 }
 
 .infoBoxes {
-  padding-top: var(--ds-spacing-6);
+  padding-top: var(--ds-size-6);
   display: flex;
   flex-direction: column;
-  gap: var(--ds-spacing-8);
+  gap: var(--ds-size-8);
 }
 
 .infoBox {
   display: flex;
-  gap: var(--ds-spacing-3);
+  gap: var(--ds-size-3);
 }
 
 .infoBox__container {
-  gap: var(--ds-spacing-1);
+  gap: var(--ds-size-1);
   display: flex;
   flex-direction: column;
 }
@@ -82,12 +82,12 @@
 
 .headerText {
   margin-right: auto;
-  font-size: var(--ds-spacing-5);
+  font-size: var(--ds-size-5);
 }
 
 .emblem {
   height: 26px;
-  margin-right: var(--ds-spacing-2);
+  margin-right: var(--ds-size-2);
 }
 
 .trigger {
@@ -96,7 +96,7 @@
 
 .step {
   display: flex;
-  gap: var(--ds-spacing-4);
+  gap: var(--ds-size-4);
 }
 
 .step span {

--- a/apps/theme/components/TokenModal/TokenModal.module.css
+++ b/apps/theme/components/TokenModal/TokenModal.module.css
@@ -104,8 +104,8 @@
   color: var(--ds-color-accent-contrast-default);
   aspect-ratio: 1;
   border-radius: var(--ds-border-radius-full);
-  width: var(--ds-sizing-8);
-  height: var(--ds-sizing-8);
+  width: var(--ds-size-8);
+  height: var(--ds-size-8);
   display: grid;
   place-items: center;
   font-size: var(--ds-body-sm-font-size);

--- a/apps/theme/components/TokenModal/TokenModal.tsx
+++ b/apps/theme/components/TokenModal/TokenModal.tsx
@@ -133,7 +133,7 @@ export const TokenModal = () => {
               <div
                 className={classes.step}
                 style={{
-                  marginTop: 'var(--ds-spacing-4)',
+                  marginTop: 'var(--ds-size-4)',
                 }}
               >
                 <span>2</span>

--- a/packages/Overview.mdx
+++ b/packages/Overview.mdx
@@ -8,7 +8,7 @@ import { Card, Heading } from './react';
   src='/img/storybook-overview.png'
   alt='Designsystemets storybook'
   style={{
-    marginBottom: 'var(--ds-spacing-12)',
+    marginBottom: 'var(--ds-size-12)',
   }}
 />
 
@@ -21,8 +21,8 @@ som kan brukes til å videreutvikle og lage mer avanserte og sammensatte kompone
   style={{
     display: 'grid',
     gridTemplateColumns: 'repeat(auto-fill, minmax(400px, 1fr))',
-    gap: 'var(--ds-spacing-4)',
-    marginBlock: 'var(--ds-spacing-6) var(--ds-spacing-12)',
+    gap: 'var(--ds-size-4)',
+    marginBlock: 'var(--ds-size-6) var(--ds-size-12)',
   }}
 >
   <Card className='sb-unstyled'>

--- a/packages/css/src/alert.css
+++ b/packages/css/src/alert.css
@@ -7,7 +7,7 @@
   --dsc-alert-border-radius: var(--ds-border-radius-md);
   --dsc-alert-color: var(--ds-color-info-text-default);
   --dsc-alert-gap: var(--ds-spacing-2);
-  --dsc-alert-icon-size: var(--ds-sizing-7);
+  --dsc-alert-icon-size: var(--ds-size-7);
   --dsc-alert-padding: var(--ds-spacing-6);
 
   background: var(--dsc-alert-background);

--- a/packages/css/src/alert.css
+++ b/packages/css/src/alert.css
@@ -6,9 +6,9 @@
   --dsc-alert-icon-url: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' d='M3.25 4A.75.75 0 0 1 4 3.25h16a.75.75 0 0 1 .75.75v16a.75.75 0 0 1-.75.75H4a.75.75 0 0 1-.75-.75zM11 7.75a1 1 0 1 1 2 0 1 1 0 0 1-2 0m-1.25 3a.75.75 0 0 1 .75-.75H12a.75.75 0 0 1 .75.75v4.75h.75a.75.75 0 0 1 0 1.5h-3a.75.75 0 0 1 0-1.5h.75v-4h-.75a.75.75 0 0 1-.75-.75'/%3E%3C/svg%3E");
   --dsc-alert-border-radius: var(--ds-border-radius-md);
   --dsc-alert-color: var(--ds-color-info-text-default);
-  --dsc-alert-gap: var(--ds-spacing-2);
+  --dsc-alert-gap: var(--ds-size-2);
   --dsc-alert-icon-size: var(--ds-size-7);
-  --dsc-alert-padding: var(--ds-spacing-6);
+  --dsc-alert-padding: var(--ds-size-6);
 
   background: var(--dsc-alert-background);
   border-radius: var(--dsc-alert-border-radius);

--- a/packages/css/src/avatar.css
+++ b/packages/css/src/avatar.css
@@ -2,7 +2,7 @@
   --dsc-avatar-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1em' height='1em' fill='none' viewBox='0 0 24 24' focusable='false' role='img'%3E%3Cpath fill='currentColor' fill-rule='evenodd' d='M8.25 7.5a3.75 3.75 0 1 1 7.5 0 3.75 3.75 0 0 1-7.5 0M12 2.25a5.25 5.25 0 1 0 0 10.5 5.25 5.25 0 0 0 0-10.5M8.288 17.288A5.25 5.25 0 0 1 17.25 21a.75.75 0 0 0 1.5 0 6.75 6.75 0 0 0-13.5 0 .75.75 0 0 0 1.5 0 5.25 5.25 0 0 1 1.538-3.712' clip-rule='evenodd'%3E%3C/path%3E%3C/svg%3E");
   --dsc-avatar-background: var(--ds-color-base-default);
   --dsc-avatar-color: var(--ds-color-contrast-default);
-  --dsc-avatar-size: var(--ds-sizing-12);
+  --dsc-avatar-size: var(--ds-size-12);
   --dsc-avatar-padding: var(--ds-spacing-2);
   --dsc-avatar-border-radius: var(--ds-border-radius-full);
 
@@ -67,6 +67,6 @@
   }
 
   @media (forced-colors: active) {
-    border: var(--ds-sizing-1) solid CanvasText;
+    border: var(--ds-size-1) solid CanvasText;
   }
 }

--- a/packages/css/src/avatar.css
+++ b/packages/css/src/avatar.css
@@ -3,7 +3,7 @@
   --dsc-avatar-background: var(--ds-color-base-default);
   --dsc-avatar-color: var(--ds-color-contrast-default);
   --dsc-avatar-size: var(--ds-size-12);
-  --dsc-avatar-padding: var(--ds-spacing-2);
+  --dsc-avatar-padding: var(--ds-size-2);
   --dsc-avatar-border-radius: var(--ds-border-radius-full);
 
   align-items: center;

--- a/packages/css/src/badge.css
+++ b/packages/css/src/badge.css
@@ -1,8 +1,8 @@
 .ds-badge {
   --dsc-badge-background: var(--ds-color-base-default);
   --dsc-badge-color: var(--ds-color-contrast-default);
-  --dsc-badge-padding: 0 calc(var(--ds-spacing-1) + calc(var(--ds-spacing-1) / 2));
-  --dsc-badge-size: calc(var(--ds-size-3) + calc(var(--ds-spacing-1) / 2));
+  --dsc-badge-padding: 0 calc(var(--ds-size-1) + calc(var(--ds-size-1) / 2));
+  --dsc-badge-size: calc(var(--ds-size-3) + calc(var(--ds-size-1) / 2));
 
   &::before {
     content: attr(data-count);

--- a/packages/css/src/badge.css
+++ b/packages/css/src/badge.css
@@ -2,7 +2,7 @@
   --dsc-badge-background: var(--ds-color-base-default);
   --dsc-badge-color: var(--ds-color-contrast-default);
   --dsc-badge-padding: 0 calc(var(--ds-spacing-1) + calc(var(--ds-spacing-1) / 2));
-  --dsc-badge-size: calc(var(--ds-sizing-3) + calc(var(--ds-spacing-1) / 2));
+  --dsc-badge-size: calc(var(--ds-size-3) + calc(var(--ds-spacing-1) / 2));
 
   &::before {
     content: attr(data-count);

--- a/packages/css/src/breadcrumbs.css
+++ b/packages/css/src/breadcrumbs.css
@@ -1,6 +1,6 @@
 .ds-breadcrumbs {
   --dsc-breadcrumbs-spacing: var(--ds-spacing-2);
-  --dsc-breadcrumbs-chevron-size: var(--ds-sizing-6);
+  --dsc-breadcrumbs-chevron-size: var(--ds-size-6);
   --dsc-breadcrumbs-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 24 24'%3E%3Cpath d='M9.47 5.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 0 1 0 1.06l-5.5 5.5a.75.75 0 1 1-1.06-1.06L14.44 12 9.47 7.03a.75.75 0 0 1 0-1.06'/%3E%3C/svg%3E");
   --dsc-breadcrumbs-color: var(--ds-color-text-subtle);
 

--- a/packages/css/src/breadcrumbs.css
+++ b/packages/css/src/breadcrumbs.css
@@ -1,5 +1,5 @@
 .ds-breadcrumbs {
-  --dsc-breadcrumbs-spacing: var(--ds-spacing-2);
+  --dsc-breadcrumbs-spacing: var(--ds-size-2);
   --dsc-breadcrumbs-chevron-size: var(--ds-size-6);
   --dsc-breadcrumbs-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 24 24'%3E%3Cpath d='M9.47 5.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 0 1 0 1.06l-5.5 5.5a.75.75 0 1 1-1.06-1.06L14.44 12 9.47 7.03a.75.75 0 0 1 0-1.06'/%3E%3C/svg%3E");
   --dsc-breadcrumbs-color: var(--ds-color-text-subtle);

--- a/packages/css/src/button.css
+++ b/packages/css/src/button.css
@@ -5,8 +5,8 @@
   --dsc-button-color: var(--ds-color-contrast-default);
   --dsc-button-color--hover: var(--ds-color-contrast-default);
   --dsc-button-border-color: transparent;
-  --dsc-button-gap: var(--ds-spacing-2);
-  --dsc-button-padding: var(--ds-spacing-2) var(--ds-spacing-4);
+  --dsc-button-gap: var(--ds-size-2);
+  --dsc-button-padding: var(--ds-size-2) var(--ds-size-4);
   --dsc-button-size: var(--ds-size-12);
 
   &[data-variant='secondary'],

--- a/packages/css/src/button.css
+++ b/packages/css/src/button.css
@@ -7,7 +7,7 @@
   --dsc-button-border-color: transparent;
   --dsc-button-gap: var(--ds-spacing-2);
   --dsc-button-padding: var(--ds-spacing-2) var(--ds-spacing-4);
-  --dsc-button-size: var(--ds-sizing-12);
+  --dsc-button-size: var(--ds-size-12);
 
   &[data-variant='secondary'],
   &[data-variant='tertiary'] {

--- a/packages/css/src/card.css
+++ b/packages/css/src/card.css
@@ -5,8 +5,8 @@
   --dsc-card-border-color: var(--ds-color-border-subtle);
   --dsc-card-color: var(--ds-color-text-default);
   --dsc-card-border: 1px solid var(--dsc-card-border-color);
-  --dsc-card-gap: var(--ds-spacing-3);
-  --dsc-card-padding: var(--ds-spacing-6);
+  --dsc-card-gap: var(--ds-size-3);
+  --dsc-card-padding: var(--ds-size-6);
 
   &[data-color='neutral'] {
     --dsc-card-background: var(--ds-color-background-default);

--- a/packages/css/src/chip.css
+++ b/packages/css/src/chip.css
@@ -13,9 +13,9 @@
   --dsc-chip-input-color--checked: var(--ds-color-base-default);
   --dsc-chip-border-radius: var(--ds-border-radius-full);
   --dsc-chip-height: var(--ds-size-8);
-  --dsc-chip-icon-size: var(--ds-spacing-7);
+  --dsc-chip-icon-size: var(--ds-size-7);
   --dsc-chip-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1em' height='1em' fill='none' viewBox='0 0 24 24' focusable='false' role='img'%3E%3Cpath fill='currentColor' d='M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z'%3E%3C/path%3E%3C/svg%3E");
-  --dsc-chip-input-size: var(--ds-spacing-6);
+  --dsc-chip-input-size: var(--ds-size-6);
   --gap: calc((var(--dsc-chip-height) - var(--dsc-chip-input-size)) / 2); /* Distance between edge of input and chip */
 
   align-items: center;
@@ -31,7 +31,7 @@
   line-height: var(--ds-line-height-sm);
   margin: 0;
   min-height: var(--dsc-chip-height);
-  padding: 0 var(--ds-spacing-3);
+  padding: 0 var(--ds-size-3);
   text-decoration: none;
 
   @composes ds-focus from './base.css';

--- a/packages/css/src/chip.css
+++ b/packages/css/src/chip.css
@@ -12,7 +12,7 @@
   --dsc-chip-input-color: var(--ds-color-border-strong);
   --dsc-chip-input-color--checked: var(--ds-color-base-default);
   --dsc-chip-border-radius: var(--ds-border-radius-full);
-  --dsc-chip-height: var(--ds-sizing-8);
+  --dsc-chip-height: var(--ds-size-8);
   --dsc-chip-icon-size: var(--ds-spacing-7);
   --dsc-chip-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1em' height='1em' fill='none' viewBox='0 0 24 24' focusable='false' role='img'%3E%3Cpath fill='currentColor' d='M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z'%3E%3C/path%3E%3C/svg%3E");
   --dsc-chip-input-size: var(--ds-spacing-6);

--- a/packages/css/src/combobox.css
+++ b/packages/css/src/combobox.css
@@ -54,17 +54,17 @@
 }
 
 .ds-combobox--sm .ds-combobox__input__wrapper {
-  min-height: var(--ds-sizing-10);
+  min-height: var(--ds-size-10);
   padding: 5px var(--ds-spacing-2);
 }
 
 .ds-combobox--md .ds-combobox__input__wrapper {
-  min-height: var(--ds-sizing-12);
+  min-height: var(--ds-size-12);
   padding: 7px var(--ds-spacing-3);
 }
 
 .ds-combobox--lg .ds-combobox__input__wrapper {
-  min-height: var(--ds-sizing-14);
+  min-height: var(--ds-size-14);
   padding: 7px var(--ds-spacing-4);
 }
 

--- a/packages/css/src/combobox.css
+++ b/packages/css/src/combobox.css
@@ -1,7 +1,7 @@
 .ds-combobox {
   display: grid;
   background-color: transparent;
-  gap: var(--ds-spacing-2);
+  gap: var(--ds-size-2);
 }
 
 .ds-combobox [data-floating-ui-portal] {
@@ -10,7 +10,7 @@
 }
 
 .ds-combobox__options-wrapper {
-  padding: var(--ds-spacing-2);
+  padding: var(--ds-size-2);
   background: var(--ds-color-neutral-background-default);
   color: var(--ds-color-neutral-text-default);
   overflow-y: auto;
@@ -28,9 +28,9 @@
   display: flex;
   align-items: center;
   position: relative;
-  gap: var(--ds-spacing-1);
+  gap: var(--ds-size-1);
   cursor: text;
-  padding: var(--ds-spacing-2);
+  padding: var(--ds-size-2);
   border-radius: var(--ds-border-radius-md);
   width: 100%;
   height: auto;
@@ -55,17 +55,17 @@
 
 .ds-combobox--sm .ds-combobox__input__wrapper {
   min-height: var(--ds-size-10);
-  padding: 5px var(--ds-spacing-2);
+  padding: 5px var(--ds-size-2);
 }
 
 .ds-combobox--md .ds-combobox__input__wrapper {
   min-height: var(--ds-size-12);
-  padding: 7px var(--ds-spacing-3);
+  padding: 7px var(--ds-size-3);
 }
 
 .ds-combobox--lg .ds-combobox__input__wrapper {
   min-height: var(--ds-size-14);
-  padding: 7px var(--ds-spacing-4);
+  padding: 7px var(--ds-size-4);
 }
 
 .ds-combobox__input__wrapper .ds-combobox__input:focus {
@@ -81,7 +81,7 @@
   display: flex;
   flex-wrap: wrap;
   width: 100%;
-  gap: var(--ds-spacing-2);
+  gap: var(--ds-size-2);
   align-items: center;
   background-color: transparent;
 }
@@ -103,13 +103,13 @@
   min-width: min-content;
   display: inline-flex;
   flex-direction: row;
-  gap: var(--ds-spacing-1);
+  gap: var(--ds-size-1);
   align-items: center;
 }
 
 .ds-combobox__description {
   color: var(--ds-color-neutral-text-subtle);
-  margin-top: calc(var(--ds-spacing-2) * -1);
+  margin-top: calc(var(--ds-size-2) * -1);
 }
 
 .ds-combobox__clear-button {
@@ -159,7 +159,7 @@
 }
 
 .ds-combobox__error-message {
-  margin-top: var(--ds-spacing-2);
+  margin-top: var(--ds-size-2);
 }
 
 .ds-combobox__error-message:empty {
@@ -168,7 +168,7 @@
 
 .ds-combobox__loading {
   display: flex;
-  gap: var(--ds-spacing-2);
+  gap: var(--ds-size-2);
   align-content: center;
 }
 
@@ -189,20 +189,20 @@
 
 .ds-combobox__empty {
   font-weight: 400;
-  padding: var(--ds-spacing-2) var(--ds-spacing-3);
+  padding: var(--ds-size-2) var(--ds-size-3);
 }
 
 .ds-combobox__custom {
   font-weight: 400;
-  padding: var(--ds-spacing-2) var(--ds-spacing-3);
+  padding: var(--ds-size-2) var(--ds-size-3);
 }
 
 .ds-combobox__option {
   width: 100%;
   display: grid;
   grid-template-columns: 1.2em 1fr;
-  padding: var(--ds-spacing-2) var(--ds-spacing-3);
-  padding-left: var(--ds-spacing-1);
+  padding: var(--ds-size-2) var(--ds-size-3);
+  padding-left: var(--ds-size-1);
   border: none;
   border-left: 5px solid transparent;
   border-radius: var(--ds-border-radius-sm);
@@ -226,7 +226,7 @@
 
 .ds-combobox__option.ds-combobox__option--multiple {
   grid-template-columns: auto 1fr;
-  gap: var(--ds-spacing-2);
+  gap: var(--ds-size-2);
 }
 
 .ds-combobox__option__label {
@@ -235,7 +235,7 @@
   flex-direction: column;
   flex-wrap: wrap;
   cursor: pointer;
-  gap: var(--ds-spacing-1);
+  gap: var(--ds-size-1);
   color: var(--ds-color-neutral-text-default);
 }
 
@@ -244,7 +244,7 @@
 }
 
 .ds-combobox__option__icon-wrapper {
-  width: var(--ds-spacing-6);
+  width: var(--ds-size-6);
   aspect-ratio: 1 / 1;
   border: 2px solid var(--ds-color-neutral-border-default);
   border-radius: var(--ds-border-radius-sm);
@@ -258,15 +258,15 @@
 }
 
 .ds-combobox--sm .ds-combobox__option .ds-combobox__option__icon-wrapper {
-  width: var(--ds-spacing-5);
+  width: var(--ds-size-5);
 }
 
 .ds-combobox--md .ds-combobox__option .ds-combobox__option__icon-wrapper {
-  width: var(--ds-spacing-6);
+  width: var(--ds-size-6);
 }
 
 .ds-combobox--lg .ds-combobox__option .ds-combobox__option__icon-wrapper {
-  width: var(--ds-spacing-7);
+  width: var(--ds-size-7);
 }
 
 .ds-combobox__option__icon-wrapper.ds-combobox__option__icon-wrapper--selected {
@@ -300,7 +300,7 @@
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
-  gap: var(--ds-spacing-1);
+  gap: var(--ds-size-1);
   color: var(--ds-color-neutral-text-subtle);
   font-weight: 400;
 }

--- a/packages/css/src/details.css
+++ b/packages/css/src/details.css
@@ -1,9 +1,9 @@
 .ds-details {
   --dsc-details-border: 1px solid var(--dsc-details-border-color);
-  --dsc-details-chevron-gap: var(--ds-spacing-2);
-  --dsc-details-chevron-size: var(--ds-spacing-6);
+  --dsc-details-chevron-gap: var(--ds-size-2);
+  --dsc-details-chevron-size: var(--ds-size-6);
   --dsc-details-chevron-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06'/%3E%3C/svg%3E");
-  --dsc-details-padding: var(--ds-spacing-2) var(--ds-spacing-4);
+  --dsc-details-padding: var(--ds-size-2) var(--ds-size-4);
   --dsc-details-size: var(--ds-size-14);
 
   --dsc-details-background: var(--ds-color-background-default);
@@ -82,7 +82,7 @@
 
   & > :not(summary, u-summary) {
     border-radius: inherit;
-    padding: var(--ds-spacing-5, 1rem);
+    padding: var(--ds-size-5, 1rem);
   }
 
   &[open] > :is(summary, u-summary) {

--- a/packages/css/src/details.css
+++ b/packages/css/src/details.css
@@ -4,7 +4,7 @@
   --dsc-details-chevron-size: var(--ds-spacing-6);
   --dsc-details-chevron-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06'/%3E%3C/svg%3E");
   --dsc-details-padding: var(--ds-spacing-2) var(--ds-spacing-4);
-  --dsc-details-size: var(--ds-sizing-14);
+  --dsc-details-size: var(--ds-size-14);
 
   --dsc-details-background: var(--ds-color-background-default);
   --dsc-details-heading-background--hover: var(--ds-color-surface-default);

--- a/packages/css/src/dropdown.css
+++ b/packages/css/src/dropdown.css
@@ -1,7 +1,7 @@
 .ds-dropdown {
-  --dsc-dropdown-padding: var(--ds-spacing-3) var(--ds-spacing-2);
-  --dsc-dropdown-item-padding: var(--ds-spacing-2) var(--ds-spacing-4);
-  --dsc-dropdown-item-size: var(--ds-spacing-12);
+  --dsc-dropdown-padding: var(--ds-size-3) var(--ds-size-2);
+  --dsc-dropdown-item-padding: var(--ds-size-2) var(--ds-size-4);
+  --dsc-dropdown-item-size: var(--ds-size-12);
   --dsc-dropdown-background: var(--ds-color-neutral-background-default);
   --dsc-dropdow-border-color: var(--ds-color-neutral-border-subtle);
   --dsc-dropdown-border: 1px solid var(--dsc-dropdow-border-color);

--- a/packages/css/src/error-summary.css
+++ b/packages/css/src/error-summary.css
@@ -1,7 +1,7 @@
 .ds-error-summary {
   --dsc-errorsummary-background: var(--ds-color-danger-surface-default);
   --dsc-errorsummary-border-radius: var(--ds-border-radius-lg);
-  --dsc-errorsummary-padding: var(--ds-spacing-6) var(--ds-spacing-8);
+  --dsc-errorsummary-padding: var(--ds-size-6) var(--ds-size-8);
   --dsc-errorsummary-link-color: var(--ds-color-neutral-text-default);
   --dsc-errorsummary-heading-color: var(--ds-color-danger-text-default);
 
@@ -13,7 +13,7 @@
   & :is(h1, h2, h3, h4, h5, h6) {
     color: var(--dsc-errorsummary-heading-color);
     font-size: var(--ds-font-size-plus-1);
-    margin-bottom: var(--ds-spacing-2);
+    margin-bottom: var(--ds-size-2);
   }
 
   & a {

--- a/packages/css/src/field.css
+++ b/packages/css/src/field.css
@@ -2,7 +2,7 @@
   align-items: start;
   display: flex;
   flex-direction: column;
-  gap: var(--ds-spacing-2);
+  gap: var(--ds-size-2);
 
   & [data-field='description'] {
     color: var(--ds-color-neutral-text-subtle); /* TODO: Change to opacity or color-mix(currentColor, trasparent) to ensure contrast when parent element color changes? */
@@ -70,7 +70,7 @@
  */
 .ds-field-affixes {
   --dsc-field-affix-border: 1px solid var(--ds-color-neutral-border-default);
-  --dsc-field-affix-padding-inline: var(--ds-spacing-4);
+  --dsc-field-affix-padding-inline: var(--ds-size-4);
 
   align-self: stretch; /* If ds-field is placed inside a flex container like ds-field, we need to fill width */
   background: var(--ds-color-neutral-background-subtle);

--- a/packages/css/src/fieldset.css
+++ b/packages/css/src/fieldset.css
@@ -11,12 +11,12 @@
 
   /* Stack everything that is not directly after legend */
   & > * + * {
-    margin-block-start: var(--ds-spacing-4);
+    margin-block-start: var(--ds-size-4);
   }
 
   & > legend + p {
     color: var(--ds-color-neutral-text-subtle);
-    margin-block: var(--ds-spacing-1) 0;
+    margin-block: var(--ds-size-1) 0;
   }
 
   &:disabled > legend,

--- a/packages/css/src/helptext.css
+++ b/packages/css/src/helptext.css
@@ -1,7 +1,7 @@
 .ds-helptext {
   --dsc-helptext-icon-size: 65%;
   --dsc-helptext-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 8 14'%3E%3Cpath fill='%23000' fill-rule='evenodd' d='M4 11a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM4 0c2.2 0 4 1.66 4 3.7 0 .98-.42 1.9-1.17 2.6l-.6.54-.29.29c-.48.46-.87.93-.94 1.41V9.5H3v-.81c0-1.26.84-2.22 1.68-3L5.42 5C5.8 4.65 6 4.2 6 3.7 6 2.66 5.1 1.83 4 1.83c-1.06 0-1.92.75-2 1.7v.15H0C0 1.66 1.8 0 4 0Z' clip-rule='evenodd'/%3E%3C/svg%3E");
-  --dsc-helptext-size: var(--ds-sizing-7);
+  --dsc-helptext-size: var(--ds-size-7);
 
   border-radius: var(--ds-border-radius-full);
   border: max(1px, calc(var(--ds-spacing-1) / 2)) solid; /* Allow border-width to grow with font-size */

--- a/packages/css/src/helptext.css
+++ b/packages/css/src/helptext.css
@@ -4,7 +4,7 @@
   --dsc-helptext-size: var(--ds-size-7);
 
   border-radius: var(--ds-border-radius-full);
-  border: max(1px, calc(var(--ds-spacing-1) / 2)) solid; /* Allow border-width to grow with font-size */
+  border: max(1px, calc(var(--ds-size-1) / 2)) solid; /* Allow border-width to grow with font-size */
   box-sizing: border-box;
   height: var(--dsc-helptext-size);
   min-height: 0;

--- a/packages/css/src/index.css
+++ b/packages/css/src/index.css
@@ -39,3 +39,27 @@
 @import url('./breadcrumbs.css') layer(ds.components);
 @import url('./badge.css') layer(ds.components);
 @import url('./avatar.css') layer(ds.components);
+
+:root {
+  /* Temporary size shim as part of https://github.com/digdir/designsystemet/issues/2927 */
+  --ds-size-0: var(--ds-sizing-0);
+  --ds-size-1: var(--ds-sizing-1);
+  --ds-size-2: var(--ds-sizing-2);
+  --ds-size-3: var(--ds-sizing-3);
+  --ds-size-4: var(--ds-sizing-4);
+  --ds-size-5: var(--ds-sizing-5);
+  --ds-size-6: var(--ds-sizing-6);
+  --ds-size-7: var(--ds-sizing-7);
+  --ds-size-8: var(--ds-sizing-8);
+  --ds-size-9: var(--ds-sizing-9);
+  --ds-size-10: var(--ds-sizing-10);
+  --ds-size-11: var(--ds-sizing-11);
+  --ds-size-12: var(--ds-sizing-12);
+  --ds-size-13: var(--ds-sizing-13);
+  --ds-size-14: var(--ds-sizing-14);
+  --ds-size-15: var(--ds-sizing-15);
+  --ds-size-18: var(--ds-sizing-18);
+  --ds-size-22: var(--ds-sizing-22);
+  --ds-size-26: var(--ds-sizing-26);
+  --ds-size-30: var(--ds-sizing-30);
+}

--- a/packages/css/src/index.css
+++ b/packages/css/src/index.css
@@ -42,24 +42,24 @@
 
 :root {
   /* Temporary size shim as part of https://github.com/digdir/designsystemet/issues/2927 */
-  --ds-size-0: var(--ds-sizing-0);
-  --ds-size-1: var(--ds-sizing-1);
-  --ds-size-2: var(--ds-sizing-2);
-  --ds-size-3: var(--ds-sizing-3);
-  --ds-size-4: var(--ds-sizing-4);
-  --ds-size-5: var(--ds-sizing-5);
-  --ds-size-6: var(--ds-sizing-6);
-  --ds-size-7: var(--ds-sizing-7);
-  --ds-size-8: var(--ds-sizing-8);
-  --ds-size-9: var(--ds-sizing-9);
-  --ds-size-10: var(--ds-sizing-10);
-  --ds-size-11: var(--ds-sizing-11);
-  --ds-size-12: var(--ds-sizing-12);
-  --ds-size-13: var(--ds-sizing-13);
-  --ds-size-14: var(--ds-sizing-14);
-  --ds-size-15: var(--ds-sizing-15);
-  --ds-size-18: var(--ds-sizing-18);
-  --ds-size-22: var(--ds-sizing-22);
-  --ds-size-26: var(--ds-sizing-26);
-  --ds-size-30: var(--ds-sizing-30);
+  --ds-size-0: var(--ds-size-0);
+  --ds-size-1: var(--ds-size-1);
+  --ds-size-2: var(--ds-size-2);
+  --ds-size-3: var(--ds-size-3);
+  --ds-size-4: var(--ds-size-4);
+  --ds-size-5: var(--ds-size-5);
+  --ds-size-6: var(--ds-size-6);
+  --ds-size-7: var(--ds-size-7);
+  --ds-size-8: var(--ds-size-8);
+  --ds-size-9: var(--ds-size-9);
+  --ds-size-10: var(--ds-size-10);
+  --ds-size-11: var(--ds-size-11);
+  --ds-size-12: var(--ds-size-12);
+  --ds-size-13: var(--ds-size-13);
+  --ds-size-14: var(--ds-size-14);
+  --ds-size-15: var(--ds-size-15);
+  --ds-size-18: var(--ds-size-18);
+  --ds-size-22: var(--ds-size-22);
+  --ds-size-26: var(--ds-size-26);
+  --ds-size-30: var(--ds-size-30);
 }

--- a/packages/css/src/index.css
+++ b/packages/css/src/index.css
@@ -42,24 +42,24 @@
 
 :root {
   /* Temporary size shim as part of https://github.com/digdir/designsystemet/issues/2927 */
-  --ds-size-0: var(--ds-size-0);
-  --ds-size-1: var(--ds-size-1);
-  --ds-size-2: var(--ds-size-2);
-  --ds-size-3: var(--ds-size-3);
-  --ds-size-4: var(--ds-size-4);
-  --ds-size-5: var(--ds-size-5);
-  --ds-size-6: var(--ds-size-6);
-  --ds-size-7: var(--ds-size-7);
-  --ds-size-8: var(--ds-size-8);
-  --ds-size-9: var(--ds-size-9);
-  --ds-size-10: var(--ds-size-10);
-  --ds-size-11: var(--ds-size-11);
-  --ds-size-12: var(--ds-size-12);
-  --ds-size-13: var(--ds-size-13);
-  --ds-size-14: var(--ds-size-14);
-  --ds-size-15: var(--ds-size-15);
-  --ds-size-18: var(--ds-size-18);
-  --ds-size-22: var(--ds-size-22);
-  --ds-size-26: var(--ds-size-26);
-  --ds-size-30: var(--ds-size-30);
+  --ds-size-0: var(--ds-sizing-0);
+  --ds-size-1: var(--ds-sizing-1);
+  --ds-size-2: var(--ds-sizing-2);
+  --ds-size-3: var(--ds-sizing-3);
+  --ds-size-4: var(--ds-sizing-4);
+  --ds-size-5: var(--ds-sizing-5);
+  --ds-size-6: var(--ds-sizing-6);
+  --ds-size-7: var(--ds-sizing-7);
+  --ds-size-8: var(--ds-sizing-8);
+  --ds-size-9: var(--ds-sizing-9);
+  --ds-size-10: var(--ds-sizing-10);
+  --ds-size-11: var(--ds-sizing-11);
+  --ds-size-12: var(--ds-sizing-12);
+  --ds-size-13: var(--ds-sizing-13);
+  --ds-size-14: var(--ds-sizing-14);
+  --ds-size-15: var(--ds-sizing-15);
+  --ds-size-18: var(--ds-sizing-18);
+  --ds-size-22: var(--ds-sizing-22);
+  --ds-size-26: var(--ds-sizing-26);
+  --ds-size-30: var(--ds-sizing-30);
 }

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -7,13 +7,13 @@
   --dsc-input-border-color--invalid: var(--ds-color-danger-border-strong);
   --dsc-input-border-color--readonly: var(--ds-color-neutral-border-subtle);
   --dsc-input-border-color: var(--ds-color-neutral-border-default);
-  --dsc-input-border-width--toggle: max(1px, calc(var(--ds-spacing-1) / 2)); /* Allow border-width to grow with font-size */
+  --dsc-input-border-width--toggle: max(1px, calc(var(--ds-size-1) / 2)); /* Allow border-width to grow with font-size */
   --dsc-input-border-width: 1px;
   --dsc-input-color--checked: var(--ds-color-contrast-default);
   --dsc-input-color--invalid: var(--ds-color-danger-contrast-default);
   --dsc-input-color--readonly: var(--ds-color-neutral-text-subtle);
   --dsc-input-color: var(--ds-color-neutral-text-default);
-  --dsc-input-padding: var(--ds-spacing-2) var(--ds-spacing-3);
+  --dsc-input-padding: var(--ds-size-2) var(--ds-size-3);
   --dsc-input-size--toggle: var(--ds-size-6);
   --dsc-input-size: var(--ds-size-12);
   --dsc-input-stroke: 0.055em;

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -14,8 +14,8 @@
   --dsc-input-color--readonly: var(--ds-color-neutral-text-subtle);
   --dsc-input-color: var(--ds-color-neutral-text-default);
   --dsc-input-padding: var(--ds-spacing-2) var(--ds-spacing-3);
-  --dsc-input-size--toggle: var(--ds-sizing-6);
-  --dsc-input-size: var(--ds-sizing-12);
+  --dsc-input-size--toggle: var(--ds-size-6);
+  --dsc-input-size: var(--ds-size-12);
   --dsc-input-stroke: 0.055em;
 
   /* Checkmark with antialiasing is achieved by percentages 48% / 50% / 52% */
@@ -146,7 +146,7 @@
   &[type='checkbox'],
   &[type='radio'] {
     --dsc-input-border-width: var(--dsc-input-border-width--toggle);
-    --dsc-input-padding: calc(var(--ds-sizing-1) / 2);
+    --dsc-input-padding: calc(var(--ds-size-1) / 2);
     --dsc-input-size: var(--dsc-input-size--toggle);
 
     flex-shrink: 0; /* Never shrink a toggle input */

--- a/packages/css/src/label.css
+++ b/packages/css/src/label.css
@@ -2,7 +2,7 @@
   --dsc-label--readonly: initial; /* Using technique https://css-tricks.com/the-css-custom-property-toggle-trick/ */
   --dsc-label-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' viewBox='0 0 24 24'%3E%3Cpath fill-rule='evenodd' d='M12 2.25A4.75 4.75 0 0 0 7.25 7v2.25H7A1.75 1.75 0 0 0 5.25 11v9c0 .41.34.75.75.75h12a.75.75 0 0 0 .75-.75v-9A1.75 1.75 0 0 0 17 9.25h-.25V7A4.75 4.75 0 0 0 12 2.25m3.25 7V7a3.25 3.25 0 0 0-6.5 0v2.25zM12 13a1.5 1.5 0 0 0-.75 2.8V17a.75.75 0 0 0 1.5 0v-1.2A1.5 1.5 0 0 0 12 13'/%3E%3C/svg%3E");
   --dsc-label-icon-size: 1.2em;
-  --dsc-label-gap: var(--ds-spacing-1);
+  --dsc-label-gap: var(--ds-size-1);
 
   font-weight: var(--ds-font-weight-medium);
   padding-inline-start: var(--dsc-label--readonly) calc(var(--dsc-label-icon-size) + var(--dsc-label-gap));

--- a/packages/css/src/list.css
+++ b/packages/css/src/list.css
@@ -1,7 +1,7 @@
 .ds-list {
-  --dsc-list-padding-left: var(--ds-spacing-6);
-  --dsc-list-spacing: var(--ds-spacing-3);
-  --dsc-list-spacing-nested: var(--ds-spacing-2);
+  --dsc-list-padding-left: var(--ds-size-6);
+  --dsc-list-spacing: var(--ds-size-3);
+  --dsc-list-spacing-nested: var(--ds-size-2);
 
   margin: 0;
   padding-left: var(--dsc-list-padding-left);

--- a/packages/css/src/modal.css
+++ b/packages/css/src/modal.css
@@ -1,12 +1,12 @@
 .ds-modal {
   --dsc-modal-backdrop-background: rgb(0 0 0 / 0.5);
   --dsc-modal-background: var(--ds-color-neutral-background-default);
-  --dsc-modal-close-margin: var(--ds-spacing-3);
+  --dsc-modal-close-margin: var(--ds-size-3);
   --dsc-modal-color: var(--ds-color-neutral-text-default);
   --dsc-modal-divider: 1px solid var(--ds-color-neutral-border-subtle);
   --dsc-modal-max-height: 80vh;
   --dsc-modal-max-width: 40rem;
-  --dsc-modal-padding: var(--ds-spacing-6);
+  --dsc-modal-padding: var(--ds-size-6);
   --close-top-right: calc(var(--dsc-modal-padding) * -1 + var(--dsc-modal-close-margin));
 
   background: var(--dsc-modal-background);
@@ -59,8 +59,8 @@
     &::before {
       content: '';
       background: currentcolor;
-      height: var(--ds-spacing-6);
-      width: var(--ds-spacing-6);
+      height: var(--ds-size-6);
+      width: var(--ds-size-6);
       mask: center / contain no-repeat
         url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1em' height='1em' fill='none' viewBox='0 0 24 24' focusable='false' role='img'%3E%3Cpath fill='currentColor' d='M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z'%3E%3C/path%3E%3C/svg%3E");
 

--- a/packages/css/src/pagination.css
+++ b/packages/css/src/pagination.css
@@ -1,5 +1,5 @@
 .ds-pagination {
-  --dsc-pagination-gap: var(--ds-spacing-2);
+  --dsc-pagination-gap: var(--ds-size-2);
   --dsc-pagination-ellipsis-width: var(--ds-size-12);
   --dsc-pagination-chevron-size: var(--ds-size-6);
   --dsc-pagination-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 24 24'%3E%3Cpath d='M9.47 5.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 0 1 0 1.06l-5.5 5.5a.75.75 0 1 1-1.06-1.06L14.44 12 9.47 7.03a.75.75 0 0 1 0-1.06'/%3E%3C/svg%3E");
@@ -42,6 +42,6 @@
   }
 
   &[data-compact] {
-    --dsc-pagination-gap: var(--ds-spacing-0);
+    --dsc-pagination-gap: var(--ds-size-0);
   }
 }

--- a/packages/css/src/pagination.css
+++ b/packages/css/src/pagination.css
@@ -1,7 +1,7 @@
 .ds-pagination {
   --dsc-pagination-gap: var(--ds-spacing-2);
-  --dsc-pagination-ellipsis-width: var(--ds-sizing-12);
-  --dsc-pagination-chevron-size: var(--ds-sizing-6);
+  --dsc-pagination-ellipsis-width: var(--ds-size-12);
+  --dsc-pagination-chevron-size: var(--ds-size-6);
   --dsc-pagination-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 24 24'%3E%3Cpath d='M9.47 5.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 0 1 0 1.06l-5.5 5.5a.75.75 0 1 1-1.06-1.06L14.44 12 9.47 7.03a.75.75 0 0 1 0-1.06'/%3E%3C/svg%3E");
 
   & > :is(ol, ul) {

--- a/packages/css/src/popover.css
+++ b/packages/css/src/popover.css
@@ -2,11 +2,11 @@
   --dsc-popover-background: var(--ds-color-surface-default);
   --dsc-popover-border-color: var(--ds-color-border-default);
   --dsc-popover-color: var(--ds-color-text-default);
-  --dsc-popover-arrow-size: var(--ds-spacing-2);
+  --dsc-popover-arrow-size: var(--ds-size-2);
   --dsc-popover-border-radius: var(--ds-border-radius-md);
   --dsc-popover-border: 1px solid var(--dsc-popover-border-color);
   --dsc-popover-max-width: 300px;
-  --dsc-popover-padding: var(--ds-spacing-3) var(--ds-spacing-4);
+  --dsc-popover-padding: var(--ds-size-3) var(--ds-size-4);
 
   background: var(--dsc-popover-background);
   border-radius: var(--dsc-popover-border-radius);

--- a/packages/css/src/search.css
+++ b/packages/css/src/search.css
@@ -1,5 +1,5 @@
 .ds-search {
-  --dsc-search-padding-inline: var(--ds-spacing-2);
+  --dsc-search-padding-inline: var(--ds-size-2);
   --dsc-search-clear-padding: var(--ds-size-1);
   --dsc-search-clear-size: var(--ds-size-9);
   --dsc-search-clear-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24'%3E%3Cpath fill='currentColor' d='M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z'/%3E%3C/svg%3E");

--- a/packages/css/src/search.css
+++ b/packages/css/src/search.css
@@ -1,10 +1,10 @@
 .ds-search {
   --dsc-search-padding-inline: var(--ds-spacing-2);
-  --dsc-search-clear-padding: var(--ds-sizing-1);
-  --dsc-search-clear-size: var(--ds-sizing-9);
+  --dsc-search-clear-padding: var(--ds-size-1);
+  --dsc-search-clear-size: var(--ds-size-9);
   --dsc-search-clear-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24'%3E%3Cpath fill='currentColor' d='M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z'/%3E%3C/svg%3E");
   --dsc-search-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24'%3E%3Cpath d='M10.5 3.25a7.25 7.25 0 1 0 4.57 12.88l5.41 5.41a.75.75 0 1 0 1.06-1.06l-5.41-5.41A7.25 7.25 0 0 0 10.5 3.25M4.75 10.5a5.75 5.75 0 1 1 11.5 0 5.75 5.75 0 0 1-11.5 0'/%3E%3C/svg%3E");
-  --dsc-search-icon-size: var(--ds-sizing-7);
+  --dsc-search-icon-size: var(--ds-size-7);
 
   display: grid;
   align-items: center;

--- a/packages/css/src/skiplink.css
+++ b/packages/css/src/skiplink.css
@@ -1,5 +1,5 @@
 .ds-skiplink {
-  --dsc-skiplink-padding: var(--ds-spacing-4);
+  --dsc-skiplink-padding: var(--ds-size-4);
   --dsc-skiplink-background-color: var(--ds-color-surface-hover);
   --dsc-skiplink-color: var(--ds-color-text-default);
 

--- a/packages/css/src/spinner.css
+++ b/packages/css/src/spinner.css
@@ -6,7 +6,7 @@
 
   animation: ds-spinner-rotate-animation linear infinite var(--dsc-spinner-animation-duration);
   box-sizing: border-box;
-  font-size: var(--ds-sizing-11);
+  font-size: var(--ds-size-11);
   height: 1em;
   width: 1em;
 

--- a/packages/css/src/table.css
+++ b/packages/css/src/table.css
@@ -9,8 +9,8 @@
   --dsc-table-header-background--sorted: var(--ds-color-neutral-background-subtle);
   --dsc-table-header-background: var(--ds-color-neutral-background-default);
   --dsc-table-header-divider: 2px solid var(--ds-color-neutral-border-subtle);
-  --dsc-table-padding: var(--ds-spacing-2) var(--ds-spacing-3);
-  --dsc-table-sort-size: var(--ds-spacing-6);
+  --dsc-table-padding: var(--ds-size-2) var(--ds-size-3);
+  --dsc-table-sort-size: var(--ds-size-6);
 
   border-collapse: separate; /* Using separate mode to enable border-radius */
   border-radius: var(--dsc-table-border-radius);

--- a/packages/css/src/tabs.css
+++ b/packages/css/src/tabs.css
@@ -1,8 +1,8 @@
 .ds-tabs {
   --dsc-tabs-tab-bottom-border-color: transparent;
-  --dsc-tabs-tab-padding: var(--ds-spacing-3) var(--ds-spacing-5);
+  --dsc-tabs-tab-padding: var(--ds-size-3) var(--ds-size-5);
   --dsc-tabs-tab-color: var(--ds-color-neutral-text-subtle);
-  --dsc-tabs-content-padding: var(--ds-spacing-5);
+  --dsc-tabs-content-padding: var(--ds-size-5);
   --dsc-tabs-content-color: var(--ds-color-neutral-text-default);
   --dsc-tabs-list-border-color: var(--ds-color-neutral-border-subtle);
 }
@@ -30,7 +30,7 @@
   flex-direction: row;
   font-family: inherit;
   font-size: inherit;
-  gap: var(--ds-spacing-1);
+  gap: var(--ds-size-1);
   justify-content: center;
   line-height: var(--ds-line-height-sm);
   margin: 0;

--- a/packages/css/src/tag.css
+++ b/packages/css/src/tag.css
@@ -2,7 +2,7 @@
   --dsc-tag-background: var(--ds-color-surface-default);
   --dsc-tag-color: var(--ds-color-text-default);
   --dsc-tag-min-height: var(--ds-size-8);
-  --dsc-tag-padding: 0 var(--ds-spacing-2);
+  --dsc-tag-padding: 0 var(--ds-size-2);
 
   align-items: center;
   background: var(--dsc-tag-background);

--- a/packages/css/src/tag.css
+++ b/packages/css/src/tag.css
@@ -1,7 +1,7 @@
 .ds-tag {
   --dsc-tag-background: var(--ds-color-surface-default);
   --dsc-tag-color: var(--ds-color-text-default);
-  --dsc-tag-min-height: var(--ds-sizing-8);
+  --dsc-tag-min-height: var(--ds-size-8);
   --dsc-tag-padding: 0 var(--ds-spacing-2);
 
   align-items: center;

--- a/packages/css/src/textfield.css
+++ b/packages/css/src/textfield.css
@@ -1,12 +1,12 @@
 .ds-textfield {
   display: grid;
-  gap: var(--ds-spacing-2);
+  gap: var(--ds-size-2);
 }
 
 .ds-textfield__adornment {
   color: var(--ds-color-neutral-text-subtle);
   background: var(--ds-color-neutral-background-subtle);
-  padding: 9px var(--ds-spacing-4);
+  padding: 9px var(--ds-size-4);
   border-radius: var(--ds-border-radius-md);
   border: solid 1px var(--ds-color-neutral-border-default);
   box-sizing: border-box;
@@ -20,7 +20,7 @@
   flex: 0 1 auto;
   width: 100%;
   appearance: none;
-  padding: 0 var(--ds-spacing-3);
+  padding: 0 var(--ds-size-3);
   border: solid 1px var(--ds-color-neutral-border-default);
   background: var(--ds-color-neutral-background-default);
   color: var(--ds-color-neutral-text-default);
@@ -53,15 +53,15 @@
 }
 
 .ds-textfield--sm .ds-textfield__adornment {
-  padding: var(--ds-size-2) var(--ds-spacing-3);
+  padding: var(--ds-size-2) var(--ds-size-3);
 }
 
 .ds-textfield--md .ds-textfield__adornment {
-  padding: 0.65rem var(--ds-spacing-4);
+  padding: 0.65rem var(--ds-size-4);
 }
 
 .ds-textfield--lg .ds-textfield__adornment {
-  padding: 0.85rem var(--ds-spacing-5);
+  padding: 0.85rem var(--ds-size-5);
 }
 
 .ds-textfield--sm .ds-textfield__field {
@@ -77,28 +77,28 @@
 }
 
 .ds-textfield--sm .ds-textfield__input {
-  padding: 0 var(--ds-spacing-2);
+  padding: 0 var(--ds-size-2);
 }
 
 .ds-textfield--md .ds-textfield__input {
-  padding: 0 var(--ds-spacing-3);
+  padding: 0 var(--ds-size-3);
 }
 
 .ds-textfield--lg .ds-textfield__input {
-  padding: 0 var(--ds-spacing-4);
+  padding: 0 var(--ds-size-4);
 }
 
 .ds-textfield__label {
   min-width: min-content;
   display: inline-flex;
   flex-direction: row;
-  gap: var(--ds-spacing-1);
+  gap: var(--ds-size-1);
   align-items: center;
 }
 
 .ds-textfield__description {
   color: var(--ds-color-neutral-text-subtle);
-  margin-top: calc(var(--ds-spacing-2) * -1);
+  margin-top: calc(var(--ds-size-2) * -1);
 }
 
 .ds-textfield:has(.ds-textfield__input:disabled) {

--- a/packages/css/src/textfield.css
+++ b/packages/css/src/textfield.css
@@ -53,7 +53,7 @@
 }
 
 .ds-textfield--sm .ds-textfield__adornment {
-  padding: var(--ds-sizing-2) var(--ds-spacing-3);
+  padding: var(--ds-size-2) var(--ds-spacing-3);
 }
 
 .ds-textfield--md .ds-textfield__adornment {
@@ -65,15 +65,15 @@
 }
 
 .ds-textfield--sm .ds-textfield__field {
-  height: var(--ds-sizing-10);
+  height: var(--ds-size-10);
 }
 
 .ds-textfield--md .ds-textfield__field {
-  height: var(--ds-sizing-12);
+  height: var(--ds-size-12);
 }
 
 .ds-textfield--lg .ds-textfield__field {
-  height: var(--ds-sizing-14);
+  height: var(--ds-size-14);
 }
 
 .ds-textfield--sm .ds-textfield__input {

--- a/packages/css/src/togglegroup.css
+++ b/packages/css/src/togglegroup.css
@@ -2,7 +2,7 @@
   --dsc-togglegroup-background: var(--ds-color-background-default);
   /* Todo: Explore the border color here */
   --dsc-togglegroup-border: var(--ds-border-width-default) solid var(--ds-color-neutral-border-default);
-  --dsc-togglegroup-padding: var(--ds-spacing-1);
+  --dsc-togglegroup-padding: var(--ds-size-1);
   --dsc-togglegroup-border-radius: var(--ds-border-radius-default);
 
   background: var(--dsc-togglegroup-background);

--- a/packages/css/src/tooltip.css
+++ b/packages/css/src/tooltip.css
@@ -2,8 +2,8 @@
   --dsc-tooltip-background: var(--ds-color-neutral-text-default);
   --dsc-tooltip-color: var(--ds-color-neutral-background-default);
   --dsc-tooltip-border-radius: var(--ds-border-radius-default);
-  --dsc-tooltip-padding: var(--ds-spacing-1) var(--ds-spacing-2);
-  --dsc-tooltip-arrow-size: var(--ds-spacing-2);
+  --dsc-tooltip-padding: var(--ds-size-1) var(--ds-size-2);
+  --dsc-tooltip-arrow-size: var(--ds-size-2);
 
   background: var(--dsc-tooltip-background);
   border-radius: var(--dsc-tooltip-border-radius);

--- a/packages/css/src/validation-message.css
+++ b/packages/css/src/validation-message.css
@@ -2,7 +2,7 @@
   /* Default is danger */
   --dsc-validation-message-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill-rule='evenodd' d='M7.74 2.47a.75.75 0 0 1 .53-.22h7.46a.75.75 0 0 1 .53.22l5.27 5.27c.14.14.22.33.22.53v7.46a.75.75 0 0 1-.22.53l-5.27 5.27a.75.75 0 0 1-.53.22H8.27a.75.75 0 0 1-.53-.22l-5.27-5.27a.75.75 0 0 1-.22-.53V8.27a.75.75 0 0 1 .22-.53zm1.29 5.5a.75.75 0 0 0-1.06 1.06L10.94 12l-2.97 2.97a.75.75 0 1 0 1.06 1.06L12 13.06l2.97 2.97a.75.75 0 1 0 1.06-1.06L13.06 12l2.97-2.97a.75.75 0 0 0-1.06-1.06L12 10.94z'/%3E%3C/svg%3E");
   --dsc-validation-message-icon-size: var(--ds-size-7);
-  --dsc-validation-message-gap: var(--ds-spacing-2);
+  --dsc-validation-message-gap: var(--ds-size-2);
   --dsc-validation-message-color: var(--ds-color-danger-text-subtle);
 
   color: var(--dsc-validation-message-color);

--- a/packages/css/src/validation-message.css
+++ b/packages/css/src/validation-message.css
@@ -1,7 +1,7 @@
 .ds-validation-message {
   /* Default is danger */
   --dsc-validation-message-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill-rule='evenodd' d='M7.74 2.47a.75.75 0 0 1 .53-.22h7.46a.75.75 0 0 1 .53.22l5.27 5.27c.14.14.22.33.22.53v7.46a.75.75 0 0 1-.22.53l-5.27 5.27a.75.75 0 0 1-.53.22H8.27a.75.75 0 0 1-.53-.22l-5.27-5.27a.75.75 0 0 1-.22-.53V8.27a.75.75 0 0 1 .22-.53zm1.29 5.5a.75.75 0 0 0-1.06 1.06L10.94 12l-2.97 2.97a.75.75 0 1 0 1.06 1.06L12 13.06l2.97 2.97a.75.75 0 1 0 1.06-1.06L13.06 12l2.97-2.97a.75.75 0 0 0-1.06-1.06L12 10.94z'/%3E%3C/svg%3E");
-  --dsc-validation-message-icon-size: var(--ds-sizing-7);
+  --dsc-validation-message-icon-size: var(--ds-size-7);
   --dsc-validation-message-gap: var(--ds-spacing-2);
   --dsc-validation-message-color: var(--ds-color-danger-text-subtle);
 

--- a/packages/react/src/components/Alert/Alert.stories.tsx
+++ b/packages/react/src/components/Alert/Alert.stories.tsx
@@ -30,7 +30,7 @@ export const VariantInfo: Story = (args) => (
       level={2}
       data-size='xs'
       style={{
-        marginBottom: 'var(--ds-spacing-2)',
+        marginBottom: 'var(--ds-size-2)',
       }}
     >
       Har du husket å bestille passtime?
@@ -48,7 +48,7 @@ export const VariantSuccess: Story = (args) => (
       level={2}
       data-size='xs'
       style={{
-        marginBottom: 'var(--ds-spacing-2)',
+        marginBottom: 'var(--ds-size-2)',
       }}
     >
       Gratulerer! Du kan nå starte selskapet ditt
@@ -66,7 +66,7 @@ export const VariantWarning: Story = (args) => (
       level={2}
       data-size='xs'
       style={{
-        marginBottom: 'var(--ds-spacing-2)',
+        marginBottom: 'var(--ds-size-2)',
       }}
     >
       Vi har tekniske problemer
@@ -84,7 +84,7 @@ export const VariantDanger: Story = (args) => (
       level={2}
       data-size='xs'
       style={{
-        marginBottom: 'var(--ds-spacing-2)',
+        marginBottom: 'var(--ds-size-2)',
       }}
     >
       Det har skjedd en feil
@@ -103,7 +103,7 @@ export const MedHeading: Story = (args) => (
       level={2}
       data-size='xs'
       style={{
-        marginBottom: 'var(--ds-spacing-2)',
+        marginBottom: 'var(--ds-size-2)',
       }}
     >
       Har du husket å bestille passtime?
@@ -127,7 +127,7 @@ export const MedLenke: Story = (args) => (
       level={2}
       data-size='xs'
       style={{
-        marginBottom: 'var(--ds-spacing-2)',
+        marginBottom: 'var(--ds-size-2)',
       }}
     >
       Søknadsfristen går ut om 3 dager
@@ -145,7 +145,7 @@ export const UtenAria: Story = (args) => (
       level={2}
       data-size='xs'
       style={{
-        marginBottom: 'var(--ds-spacing-2)',
+        marginBottom: 'var(--ds-size-2)',
       }}
     >
       Nedetid
@@ -163,7 +163,7 @@ export const MedAria: Story = (args) => (
       level={2}
       data-size='xs'
       style={{
-        marginBottom: 'var(--ds-spacing-2)',
+        marginBottom: 'var(--ds-size-2)',
       }}
     >
       Vi klarer ikke lagre skjemaet

--- a/packages/react/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/react/src/components/Avatar/Avatar.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof Avatar> = {
     layout: 'padded',
     customStyles: {
       display: 'flex',
-      gap: 'var(--ds-spacing-2)',
+      gap: 'var(--ds-size-2)',
       justifyContent: 'center',
       alignItems: 'center',
     },

--- a/packages/react/src/components/Badge/Badge.stories.tsx
+++ b/packages/react/src/components/Badge/Badge.stories.tsx
@@ -35,7 +35,7 @@ export const Floating: Story = (args) => (
   <div
     style={{
       display: 'flex',
-      gap: 'var(--ds-spacing-6)',
+      gap: 'var(--ds-size-6)',
     }}
   >
     <Badge.Position placement='top-right'>
@@ -105,7 +105,7 @@ export const CustomPlacement: Story = (args) => (
   <div
     style={{
       display: 'flex',
-      gap: 'var(--ds-spacing-6)',
+      gap: 'var(--ds-size-6)',
     }}
   >
     <Badge.Position
@@ -125,7 +125,7 @@ export const Status: Story = (args) => (
   <div
     style={{
       display: 'flex',
-      gap: 'var(--ds-spacing-4)',
+      gap: 'var(--ds-size-4)',
     }}
   >
     <Badge.Position data-size='sm'>
@@ -168,7 +168,7 @@ export const InButton: Story = (args) => (
   <div
     style={{
       display: 'flex',
-      gap: 'var(--ds-spacing-4)',
+      gap: 'var(--ds-size-4)',
     }}
   >
     <Button icon variant='tertiary'>

--- a/packages/react/src/components/Button/Button.stories.tsx
+++ b/packages/react/src/components/Button/Button.stories.tsx
@@ -27,7 +27,7 @@ const meta: Meta<typeof Button> = {
       justifyContent: 'center',
       alignItems: 'center',
       flexWrap: 'wrap',
-      gap: 'var(--ds-spacing-4)',
+      gap: 'var(--ds-size-4)',
     },
   },
 };

--- a/packages/react/src/components/Card/Card.stories.tsx
+++ b/packages/react/src/components/Card/Card.stories.tsx
@@ -29,7 +29,7 @@ export default {
       maxWidth: 800,
       alignItems: 'center',
       display: 'grid',
-      gap: 'var(--ds-spacing-4)',
+      gap: 'var(--ds-size-4)',
       gridTemplateColumns: 'repeat(auto-fit, minmax(280px , 1fr))',
     },
   },
@@ -231,7 +231,7 @@ export const Composed: Story = () => (
   <div
     style={{
       display: 'grid', // Used to test Card.Block border logic
-      gap: 'var(--ds-spacing-4)',
+      gap: 'var(--ds-size-4)',
       gridColumn: '1 / -1',
       gridTemplateColumns: 'repeat(auto-fit, minmax(300px , 1fr))',
       width: '100%',

--- a/packages/react/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.stories.tsx
@@ -109,8 +109,8 @@ export const Controlled: StoryFn<UseCheckboxGroupProps> = (args) => {
         <Checkbox label='Hobsyssel' {...getCheckboxProps('hobsyssel')} />
       </Fieldset>
       <ValidationMessage {...validationMessageProps} />
-      <Divider style={{ marginTop: 'var(--ds-spacing-4)' }} />
-      <Paragraph style={{ margin: 'var(--ds-spacing-2) 0' }}>
+      <Divider style={{ marginTop: 'var(--ds-size-4)' }} />
+      <Paragraph style={{ margin: 'var(--ds-size-2) 0' }}>
         Du har valgt: {value.toString()}
       </Paragraph>
       <div style={{ display: 'flex', gap: '1rem' }}>

--- a/packages/react/src/components/Chip/Chip.stories.tsx
+++ b/packages/react/src/components/Chip/Chip.stories.tsx
@@ -6,7 +6,7 @@ export default {
   title: 'Komponenter/Chip',
   component: Chip.Radio,
   parameters: {
-    customStyles: { display: 'flex', gap: 'var(--ds-spacing-2)' },
+    customStyles: { display: 'flex', gap: 'var(--ds-size-2)' },
   },
 } satisfies Meta;
 

--- a/packages/react/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/react/src/components/Combobox/Combobox.stories.tsx
@@ -229,7 +229,7 @@ export const Controlled: StoryFn<typeof Combobox> = (args) => {
         ))}
       </Combobox>
 
-      <Divider style={{ marginTop: 'var(--ds-spacing-4)' }} />
+      <Divider style={{ marginTop: 'var(--ds-size-4)' }} />
 
       <Switch
         label='Multiple'
@@ -240,7 +240,7 @@ export const Controlled: StoryFn<typeof Combobox> = (args) => {
         }}
       />
 
-      <Paragraph style={{ margin: 'var(--ds-spacing-2) 0' }}>
+      <Paragraph style={{ margin: 'var(--ds-size-2) 0' }}>
         Value er: {value.join(', ')}
       </Paragraph>
       <Button
@@ -321,7 +321,7 @@ export const InModal: StoryFn<typeof Combobox> = (args) => {
     <Modal.TriggerContext>
       <Modal.Trigger>Open Modal</Modal.Trigger>
       <Modal style={{ overflow: 'visible' }}>
-        <Heading data-size='xs' style={{ marginBottom: 'var(--ds-spacing-2)' }}>
+        <Heading data-size='xs' style={{ marginBottom: 'var(--ds-size-2)' }}>
           Combobox i Modal
         </Heading>
         <Combobox
@@ -369,7 +369,7 @@ export const WithChipsOutside: StoryFn<typeof Combobox> = (args) => {
           marginBottom: '2rem',
           display: 'flex',
           flexWrap: 'wrap',
-          gap: 'var(--ds-spacing-2)',
+          gap: 'var(--ds-size-2)',
         }}
       >
         {value.map((item, index) => (

--- a/packages/react/src/components/ErrorSummary/ErrorSummary.stories.tsx
+++ b/packages/react/src/components/ErrorSummary/ErrorSummary.stories.tsx
@@ -66,7 +66,7 @@ export const WithForm: Story = () => (
 );
 
 WithForm.parameters = {
-  customStyles: { display: 'grid', gap: 'var(--ds-spacing-4)' },
+  customStyles: { display: 'grid', gap: 'var(--ds-size-4)' },
 };
 
 export const ShowHide: Story = () => {
@@ -78,7 +78,7 @@ export const ShowHide: Story = () => {
         style={{
           display: 'grid',
           placeItems: 'center',
-          marginBottom: 'var(--ds-spacing-4)',
+          marginBottom: 'var(--ds-size-4)',
         }}
       >
         <Button onClick={() => setShow(!show)}>{show ? 'Skjul' : 'Vis'}</Button>

--- a/packages/react/src/components/Input/Input.stories.tsx
+++ b/packages/react/src/components/Input/Input.stories.tsx
@@ -59,7 +59,7 @@ export default {
       <div
         style={{
           display: 'flex',
-          gap: 'var(--ds-spacing-2)',
+          gap: 'var(--ds-size-2)',
           flexDirection: 'column',
         }}
       >
@@ -130,7 +130,7 @@ export const Controlled: StoryFn<typeof Input> = (args) => {
       <div>
         <Divider />
 
-        <Paragraph style={{ margin: 'var(--ds-spacing-2) 0' }}>
+        <Paragraph style={{ margin: 'var(--ds-size-2) 0' }}>
           Du har skrevet inn: {value}
         </Paragraph>
         <Button onClick={() => setValue('Kake')}>Jeg vil ha Kake</Button>

--- a/packages/react/src/components/List/List.stories.tsx
+++ b/packages/react/src/components/List/List.stories.tsx
@@ -28,7 +28,7 @@ export const Sortert: StoryFn<typeof List.Ordered> = (args) => (
     <Heading
       level={2}
       data-size='xs'
-      style={{ marginBottom: 'var(--ds-spacing-2)' }}
+      style={{ marginBottom: 'var(--ds-size-2)' }}
     >
       Slik gjør du:
     </Heading>
@@ -55,7 +55,7 @@ export const Usortert: Story = (args) => (
     <Heading
       level={2}
       data-size='xs'
-      style={{ marginBottom: 'var(--ds-spacing-2)' }}
+      style={{ marginBottom: 'var(--ds-size-2)' }}
     >
       Foreningen har plikt til å ha revisor hvis de har
     </Heading>
@@ -78,7 +78,7 @@ export const Innrykk: Story = (args) => (
       <Heading
         level={3}
         data-size='xs'
-        style={{ marginBottom: 'var(--ds-spacing-2)' }}
+        style={{ marginBottom: 'var(--ds-size-2)' }}
       >
         {' '}
         List Item 1
@@ -93,7 +93,7 @@ export const Innrykk: Story = (args) => (
       <Heading
         level={3}
         data-size='xs'
-        style={{ marginBottom: 'var(--ds-spacing-2)' }}
+        style={{ marginBottom: 'var(--ds-size-2)' }}
       >
         {' '}
         List Item 2
@@ -108,7 +108,7 @@ export const Innrykk: Story = (args) => (
       <Heading
         level={3}
         data-size='xs'
-        style={{ marginBottom: 'var(--ds-spacing-2)' }}
+        style={{ marginBottom: 'var(--ds-size-2)' }}
       >
         List Item 3
       </Heading>
@@ -147,7 +147,7 @@ export const ListeMedOverskrift: Story = (args) => (
       <Heading
         level={2}
         data-size='2xs'
-        style={{ marginBottom: 'var(--ds-spacing-2)' }}
+        style={{ marginBottom: 'var(--ds-size-2)' }}
       >
         List sm og Heading 2xs
       </Heading>
@@ -179,7 +179,7 @@ export const ListeMedOverskrift: Story = (args) => (
       <Heading
         level={2}
         data-size='xs'
-        style={{ marginBottom: 'var(--ds-spacing-2)' }}
+        style={{ marginBottom: 'var(--ds-size-2)' }}
       >
         List md og Heading xs
       </Heading>
@@ -211,7 +211,7 @@ export const ListeMedOverskrift: Story = (args) => (
       <Heading
         level={2}
         data-size='sm'
-        style={{ marginBottom: 'var(--ds-spacing-2)' }}
+        style={{ marginBottom: 'var(--ds-size-2)' }}
       >
         List lg og Heading sm
       </Heading>

--- a/packages/react/src/components/Modal/Modal.stories.tsx
+++ b/packages/react/src/components/Modal/Modal.stories.tsx
@@ -59,10 +59,10 @@ export const Preview: StoryFn<typeof Modal> = (args) => (
       Open Modal
     </Modal.Trigger>
     <Modal {...args}>
-      <Heading style={{ marginBottom: 'var(--ds-spacing-2)' }}>
+      <Heading style={{ marginBottom: 'var(--ds-size-2)' }}>
         Modal header
       </Heading>
-      <Paragraph style={{ marginBottom: 'var(--ds-spacing-2)' }}>
+      <Paragraph style={{ marginBottom: 'var(--ds-size-2)' }}>
         Lorem ipsum dolor sit, amet consectetur adipisicing elit. Blanditiis
         doloremque obcaecati assumenda odio ducimus sunt et.
       </Paragraph>
@@ -79,10 +79,10 @@ export const WithoutModalTriggerContext: StoryFn<typeof Modal> = (args) => {
       <Button onClick={() => modalRef.current?.showModal()}>Open Modal</Button>
       <Modal {...args} ref={modalRef}>
         <Paragraph data-size='sm'>Modal subtittel</Paragraph>
-        <Heading style={{ marginBottom: 'var(--ds-spacing-2)' }}>
+        <Heading style={{ marginBottom: 'var(--ds-size-2)' }}>
           Modal header
         </Heading>
-        <Paragraph style={{ marginBottom: 'var(--ds-spacing-2)' }}>
+        <Paragraph style={{ marginBottom: 'var(--ds-size-2)' }}>
           Lorem ipsum dolor sit, amet consectetur adipisicing elit. Blanditiis
           doloremque obcaecati assumenda odio ducimus sunt et.
         </Paragraph>
@@ -119,7 +119,7 @@ export const WithHeaderAndFooter: StoryFn<typeof Modal> = () => (
         <Heading>Vi kan legge divider under header</Heading>
       </Modal.Block>
       <Modal.Block>
-        <Paragraph style={{ marginBottom: 'var(--ds-spacing-2)' }}>
+        <Paragraph style={{ marginBottom: 'var(--ds-size-2)' }}>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur
           sodales eros justo. Aenean non mi ipsum. Cras viverra elit nec
           vulputate mattis. Nunc placerat euismod pulvinar. Sed nec fringilla
@@ -155,7 +155,7 @@ export const ModalWithForm: StoryFn<typeof Modal> = () => {
     <Modal.TriggerContext>
       <Modal.Trigger>Open Modal</Modal.Trigger>
       <Modal ref={modalRef} onClose={() => setInput('')} backdropClose>
-        <Heading style={{ marginBottom: 'var(--ds-spacing-2)' }}>
+        <Heading style={{ marginBottom: 'var(--ds-size-2)' }}>
           Modal med skjema
         </Heading>
         <Textfield
@@ -168,8 +168,8 @@ export const ModalWithForm: StoryFn<typeof Modal> = () => {
         <div
           style={{
             display: 'flex',
-            gap: 'var(--ds-spacing-4)',
-            marginTop: 'var(--ds-spacing-4)',
+            gap: 'var(--ds-size-4)',
+            marginTop: 'var(--ds-size-4)',
           }}
         >
           <Button
@@ -193,7 +193,7 @@ export const ModalWithMaxWidth: StoryFn<typeof Modal> = () => (
   <Modal.TriggerContext>
     <Modal.Trigger>Open Modal</Modal.Trigger>
     <Modal style={{ maxWidth: 1200 }}>
-      <Heading style={{ marginBottom: 'var(--ds-spacing-2)' }}>
+      <Heading style={{ marginBottom: 'var(--ds-size-2)' }}>
         Modal med en veldig lang bredde
       </Heading>
       <Paragraph>

--- a/packages/react/src/components/Popover/Popover.stories.tsx
+++ b/packages/react/src/components/Popover/Popover.stories.tsx
@@ -62,8 +62,8 @@ export const Interactive: StoryFn<typeof Popover> = () => {
         <div
           style={{
             display: 'flex',
-            gap: 'var(--ds-spacing-2)',
-            marginTop: 'var(--ds-spacing-2)',
+            gap: 'var(--ds-size-2)',
+            marginTop: 'var(--ds-size-2)',
           }}
         >
           <Button data-size='sm'>Ja, slett den</Button>
@@ -128,7 +128,7 @@ export const Variants: StoryFn<typeof Popover> = () => {
         style={{
           display: 'flex',
           flexDirection: 'column',
-          gap: 'var(--ds-spacing-2)',
+          gap: 'var(--ds-size-2)',
           flexWrap: 'wrap',
           height: '100%',
           width: '100%',
@@ -203,7 +203,7 @@ export const Controlled: StoryFn<typeof Popover> = () => {
           data-color='danger'
           onClick={() => setOpen(false)}
           data-size='sm'
-          style={{ marginTop: 'var(--ds-spacing-2)' }}
+          style={{ marginTop: 'var(--ds-size-2)' }}
         >
           Slett
         </Button>
@@ -236,7 +236,7 @@ export const WithoutContext: StoryFn<typeof Popover> = () => {
           data-color='danger'
           onClick={() => setOpen(false)}
           data-size='sm'
-          style={{ marginTop: 'var(--ds-spacing-2)' }}
+          style={{ marginTop: 'var(--ds-size-2)' }}
         >
           Slett
         </Button>

--- a/packages/react/src/components/Radio/Radio.stories.tsx
+++ b/packages/react/src/components/Radio/Radio.stories.tsx
@@ -98,9 +98,9 @@ export const Controlled: StoryFn<UseRadioGroupProps> = (args) => {
         <Radio label='Snadder' {...getRadioProps('snadder')} />
       </Fieldset>
 
-      <Divider style={{ marginTop: 'var(--ds-spacing-4)' }} />
+      <Divider style={{ marginTop: 'var(--ds-size-4)' }} />
 
-      <Paragraph style={{ marginBlock: 'var(--ds-spacing-2)' }}>
+      <Paragraph style={{ marginBlock: 'var(--ds-size-2)' }}>
         Du har valgt: {value}
       </Paragraph>
       <div style={{ display: 'flex', gap: '1rem' }}>
@@ -127,9 +127,7 @@ export const Inline: StoryFn<typeof Fieldset> = () => (
     <Fieldset.Description>
       Bekreft om du ønsker å bli kontaktet per e-post.
     </Fieldset.Description>
-    <div
-      style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--ds-spacing-6)' }}
-    >
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--ds-size-6)' }}>
       <Radio name='my-inline' label='Ja' value='ja' />
       <Radio name='my-inline' label='Nei' value='nei' />
     </div>

--- a/packages/react/src/components/Search/Search.stories.tsx
+++ b/packages/react/src/components/Search/Search.stories.tsx
@@ -32,9 +32,9 @@ export const Controlled: StoryFn<typeof Search> = () => {
         <Search.Button />
       </Search>
 
-      <Divider style={{ marginTop: 'var(--ds-spacing-4)' }} />
+      <Divider style={{ marginTop: 'var(--ds-size-4)' }} />
 
-      <Paragraph style={{ margin: 'var(--ds-spacing-2) 0' }}>
+      <Paragraph style={{ margin: 'var(--ds-size-2) 0' }}>
         Du har skrevet inn: {value}
       </Paragraph>
       <Button onClick={() => setValue('Pizza')}>Jeg vil ha Pizza</Button>
@@ -49,7 +49,7 @@ export const Variants: StoryFn<typeof Search> = () => (
       <Search.Clear />
     </Search>
 
-    <Divider style={{ marginTop: 'var(--ds-spacing-4)' }} />
+    <Divider style={{ marginTop: 'var(--ds-size-4)' }} />
 
     <Search>
       <Search.Input aria-label='Søk' />
@@ -57,7 +57,7 @@ export const Variants: StoryFn<typeof Search> = () => (
       <Search.Button />
     </Search>
 
-    <Divider style={{ marginTop: 'var(--ds-spacing-4)' }} />
+    <Divider style={{ marginTop: 'var(--ds-size-4)' }} />
 
     <Search>
       <Search.Input aria-label='Søk' />
@@ -102,7 +102,7 @@ export const Form: StoryFn<typeof Search> = () => {
         </Search>
       </form>
 
-      <Paragraph data-size='md' style={{ marginTop: 'var(--ds-spacing-2)' }}>
+      <Paragraph data-size='md' style={{ marginTop: 'var(--ds-size-2)' }}>
         Submitted value: {submittedValue}
       </Paragraph>
     </>

--- a/packages/react/src/components/Tag/Tag.stories.tsx
+++ b/packages/react/src/components/Tag/Tag.stories.tsx
@@ -28,7 +28,7 @@ export const Sizes: StoryFn<typeof Tag> = ({ ...rest }): JSX.Element => {
       style={{
         display: 'flex',
         alignItems: 'center',
-        gap: 'var(--ds-spacing-2)',
+        gap: 'var(--ds-size-2)',
       }}
     >
       {sizes.map((size) => (

--- a/packages/react/src/components/Textarea/Textarea.stories.tsx
+++ b/packages/react/src/components/Textarea/Textarea.stories.tsx
@@ -17,7 +17,7 @@ export default {
         style={{
           display: 'flex',
           flexDirection: 'column',
-          gap: 'var(--ds-spacing-2)',
+          gap: 'var(--ds-size-2)',
           maxWidth: '100%',
           width: parameters.layout === 'padded' ? '' : '20rem',
         }}
@@ -74,9 +74,9 @@ export const Controlled: StoryFn<typeof Textarea> = (args) => {
         {...args}
       />
 
-      <Divider style={{ marginTop: 'var(--ds-spacing-4)' }} />
+      <Divider style={{ marginTop: 'var(--ds-size-4)' }} />
 
-      <Paragraph style={{ margin: 'var(--ds-spacing-2) 0' }}>
+      <Paragraph style={{ margin: 'var(--ds-size-2) 0' }}>
         Du har skrevet inn: {value}
       </Paragraph>
       <Button onClick={() => setValue('Pizza')}>Jeg vil ha Pizza</Button>

--- a/packages/react/src/components/Textfield/Textfield.stories.tsx
+++ b/packages/react/src/components/Textfield/Textfield.stories.tsx
@@ -91,9 +91,9 @@ export const Controlled: StoryFn<typeof Textfield> = () => {
         onChange={(e) => setValue(e.target.value)}
       />
 
-      <Divider style={{ marginTop: 'var(--ds-spacing-4)' }} />
+      <Divider style={{ marginTop: 'var(--ds-size-4)' }} />
 
-      <Paragraph style={{ margin: 'var(--ds-spacing-2) 0' }}>
+      <Paragraph style={{ margin: 'var(--ds-size-2) 0' }}>
         Du har skrevet inn: {value}
       </Paragraph>
       <Button onClick={() => setValue('Kake')}>Jeg vil ha Kake</Button>

--- a/packages/react/stories/Typography.stories.tsx
+++ b/packages/react/stories/Typography.stories.tsx
@@ -13,12 +13,12 @@ export const EksempelTekst: StoryFn = () => (
     <Heading
       level={1}
       data-size='xl'
-      style={{ marginBottom: 'var(--ds-spacing-2)' }}
+      style={{ marginBottom: 'var(--ds-size-2)' }}
     >
       Samordnet registermelding (H1)
     </Heading>
 
-    <Paragraph style={{ marginBottom: 'var(--ds-spacing-2)' }} variant='long'>
+    <Paragraph style={{ marginBottom: 'var(--ds-size-2)' }} variant='long'>
       Her kan du registrere nye virksomheter, som for eksempel
       enkeltpersonforetak, foreninger, aksjeselskap, ansvarlige selskap,
       samvirkeforetak og stiftelser. De aller fleste organisasjonsformene kan
@@ -28,12 +28,12 @@ export const EksempelTekst: StoryFn = () => (
     <Heading
       level={2}
       data-size='lg'
-      style={{ marginBottom: 'var(--ds-spacing-2)' }}
+      style={{ marginBottom: 'var(--ds-size-2)' }}
     >
       Når skal du bruke skjemaet? (H2)
     </Heading>
 
-    <Paragraph style={{ marginBottom: 'var(--ds-spacing-2)' }}>
+    <Paragraph style={{ marginBottom: 'var(--ds-size-2)' }}>
       Denne tjenesten kan du bruke for å melde opplysninger til
       Enhetsregisteret, Foretaksregisteret, Frivillighetsregisteret, NAV
       Aa-registeret, Virksomhets- og foretaksregisteret hos SSB,
@@ -44,12 +44,12 @@ export const EksempelTekst: StoryFn = () => (
     <Heading
       level={3}
       data-size='md'
-      style={{ marginBottom: 'var(--ds-spacing-2)' }}
+      style={{ marginBottom: 'var(--ds-size-2)' }}
     >
       Signering (H3)
     </Heading>
 
-    <Paragraph variant='short' style={{ marginBottom: 'var(--ds-spacing-2)' }}>
+    <Paragraph variant='short' style={{ marginBottom: 'var(--ds-size-2)' }}>
       Når du skal signere meldingen vil du motta en signeringsoppgave i
       meldingsboksen din i Altinn. Meldingen blir ikke sendt til behandling før
       alle har signert.
@@ -58,12 +58,12 @@ export const EksempelTekst: StoryFn = () => (
     <Heading
       level={4}
       data-size='sm'
-      style={{ marginBottom: 'var(--ds-spacing-2)' }}
+      style={{ marginBottom: 'var(--ds-size-2)' }}
     >
       Krav om rolle for signering (H4)
     </Heading>
 
-    <Paragraph style={{ marginBottom: 'var(--ds-spacing-2)' }}>
+    <Paragraph style={{ marginBottom: 'var(--ds-size-2)' }}>
       For å signere på vegne av en virksomhet, trenger du Altinn-rollen Signerer
       av Samordnet registermelding. Du kan se hvilke roller du har for en aktør
       på menypunktet Profil, Skjema og tjenester du har rettighet til. Om du
@@ -74,12 +74,12 @@ export const EksempelTekst: StoryFn = () => (
     <Heading
       level={5}
       data-size='xs'
-      style={{ marginBottom: 'var(--ds-spacing-2)' }}
+      style={{ marginBottom: 'var(--ds-size-2)' }}
     >
       Personvern (H5)
     </Heading>
 
-    <Paragraph variant='short' style={{ marginBottom: 'var(--ds-spacing-2)' }}>
+    <Paragraph variant='short' style={{ marginBottom: 'var(--ds-size-2)' }}>
       Personvernerklæringen gir informasjon om hvilke personopplysninger vi
       behandler, hvordan disse blir behandlet og hvilke rettigheter du har.
     </Paragraph>
@@ -91,12 +91,12 @@ export const EksempelTekstDark: StoryFn = () => (
     <Heading
       level={1}
       data-size='xl'
-      style={{ marginBottom: 'var(--ds-spacing-2)' }}
+      style={{ marginBottom: 'var(--ds-size-2)' }}
     >
       Samordnet registermelding (H1)
     </Heading>
 
-    <Paragraph style={{ marginBottom: 'var(--ds-spacing-2)' }} variant='long'>
+    <Paragraph style={{ marginBottom: 'var(--ds-size-2)' }} variant='long'>
       Her kan du registrere nye virksomheter, som for eksempel
       enkeltpersonforetak, foreninger, aksjeselskap, ansvarlige selskap,
       samvirkeforetak og stiftelser. De aller fleste organisasjonsformene kan
@@ -106,12 +106,12 @@ export const EksempelTekstDark: StoryFn = () => (
     <Heading
       level={2}
       data-size='lg'
-      style={{ marginBottom: 'var(--ds-spacing-2)' }}
+      style={{ marginBottom: 'var(--ds-size-2)' }}
     >
       Når skal du bruke skjemaet? (H2)
     </Heading>
 
-    <Paragraph style={{ marginBottom: 'var(--ds-spacing-2)' }}>
+    <Paragraph style={{ marginBottom: 'var(--ds-size-2)' }}>
       Denne tjenesten kan du bruke for å melde opplysninger til
       Enhetsregisteret, Foretaksregisteret, Frivillighetsregisteret, NAV
       Aa-registeret, Virksomhets- og foretaksregisteret hos SSB,
@@ -122,12 +122,12 @@ export const EksempelTekstDark: StoryFn = () => (
     <Heading
       level={3}
       data-size='md'
-      style={{ marginBottom: 'var(--ds-spacing-2)' }}
+      style={{ marginBottom: 'var(--ds-size-2)' }}
     >
       Signering (H3)
     </Heading>
 
-    <Paragraph variant='short' style={{ marginBottom: 'var(--ds-spacing-2)' }}>
+    <Paragraph variant='short' style={{ marginBottom: 'var(--ds-size-2)' }}>
       Når du skal signere meldingen vil du motta en signeringsoppgave i
       meldingsboksen din i Altinn. Meldingen blir ikke sendt til behandling før
       alle har signert.
@@ -136,12 +136,12 @@ export const EksempelTekstDark: StoryFn = () => (
     <Heading
       level={4}
       data-size='sm'
-      style={{ marginBottom: 'var(--ds-spacing-2)' }}
+      style={{ marginBottom: 'var(--ds-size-2)' }}
     >
       Krav om rolle for signering (H4)
     </Heading>
 
-    <Paragraph style={{ marginBottom: 'var(--ds-spacing-2)' }}>
+    <Paragraph style={{ marginBottom: 'var(--ds-size-2)' }}>
       For å signere på vegne av en virksomhet, trenger du Altinn-rollen Signerer
       av Samordnet registermelding. Du kan se hvilke roller du har for en aktør
       på menypunktet Profil, Skjema og tjenester du har rettighet til. Om du
@@ -152,12 +152,12 @@ export const EksempelTekstDark: StoryFn = () => (
     <Heading
       level={5}
       data-size='xs'
-      style={{ marginBottom: 'var(--ds-spacing-2)' }}
+      style={{ marginBottom: 'var(--ds-size-2)' }}
     >
       Personvern (H5)
     </Heading>
 
-    <Paragraph variant='short' style={{ marginBottom: 'var(--ds-spacing-2)' }}>
+    <Paragraph variant='short' style={{ marginBottom: 'var(--ds-size-2)' }}>
       Personvernerklæringen gir informasjon om hvilke personopplysninger vi
       behandler, hvordan disse blir behandlet og hvilke rettigheter du har.
     </Paragraph>

--- a/packages/react/stories/testing.stories.tsx
+++ b/packages/react/stories/testing.stories.tsx
@@ -51,7 +51,7 @@ export default {
       disable: true,
     },
     customStyles: {
-      padding: 'var(--ds-spacing-4)',
+      padding: 'var(--ds-size-4)',
       background: 'var(--ds-color-neutral-background-default)',
       borderRadius: 'var(--ds-border-radius-md)',
     },
@@ -68,7 +68,7 @@ export const MediumRow: StoryFn<{
         style={{
           display: 'flex',
           alignItems: 'center',
-          gap: 'var(--ds-spacing-2)',
+          gap: 'var(--ds-size-2)',
           background: 'rgba(255 0 0/0.3)',
           flexDirection: direction,
         }}
@@ -96,7 +96,7 @@ export const MediumRow: StoryFn<{
         style={{
           display: 'flex',
           alignItems: 'center',
-          gap: 'var(--ds-spacing-2)',
+          gap: 'var(--ds-size-2)',
           background: 'rgba(255 0 0/0.3)',
           flexDirection: direction,
         }}
@@ -342,10 +342,10 @@ export const Sizes: StoryFn = () => {
           <Modal.TriggerContext>
             <Modal.Trigger>Open Modal</Modal.Trigger>
             <Modal>
-              <Heading style={{ marginBottom: 'var(--ds-spacing-2)' }}>
+              <Heading style={{ marginBottom: 'var(--ds-size-2)' }}>
                 Modal header
               </Heading>
-              <Paragraph style={{ marginBottom: 'var(--ds-spacing-2)' }}>
+              <Paragraph style={{ marginBottom: 'var(--ds-size-2)' }}>
                 Lorem ipsum dolor sit, amet consectetur adipisicing elit.
                 Blanditiis doloremque obcaecati assumenda odio ducimus sunt et.
               </Paragraph>

--- a/packages/react/stories/testing.stories.tsx
+++ b/packages/react/stories/testing.stories.tsx
@@ -246,7 +246,7 @@ export const Sizes: StoryFn = () => {
       {sizes.map((size) => (
         <div
           key={size}
-          style={{ display: 'flex', gap: 'var(--ds-sizing-2)' }}
+          style={{ display: 'flex', gap: 'var(--ds-size-2)' }}
           data-size={size}
         >
           <Chip.Radio>Radio</Chip.Radio>

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -39,7 +39,7 @@ import '@digdir/designsystemet-theme/altinn.css';
 
 ```css
 div {
-  padding: var(--ds-spacing-1);
+  padding: var(--ds-size-1);
 }
 ```
 


### PR DESCRIPTION
Resolves #2934 

Made a shim for renaming `spacing` & `sizing` to `size` as design-tokens for theme will be done in a separate PR.

Added shim in `css/src/index.css`, apart from that just search and replace `spacing`/`sizing` with `size`.

Did not update all code under Figma plugin as there are som duplicates there that needs to be resolved first.