### PR TITLE
feat: blacklist `input` types for `Textfield`

### DIFF
--- a/.changeset/proud-deers-poke.md
+++ b/.changeset/proud-deers-poke.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+Textfield: Blacklist some `input` types for `Textfield`

--- a/packages/react/src/components/Textfield/Textfield.stories.tsx
+++ b/packages/react/src/components/Textfield/Textfield.stories.tsx
@@ -14,32 +14,24 @@ export default {
     multiline: {
       type: 'boolean',
     },
-    // Using argType here to exclude values from React.HTMLInputTypeAttribute
     type: {
       control: 'select',
+      /* Only allowed types for Textfield */
       options: [
-        'checkbox',
         'date',
         'datetime-local',
         'email',
         'month',
         'number',
         'password',
-        'radio',
         'search',
         'tel',
         'text',
         'time',
         'url',
         'week',
-        // 'button',
         'color',
         'file',
-        // 'hidden',
-        // 'image',
-        // 'range',
-        // 'reset',
-        // 'submit',
       ],
     },
   },

--- a/packages/react/src/components/Textfield/Textfield.tsx
+++ b/packages/react/src/components/Textfield/Textfield.tsx
@@ -49,6 +49,20 @@ type TextfieldTextareaProps = {
 type TextfieldInputProps = {
   /** Use to render a `Textarea` instead of `Input` for multiline support  */
   multiline?: never | false;
+  /**
+   * type of the input field
+   */
+  type?: Omit<
+    InputProps['type'],
+    | 'button'
+    | 'image'
+    | 'range'
+    | 'reset'
+    | 'submit'
+    | 'checkbox'
+    | 'hidden'
+    | 'radio'
+  >;
 } & InputProps_;
 
 export type TextfieldProps = SharedTextfieldProps &


### PR DESCRIPTION
resolves #2869