### PR TITLE
refactor: :label:  Make `data-size` and `data-color` behave more predictable

### DIFF
--- a/.changeset/long-stingrays-repeat.md
+++ b/.changeset/long-stingrays-repeat.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+Loosen default types for `data-color` and `data-size` to support accept `string`

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -120,6 +120,10 @@ const components = {
 };
 
 const preview: Preview = {
+  argTypes: {
+    'data-color': { control: { type: 'text' } },
+    'data-size': { control: { type: 'text' } },
+  },
   parameters: {
     layout: 'centered',
     viewMode: 'docs',

--- a/packages/react/src/components/Alert/Alert.stories.tsx
+++ b/packages/react/src/components/Alert/Alert.stories.tsx
@@ -20,6 +20,8 @@ export const Preview: Story = (args) => <Alert {...args}></Alert>;
 
 Preview.args = {
   children: 'En beskjed det er viktig at brukeren ser',
+  'data-color': 'info',
+  'data-size': 'md',
 };
 
 export const VariantInfo: Story = (args) => (

--- a/packages/react/src/components/Alert/Alert.stories.tsx
+++ b/packages/react/src/components/Alert/Alert.stories.tsx
@@ -19,8 +19,6 @@ export default meta;
 export const Preview: Story = (args) => <Alert {...args}></Alert>;
 
 Preview.args = {
-  'data-color': undefined,
-  'data-size': undefined,
   children: 'En beskjed det er viktig at brukeren ser',
 };
 

--- a/packages/react/src/components/Alert/Alert.stories.tsx
+++ b/packages/react/src/components/Alert/Alert.stories.tsx
@@ -21,7 +21,6 @@ export const Preview: Story = (args) => <Alert {...args}></Alert>;
 Preview.args = {
   children: 'En beskjed det er viktig at brukeren ser',
   'data-color': 'info',
-  'data-size': 'md',
 };
 
 export const VariantInfo: Story = (args) => (

--- a/packages/react/src/components/Alert/Alert.stories.tsx
+++ b/packages/react/src/components/Alert/Alert.stories.tsx
@@ -19,7 +19,7 @@ export default meta;
 export const Preview: Story = (args) => <Alert {...args}></Alert>;
 
 Preview.args = {
-  'data-color': 'info',
+  'data-color': undefined,
   'data-size': undefined,
   children: 'En beskjed det er viktig at brukeren ser',
 };

--- a/packages/react/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/react/src/components/Avatar/Avatar.stories.tsx
@@ -27,7 +27,6 @@ export const Preview: Story = (args) => <Avatar {...args} />;
 
 Preview.args = {
   'aria-label': 'Ola Nordmann',
-  'data-color': undefined,
   'data-size': 'md',
   variant: 'circle',
   children: '',

--- a/packages/react/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/react/src/components/Avatar/Avatar.stories.tsx
@@ -27,7 +27,6 @@ export const Preview: Story = (args) => <Avatar {...args} />;
 
 Preview.args = {
   'aria-label': 'Ola Nordmann',
-  'data-size': 'md',
   variant: 'circle',
   children: '',
 };

--- a/packages/react/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/react/src/components/Avatar/Avatar.stories.tsx
@@ -27,7 +27,7 @@ export const Preview: Story = (args) => <Avatar {...args} />;
 
 Preview.args = {
   'aria-label': 'Ola Nordmann',
-  'data-color': 'accent',
+  'data-color': undefined,
   'data-size': 'md',
   variant: 'circle',
   children: '',

--- a/packages/react/src/components/Avatar/Avatar.tsx
+++ b/packages/react/src/components/Avatar/Avatar.tsx
@@ -2,7 +2,6 @@ import { Slot } from '@radix-ui/react-slot';
 import cl from 'clsx/lite';
 import { Fragment, forwardRef } from 'react';
 import type { HTMLAttributes, ReactNode } from 'react';
-import type { Color } from '../../colors';
 import type { DefaultProps, Size } from '../../types';
 import type { MergeRight } from '../../utilities';
 
@@ -13,11 +12,6 @@ export type AvatarProps = MergeRight<
      * The name of the person the avatar represents.
      */
     'aria-label': string;
-    /**
-     * The color of the avatar.
-     * @default accent
-     */
-    'data-color'?: Color;
     /**
      * The size of the avatar.
      */

--- a/packages/react/src/components/Badge/Badge.stories.tsx
+++ b/packages/react/src/components/Badge/Badge.stories.tsx
@@ -26,7 +26,6 @@ export const Preview: Story = (args) => <Badge {...args} />;
 
 Preview.args = {
   'data-size': 'md',
-  'data-color': undefined,
   count: 15,
   maxCount: 9,
 };

--- a/packages/react/src/components/Badge/Badge.stories.tsx
+++ b/packages/react/src/components/Badge/Badge.stories.tsx
@@ -25,7 +25,6 @@ export default meta;
 export const Preview: Story = (args) => <Badge {...args} />;
 
 Preview.args = {
-  'data-size': 'md',
   count: 15,
   maxCount: 9,
 };

--- a/packages/react/src/components/Badge/Badge.stories.tsx
+++ b/packages/react/src/components/Badge/Badge.stories.tsx
@@ -26,7 +26,7 @@ export const Preview: Story = (args) => <Badge {...args} />;
 
 Preview.args = {
   'data-size': 'md',
-  'data-color': 'accent',
+  'data-color': undefined,
   count: 15,
   maxCount: 9,
 };

--- a/packages/react/src/components/Badge/Badge.tsx
+++ b/packages/react/src/components/Badge/Badge.tsx
@@ -1,16 +1,11 @@
 import cl from 'clsx/lite';
 import { type HTMLAttributes, forwardRef } from 'react';
-import type { Color } from '../../colors';
 import type { DefaultProps } from '../../types';
 import type { MergeRight } from '../../utilities';
 
 export type BadgeProps = MergeRight<
   DefaultProps & HTMLAttributes<HTMLSpanElement>,
   {
-    /**
-     * The color of the badge. If left unspecified, the color is inherited from the nearest ancestor with data-color.
-     */
-    'data-color'?: Color;
     /**
      * The number to display in the badge
      */

--- a/packages/react/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/react/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -5,9 +5,6 @@ import { Breadcrumbs } from '.';
 export default {
   title: 'Komponenter/Breadcrumbs',
   component: Breadcrumbs,
-  args: {
-    'data-size': 'md',
-  },
 } as Meta;
 
 export const Preview: StoryFn<typeof Breadcrumbs> = (args) => (

--- a/packages/react/src/components/Button/Button.stories.tsx
+++ b/packages/react/src/components/Button/Button.stories.tsx
@@ -42,8 +42,6 @@ export const Preview: Story = {
     children: 'Knapp',
     disabled: false,
     variant: 'primary',
-    'data-color': undefined,
-    'data-size': 'md',
     icon: false,
   },
 };

--- a/packages/react/src/components/Button/Button.stories.tsx
+++ b/packages/react/src/components/Button/Button.stories.tsx
@@ -42,7 +42,7 @@ export const Preview: Story = {
     children: 'Knapp',
     disabled: false,
     variant: 'primary',
-    'data-color': 'accent',
+    'data-color': undefined,
     'data-size': 'md',
     icon: false,
   },

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -2,7 +2,6 @@ import { Slot, Slottable } from '@radix-ui/react-slot';
 import cl from 'clsx/lite';
 import { forwardRef } from 'react';
 import type { ButtonHTMLAttributes } from 'react';
-import type { Color } from '../../colors';
 import type { DefaultProps } from '../../types';
 import type { MergeRight } from '../../utilities';
 import { Spinner } from '../Spinner';
@@ -15,10 +14,6 @@ export type ButtonProps = MergeRight<
      * @default primary
      */
     variant?: 'primary' | 'secondary' | 'tertiary';
-    /** Specify which color palette to use.
-     * @default accent
-     */
-    'data-color'?: Color;
     /** Toggle icon only styling, pass icon as children
      * @default false
      */

--- a/packages/react/src/components/Card/Card.stories.tsx
+++ b/packages/react/src/components/Card/Card.stories.tsx
@@ -47,7 +47,7 @@ export const Preview: Story = (args) => (
 );
 
 Preview.args = {
-  'data-color': undefined,
+  'data-color': 'neutral',
 };
 
 export const Variants: StoryFn<typeof Card> = () => (

--- a/packages/react/src/components/Card/Card.stories.tsx
+++ b/packages/react/src/components/Card/Card.stories.tsx
@@ -47,7 +47,7 @@ export const Preview: Story = (args) => (
 );
 
 Preview.args = {
-  'data-color': 'neutral',
+  'data-color': undefined,
 };
 
 export const Variants: StoryFn<typeof Card> = () => (

--- a/packages/react/src/components/Card/Card.tsx
+++ b/packages/react/src/components/Card/Card.tsx
@@ -3,7 +3,6 @@ import { Slot } from '@radix-ui/react-slot';
 import cl from 'clsx/lite';
 import type { HTMLAttributes, ReactNode } from 'react';
 import { forwardRef, useEffect, useRef } from 'react';
-import type { CustomColors } from '../../colors';
 import type { DefaultProps } from '../../types';
 import type { MergeRight } from '../../utilities';
 
@@ -14,7 +13,7 @@ export type CardProps = MergeRight<
      * Changes background & border color.
      * @default neutral
      */
-    'data-color'?: 'subtle' | CustomColors;
+    'data-color'?: 'subtle' | DefaultProps['data-color'];
     asChild?: boolean;
     /** Instances of `Card.Block`, `Divider` or other React nodes */
     children: ReactNode;

--- a/packages/react/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.stories.tsx
@@ -24,7 +24,6 @@ export const Preview: Story = {
     disabled: false,
     readOnly: false,
     value: 'value',
-    'data-size': 'md',
   },
 };
 

--- a/packages/react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.tsx
@@ -1,7 +1,5 @@
 import type { ReactNode } from 'react';
 import { forwardRef } from 'react';
-
-import type { Color } from '../../colors';
 import type { DefaultProps, LabelRequired } from '../../types';
 import type { MergeRight } from '../../utilities';
 import { Field } from '../Field';
@@ -12,10 +10,6 @@ import { ValidationMessage } from '../ValidationMessage';
 export type CheckboxProps = MergeRight<
   DefaultProps & Omit<InputProps, 'type' | 'role' | 'size'>,
   {
-    /** The color of the fill for checked and indeterminate checkboxes.
-     * If left unspecified, the color is inherited from the nearest ancestor with data-color.
-     */
-    'data-color'?: Color;
     /** Optional aria-label */
     'aria-label'?: string;
     /** Checkbox label */

--- a/packages/react/src/components/Chip/Chips.tsx
+++ b/packages/react/src/components/Chip/Chips.tsx
@@ -2,15 +2,11 @@ import { Slot, Slottable } from '@radix-ui/react-slot';
 import cl from 'clsx/lite';
 import { forwardRef } from 'react';
 import type { ButtonHTMLAttributes, InputHTMLAttributes } from 'react';
-import type { Color } from '../../colors';
 import type { DefaultProps } from '../../types';
 import type { MergeRight } from '../../utilities';
 import { Input } from '../Input';
 
 type ChipBaseProps = {
-  /** Specify which color palette to use. If left unspecified, the color is inherited from the nearest ancestor with data-color.
-   */
-  'data-color'?: Color;
   /**
    * Change the default rendered element for the one passed as a child, merging their props and behavior.
    * @default false

--- a/packages/react/src/components/Combobox/Combobox.tsx
+++ b/packages/react/src/components/Combobox/Combobox.tsx
@@ -3,8 +3,6 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import cl from 'clsx/lite';
 import { forwardRef, useEffect, useRef, useState } from 'react';
 import type { InputHTMLAttributes, ReactNode } from 'react';
-
-import type { PortalProps } from '../../types';
 import { omit, useDebounceCallback } from '../../utilities';
 import type { FormFieldProps } from '../../utilities/hooks/useFormField/useFormField';
 import { useFormField } from '../../utilities/hooks/useFormField/useFormField';
@@ -114,8 +112,13 @@ export type ComboboxProps = {
    * @default (option) => 'Slett ' + option.label,
    */
   chipSrLabel?: (option: Option) => string;
-} & PortalProps &
-  FormFieldProps &
+  /**
+   * Portals the floating element outside of the app root and into the body.
+   * @see https://floating-ui.com/docs/floatingportal
+   * @default false
+   */
+  portal?: boolean;
+} & FormFieldProps &
   Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>;
 
 export const ComboboxComponent = forwardRef<HTMLInputElement, ComboboxProps>(

--- a/packages/react/src/components/Details/Details.stories.tsx
+++ b/packages/react/src/components/Details/Details.stories.tsx
@@ -24,10 +24,6 @@ export const Preview: StoryFn<typeof Details> = (args) => (
     </Details.Content>
   </Details>
 );
-// Default values are selected in Controls
-Preview.args = {
-  'data-color': undefined,
-};
 
 export const InCard: StoryFn<typeof Details> = () => (
   <Card data-color='neutral'>

--- a/packages/react/src/components/Details/Details.stories.tsx
+++ b/packages/react/src/components/Details/Details.stories.tsx
@@ -26,7 +26,7 @@ export const Preview: StoryFn<typeof Details> = (args) => (
 );
 // Default values are selected in Controls
 Preview.args = {
-  'data-color': 'neutral',
+  'data-color': undefined,
 };
 
 export const InCard: StoryFn<typeof Details> = () => (

--- a/packages/react/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.stories.tsx
@@ -65,7 +65,6 @@ export const Preview: StoryFn<typeof Dropdown> = (args) => {
 
 Preview.args = {
   placement: 'bottom-end',
-  'data-size': 'md',
 };
 
 export const Icons: StoryFn<typeof Dropdown> = (args) => {

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -2,7 +2,6 @@ import cl from 'clsx/lite';
 import { forwardRef } from 'react';
 
 import type { Placement } from '@floating-ui/react';
-import type { Color } from '../../colors';
 import type { DefaultProps } from '../../types';
 import type { MergeRight } from '../../utilities';
 import { Popover } from '../Popover';
@@ -11,9 +10,6 @@ import type { PopoverProps } from '../Popover';
 export type DropdownProps = MergeRight<
   DefaultProps & Omit<PopoverProps, 'variant'>,
   {
-    /** Specify which color palette to use. If left unspecified, the color is inherited from the nearest ancestor with data-color.
-     */
-    'data-color'?: Color;
     /** The placement of the dropdown
      * @default bottom-end
      */

--- a/packages/react/src/components/ErrorSummary/ErrorSummary.stories.tsx
+++ b/packages/react/src/components/ErrorSummary/ErrorSummary.stories.tsx
@@ -30,9 +30,6 @@ export const Preview: Story = (args) => (
     </ErrorSummary.List>
   </ErrorSummary>
 );
-Preview.args = {
-  'data-size': 'md',
-};
 
 export const WithForm: Story = () => (
   <>

--- a/packages/react/src/components/Heading/Heading.stories.tsx
+++ b/packages/react/src/components/Heading/Heading.stories.tsx
@@ -14,6 +14,5 @@ type Story = StoryObj<typeof Heading>;
 export const Preview: Story = {
   args: {
     children: 'Tittel tekst',
-    'data-size': 'xl',
   },
 };

--- a/packages/react/src/components/Heading/Heading.tsx
+++ b/packages/react/src/components/Heading/Heading.tsx
@@ -11,7 +11,15 @@ export type HeadingProps = {
   level?: 1 | 2 | 3 | 4 | 5 | 6;
   /** Changes text sizing
    */
-  'data-size'?: '2xs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+  'data-size'?:
+    | '2xs'
+    | 'xs'
+    | 'sm'
+    | 'md'
+    | 'lg'
+    | 'xl'
+    | '2xl'
+    | (string & {});
   /**
    * Change the default rendered element for the one passed as a child, merging their props and behavior.
    * @default false

--- a/packages/react/src/components/HelpText/HelpText.stories.tsx
+++ b/packages/react/src/components/HelpText/HelpText.stories.tsx
@@ -14,7 +14,6 @@ export const Preview: Story = {
   args: {
     'aria-label': 'Help text title',
     children: 'Help text content',
-    'data-size': 'md',
   },
 };
 

--- a/packages/react/src/components/Input/Input.stories.tsx
+++ b/packages/react/src/components/Input/Input.stories.tsx
@@ -82,7 +82,6 @@ export const Preview: Story = {
     'aria-invalid': false,
     disabled: false,
     readOnly: false,
-    'data-size': 'md',
     type: 'text',
     role: 'checkbox',
     name: 'inputs',

--- a/packages/react/src/components/Input/Input.tsx
+++ b/packages/react/src/components/Input/Input.tsx
@@ -1,7 +1,6 @@
 import cl from 'clsx/lite';
 import type { InputHTMLAttributes } from 'react';
 import { forwardRef } from 'react';
-import type { Color } from '../../colors';
 import type { DefaultProps } from '../../types';
 import type { MergeRight } from '../../utilities';
 
@@ -10,11 +9,6 @@ type InputAttr = InputHTMLAttributes<HTMLInputElement>;
 export type InputProps = MergeRight<
   DefaultProps & Omit<InputAttr, 'prefix'>,
   {
-    /**
-     * Sets a color palette which **may** be used by this component, depending on the `type` prop.
-     * If left unspecified, the color is inherited from the nearest ancestor with data-color.
-     */
-    'data-color'?: Color;
     /** Supported `input` types */
     type?: InputAttr['type'];
     /** Defines the width of `Input` in count of characters.

--- a/packages/react/src/components/Label/Label.stories.tsx
+++ b/packages/react/src/components/Label/Label.stories.tsx
@@ -14,7 +14,6 @@ type Story = StoryObj<typeof Label>;
 export const Preview: Story = {
   args: {
     children: 'Vennligst skriv inn fødselsnummer. 11 tegn',
-    'data-size': 'md',
     weight: 'medium',
   },
 };

--- a/packages/react/src/components/Link/Link.stories.tsx
+++ b/packages/react/src/components/Link/Link.stories.tsx
@@ -26,7 +26,7 @@ export const Normal: Story = {
   args: {
     children: 'Gå til designsystemet',
     href: designsystemetLink,
-    'data-color': 'accent',
+    'data-color': undefined,
   },
 };
 

--- a/packages/react/src/components/Link/Link.stories.tsx
+++ b/packages/react/src/components/Link/Link.stories.tsx
@@ -26,7 +26,6 @@ export const Normal: Story = {
   args: {
     children: 'Gå til designsystemet',
     href: designsystemetLink,
-    'data-color': undefined,
   },
 };
 

--- a/packages/react/src/components/Link/Link.tsx
+++ b/packages/react/src/components/Link/Link.tsx
@@ -2,7 +2,6 @@ import { Slot } from '@radix-ui/react-slot';
 import cl from 'clsx/lite';
 import type { AnchorHTMLAttributes, ReactNode } from 'react';
 import { forwardRef } from 'react';
-import type { Color } from '../../colors';
 import type { DefaultProps } from '../../types';
 import type { MergeRight } from '../../utilities';
 
@@ -13,11 +12,6 @@ export type LinkProps = MergeRight<
     children: ReactNode;
     /** Custom class name for the link. This will be appended to the design system class names. */
     className?: string;
-    /**
-     * The color of the link.
-     * @default accent
-     */
-    'data-color'?: Color;
     /** The URL that the link points to. This can also be an email address (starting with `mailto:`) or a phone number (staring with `tel:`). */
     href?: string;
     /**

--- a/packages/react/src/components/List/List.stories.tsx
+++ b/packages/react/src/components/List/List.stories.tsx
@@ -19,10 +19,6 @@ export const Preview: Story = (args) => (
   </List.Unordered>
 );
 
-Preview.args = {
-  'data-size': 'md',
-};
-
 export const Sortert: StoryFn<typeof List.Ordered> = (args) => (
   <>
     <Heading

--- a/packages/react/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/react/src/components/Pagination/Pagination.stories.tsx
@@ -45,10 +45,6 @@ export const Preview: StoryFn<typeof Pagination> = (args) => {
   );
 };
 
-Preview.args = {
-  'data-size': 'md',
-};
-
 export const WithAnchor: StoryFn<UsePaginationProps> = (args) => {
   const [, updateArgs] = useArgs();
   const { pages, nextButtonProps, prevButtonProps } = usePagination({

--- a/packages/react/src/components/Pagination/Pagination.tsx
+++ b/packages/react/src/components/Pagination/Pagination.tsx
@@ -2,17 +2,12 @@ import { Slot } from '@radix-ui/react-slot';
 import cl from 'clsx/lite';
 import { forwardRef } from 'react';
 import type { HTMLAttributes } from 'react';
-import type { Color } from '../../colors';
 import type { DefaultProps } from '../../types';
 import type { MergeRight } from '../../utilities';
 
 export type PaginationProps = MergeRight<
   DefaultProps & HTMLAttributes<HTMLElement>,
   {
-    /**
-     * The color of the pagination buttons. If left unspecified, the color is inherited from the nearest ancestor with data-color.
-     */
-    'data-color'?: Color;
     /**
      * Sets the screen reader label for the Pagination area
      * @default Sidenavigering

--- a/packages/react/src/components/Paragraph/Paragraph.stories.tsx
+++ b/packages/react/src/components/Paragraph/Paragraph.stories.tsx
@@ -15,7 +15,6 @@ export const Preview: Story = {
   args: {
     children:
       'Personvernerklæringen gir informasjon om hvilke personopplysninger vi behandler, hvordan disse blir behandlet og hvilke rettigheter du har.',
-    'data-size': 'md',
     variant: 'default',
   },
 };

--- a/packages/react/src/components/Paragraph/Paragraph.tsx
+++ b/packages/react/src/components/Paragraph/Paragraph.tsx
@@ -7,7 +7,7 @@ export type ParagraphProps = {
   /**
    * Changes text sizing
    */
-  'data-size'?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+  'data-size'?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | (string & {});
   /**
    *  Adjusts styling for paragraph length
    *  @default 'default'

--- a/packages/react/src/components/Popover/Popover.stories.tsx
+++ b/packages/react/src/components/Popover/Popover.stories.tsx
@@ -40,7 +40,6 @@ export const Preview: StoryFn<typeof Popover> = (args) => {
 
 Preview.args = {
   placement: 'top',
-  'data-size': 'md',
 };
 Preview.parameters = {
   customStyles: {

--- a/packages/react/src/components/Popover/Popover.stories.tsx
+++ b/packages/react/src/components/Popover/Popover.stories.tsx
@@ -41,7 +41,7 @@ export const Preview: StoryFn<typeof Popover> = (args) => {
 Preview.args = {
   placement: 'top',
   'data-size': 'md',
-  'data-color': 'neutral',
+  'data-color': undefined,
 };
 Preview.parameters = {
   customStyles: {

--- a/packages/react/src/components/Popover/Popover.stories.tsx
+++ b/packages/react/src/components/Popover/Popover.stories.tsx
@@ -41,7 +41,6 @@ export const Preview: StoryFn<typeof Popover> = (args) => {
 Preview.args = {
   placement: 'top',
   'data-size': 'md',
-  'data-color': undefined,
 };
 Preview.parameters = {
   customStyles: {

--- a/packages/react/src/components/Popover/Popover.tsx
+++ b/packages/react/src/components/Popover/Popover.tsx
@@ -12,7 +12,6 @@ import cl from 'clsx/lite';
 import { forwardRef, useContext, useRef, useState } from 'react';
 import type { HTMLAttributes } from 'react';
 import { useEffect } from 'react';
-import type { Color } from '../../colors';
 import type { DefaultProps } from '../../types';
 import type { MergeRight } from '../../utilities';
 import { Context } from './PopoverTriggerContext';
@@ -44,10 +43,7 @@ export type PopoverProps = MergeRight<
      * @default top
      */
     placement?: Placement;
-    /**
-     * The color of the popover.
-     */
-    'data-color'?: Color;
+
     /**
      * Use this to make the popover controlled.
      * @default undefined

--- a/packages/react/src/components/Radio/Radio.stories.tsx
+++ b/packages/react/src/components/Radio/Radio.stories.tsx
@@ -21,7 +21,6 @@ export const Preview: StoryObj<typeof Radio> = {
     disabled: false,
     readOnly: false,
     value: 'value',
-    'data-size': 'md',
   },
 };
 

--- a/packages/react/src/components/Radio/Radio.tsx
+++ b/packages/react/src/components/Radio/Radio.tsx
@@ -1,7 +1,5 @@
 import type { ReactNode } from 'react';
 import { forwardRef } from 'react';
-
-import type { Color } from '../../colors';
 import type { DefaultProps, LabelRequired } from '../../types';
 import type { MergeRight } from '../../utilities';
 import { Field } from '../Field';
@@ -12,10 +10,6 @@ import { ValidationMessage } from '../ValidationMessage';
 export type RadioProps = MergeRight<
   DefaultProps & Omit<InputProps, 'type' | 'role' | 'size'>,
   {
-    /** The color of the fill for selected radios.
-     * If left unspecified, the color is inherited from the nearest ancestor with data-color.
-     */
-    'data-color'?: Color;
     /** Optional aria-label */
     'aria-label'?: string;
     /** Radio label */

--- a/packages/react/src/components/Select/Select.stories.tsx
+++ b/packages/react/src/components/Select/Select.stories.tsx
@@ -29,7 +29,6 @@ export const Preview: StoryFn<typeof Select> = (args) => (
 
 Preview.args = {
   'aria-invalid': false,
-  'data-size': 'md',
   width: 'full',
   disabled: false,
   readOnly: false,

--- a/packages/react/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/react/src/components/Spinner/Spinner.stories.tsx
@@ -21,7 +21,6 @@ export const Preview: Story = (args) => <Spinner {...args} />;
 
 Preview.args = {
   'aria-label': 'Henter kaffi',
-  'data-size': 'md',
 };
 
 export const Variants: Story = () => (

--- a/packages/react/src/components/Spinner/Spinner.tsx
+++ b/packages/react/src/components/Spinner/Spinner.tsx
@@ -1,8 +1,6 @@
 import { useMergeRefs } from '@floating-ui/react';
 import cl from 'clsx/lite';
 import { type ComponentPropsWithoutRef, forwardRef } from 'react';
-
-import type { Color } from '../../colors';
 import { useSynchronizedAnimation } from '../../utilities';
 
 export type SpinnerProps = {
@@ -11,11 +9,7 @@ export type SpinnerProps = {
   /**
    * Spinner size
    */
-  'data-size'?: '2xs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
-  /**
-   * The color of the spinner. If left unspecified, the color is inherited from the nearest ancestor with data-color.
-   */
-  'data-color'?: Color;
+  'data-size'?: '2xs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | (string & {});
 } & ComponentPropsWithoutRef<'svg'> &
   (
     | { 'aria-label': string; 'aria-hidden'?: never }

--- a/packages/react/src/components/Switch/Switch.stories.tsx
+++ b/packages/react/src/components/Switch/Switch.stories.tsx
@@ -13,7 +13,6 @@ export default {
 
 export const Preview: Story = {
   args: {
-    'data-size': 'md',
     label: 'Switch',
     description: '',
     disabled: false,

--- a/packages/react/src/components/Switch/Switch.tsx
+++ b/packages/react/src/components/Switch/Switch.tsx
@@ -24,10 +24,6 @@ export type SwitchProps = MergeRight<
      */
     position?: FieldProps['position'];
     /**
-     * Changes field size and paddings
-     */
-    'data-size'?: 'sm' | 'md' | 'lg';
-    /**
      * Specify which color palette to use. If left unspecified, the color is inherited
      * from the nearest ancestor with data-color.
      */

--- a/packages/react/src/components/Switch/Switch.tsx
+++ b/packages/react/src/components/Switch/Switch.tsx
@@ -1,7 +1,5 @@
 import type { InputHTMLAttributes, ReactNode } from 'react';
 import { forwardRef } from 'react';
-
-import type { Color } from '../../colors';
 import type { DefaultProps, LabelRequired } from '../../types';
 import type { MergeRight } from '../../utilities';
 import { Field, type FieldProps } from '../Field';
@@ -23,11 +21,6 @@ export type SwitchProps = MergeRight<
      * @default start
      */
     position?: FieldProps['position'];
-    /**
-     * Specify which color palette to use. If left unspecified, the color is inherited
-     * from the nearest ancestor with data-color.
-     */
-    'data-color'?: Color;
   } & LabelRequired
 >;
 

--- a/packages/react/src/components/Table/Table.stories.tsx
+++ b/packages/react/src/components/Table/Table.stories.tsx
@@ -48,7 +48,6 @@ export const Preview: Story = (args) => {
 };
 
 Preview.args = {
-  'data-size': 'md',
   zebra: false,
   stickyHeader: false,
   border: false,

--- a/packages/react/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/react/src/components/Tabs/Tabs.stories.tsx
@@ -32,7 +32,6 @@ export const Preview: StoryFn<typeof Tabs> = (args) => (
 
 Preview.args = {
   defaultValue: 'value1',
-  'data-size': 'md',
 };
 
 export const IconsOnly: StoryFn<typeof Tabs> = () => (

--- a/packages/react/src/components/Tabs/Tabs.tsx
+++ b/packages/react/src/components/Tabs/Tabs.tsx
@@ -1,16 +1,12 @@
 import cl from 'clsx/lite';
 import type { HTMLAttributes } from 'react';
 import { createContext, forwardRef, useState } from 'react';
-import type { Color } from '../../colors';
 import type { DefaultProps } from '../../types';
 import type { MergeRight } from '../../utilities';
 
 export type TabsProps = MergeRight<
   DefaultProps & Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'value'>,
   {
-    /** Specify which color palette to use. If left unspecified, the color is inherited from the nearest ancestor with data-color.
-     */
-    'data-color'?: Color;
     /** Controlled state for `Tabs` component. */
     value?: string;
     /** Default value. */

--- a/packages/react/src/components/Tag/Tag.stories.tsx
+++ b/packages/react/src/components/Tag/Tag.stories.tsx
@@ -17,7 +17,7 @@ export const Preview: Story = {
   args: {
     children: 'New',
     'data-size': 'md',
-    'data-color': 'neutral',
+    'data-color': undefined,
   },
 };
 

--- a/packages/react/src/components/Tag/Tag.stories.tsx
+++ b/packages/react/src/components/Tag/Tag.stories.tsx
@@ -17,7 +17,6 @@ export const Preview: Story = {
   args: {
     children: 'New',
     'data-size': 'md',
-    'data-color': undefined,
   },
 };
 

--- a/packages/react/src/components/Tag/Tag.stories.tsx
+++ b/packages/react/src/components/Tag/Tag.stories.tsx
@@ -16,7 +16,6 @@ export default {
 export const Preview: Story = {
   args: {
     children: 'New',
-    'data-size': 'md',
   },
 };
 

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -1,20 +1,9 @@
 import cl from 'clsx/lite';
 import type { HTMLAttributes } from 'react';
 import { forwardRef } from 'react';
-import type { Color } from '../../colors';
 import type { DefaultProps } from '../../types';
-import type { MergeRight } from '../../utilities';
 
-export type TagProps = MergeRight<
-  DefaultProps & HTMLAttributes<HTMLSpanElement>,
-  {
-    /**
-     * Color of the tag.
-     * @default neutral
-     */
-    'data-color'?: Color;
-  }
->;
+export type TagProps = DefaultProps & HTMLAttributes<HTMLSpanElement>;
 
 /**
  * Use `Tag` to display a small piece of information.

--- a/packages/react/src/components/Tag/Tag.tsx
+++ b/packages/react/src/components/Tag/Tag.tsx
@@ -8,18 +8,11 @@ export type TagProps = DefaultProps & HTMLAttributes<HTMLSpanElement>;
 /**
  * Use `Tag` to display a small piece of information.
  * @example
- * <Tag color='success'>Success</Tag>
+ * <Tag>Success</Tag>
  */
 export const Tag = forwardRef<HTMLSpanElement, TagProps>(function Tag(
-  { color = 'neutral', className, ...rest },
+  { className, ...rest },
   ref,
 ) {
-  return (
-    <span
-      className={cl('ds-tag', className)}
-      data-color={color}
-      ref={ref}
-      {...rest}
-    />
-  );
+  return <span className={cl('ds-tag', className)} ref={ref} {...rest} />;
 });

--- a/packages/react/src/components/Textarea/Textarea.stories.tsx
+++ b/packages/react/src/components/Textarea/Textarea.stories.tsx
@@ -33,7 +33,6 @@ export const Preview: Story = {
   args: {
     disabled: false,
     readOnly: false,
-    'data-size': 'md',
     cols: 40,
     id: 'my-textarea',
   },

--- a/packages/react/src/components/Textfield/Textfield.stories.tsx
+++ b/packages/react/src/components/Textfield/Textfield.stories.tsx
@@ -50,7 +50,6 @@ export const Preview: Story = {
     label: 'Label',
     disabled: false,
     readOnly: false,
-    'data-size': 'md',
     multiline: false,
     description: '',
     error: '',

--- a/packages/react/src/components/ToggleGroup/ToggleGroup.stories.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroup.stories.tsx
@@ -35,7 +35,6 @@ export const Preview: StoryFn<typeof ToggleGroup> = (args) => {
 
 Preview.args = {
   defaultValue: 'innboks',
-  'data-size': 'md',
   name: 'toggle-group-nuts',
 };
 

--- a/packages/react/src/components/ToggleGroup/ToggleGroup.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroup.tsx
@@ -1,8 +1,6 @@
 import cl from 'clsx/lite';
 import type { HTMLAttributes } from 'react';
 import { createContext, forwardRef, useId, useState } from 'react';
-
-import type { Color } from '../../colors';
 import type { DefaultProps } from '../../types';
 import type { MergeRight } from '../../utilities';
 import { RovingFocusRoot } from '../../utilities/RovingFocus';
@@ -19,9 +17,6 @@ export const ToggleGroupContext = createContext<ToggleGroupContextProps>({});
 export type ToggleGroupProps = MergeRight<
   DefaultProps & Omit<HTMLAttributes<HTMLDivElement>, 'value' | 'onChange'>,
   {
-    /** Specify which color palette to use. If left unspecified, the color is inherited from the nearest ancestor with data-color.
-     */
-    'data-color'?: Color;
     /** Controlled state for `ToggleGroup` component. */
     value?: string;
     /** Default value. */

--- a/packages/react/src/components/ValidationMessage/ValidationMessage.stories.tsx
+++ b/packages/react/src/components/ValidationMessage/ValidationMessage.stories.tsx
@@ -15,6 +15,6 @@ export const Preview: Story = {
   args: {
     children: 'Dette er en valideringsmelding.',
     'data-size': 'md',
-    'data-color': 'danger',
+    'data-color': undefined,
   },
 };

--- a/packages/react/src/components/ValidationMessage/ValidationMessage.stories.tsx
+++ b/packages/react/src/components/ValidationMessage/ValidationMessage.stories.tsx
@@ -15,6 +15,5 @@ export const Preview: Story = {
   args: {
     children: 'Dette er en valideringsmelding.',
     'data-size': 'md',
-    'data-color': undefined,
   },
 };

--- a/packages/react/src/components/ValidationMessage/ValidationMessage.stories.tsx
+++ b/packages/react/src/components/ValidationMessage/ValidationMessage.stories.tsx
@@ -14,6 +14,5 @@ type Story = StoryObj<typeof ValidationMessage>;
 export const Preview: Story = {
   args: {
     children: 'Dette er en valideringsmelding.',
-    'data-size': 'md',
   },
 };

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -5,11 +5,11 @@ export type Size = 'sm' | 'md' | 'lg';
 
 export type DefaultProps = {
   /**
-   * Choose between suggested sizes for descendants Designsystemet components.
+   * Sets a size for descendant Designsystemet components.
    */
   'data-size'?: Size | (string & {});
   /**
-   * Sets a color palette for descendants Designsystemet components.
+   * Sets a color for descendant Designsystemet components.
    */
   'data-color'?: Color | (string & {});
 };

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -3,22 +3,15 @@ import type { Color } from './colors';
 
 export type Size = 'sm' | 'md' | 'lg';
 
-export type PortalProps = {
-  /**
-   * Portals the floating element outside of the app root and into the body.
-   * @see https://floating-ui.com/docs/floatingportal
-   * @default false
-   */
-  portal?: boolean;
-};
-
 export type DefaultProps = {
-  'data-size'?: Size;
   /**
-   * Sets a color palette which may be used by descendants. Does not affect this component.
-   * If left unspecified, the color is inherited from the nearest ancestor with data-color.
+   * Choose between suggested sizes for descendants Designsystemet components.
    */
-  'data-color'?: Color;
+  'data-size'?: Size | (string & {});
+  /**
+   * Sets a color palette for descendants Designsystemet components.
+   */
+  'data-color'?: Color | (string & {});
 };
 
 export type LabelRequired =

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -5,11 +5,12 @@ export type Size = 'sm' | 'md' | 'lg';
 
 export type DefaultProps = {
   /**
-   * Sets a size for descendant Designsystemet components.
+   * Changes size for descendant Designsystemet components. Select from predefined sizes.
    */
   'data-size'?: Size | (string & {});
   /**
-   * Sets a color for descendant Designsystemet components.
+   * Changes color for descendant Designsystemet components.
+   * Select from predefined colors and colors defined using theme.designsystemet.no.
    */
   'data-color'?: Color | (string & {});
 };


### PR DESCRIPTION
#2943

- Made it so `data-size` and `data-color` also accept any string as default so its the same as behaviour for other data attributes.
  - Except for explicits components
- Removed references and default values for `data-size` and `data-color` in stories as thats contextual.
- Removed unnecessary override to `data-size` and `data-color` to make sure the jsdocs and behaviour is uniform.
- Added `data-color` and `data-size` as global `argTypes` for storybook so that they show up in controls for all components