### PR TITLE
fix(cli): outDir default wasn't used + remove unwanted console.logs

### DIFF
--- a/.changeset/twelve-paws-jog.md
+++ b/.changeset/twelve-paws-jog.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet": patch
+---
+
+outDir option was required, but it should have a default value

--- a/packages/cli/bin/options.ts
+++ b/packages/cli/bin/options.ts
@@ -7,7 +7,6 @@ const getOptionIfMatchingSource =
     option: K,
   ) => {
     const source = command.getOptionValueSource(option);
-    console.log(sources, source);
     if (sources.includes(source)) {
       return command.getOptionValue(option);
     }
@@ -26,4 +25,4 @@ export const getExplicitOptionOnly = getOptionIfMatchingSource('cli');
  * This function is basically the default behaviour, unlike {@link getExplicitOptionOnly}.
  * It is provided so that the program can choose its behaviour as needed.
  */
-export const getExplicitOrDefaultOption = getOptionIfMatchingSource('cli', 'default');
+export const getDefaultOrExplicitOption = getOptionIfMatchingSource('cli', 'default');


### PR DESCRIPTION
Before this change:
<img width="634" alt="image" src="https://github.com/user-attachments/assets/c79bfbe8-31cc-43cc-8e0e-cf8acbfa21f1" />

After:
<img width="634" alt="image" src="https://github.com/user-attachments/assets/3304f0de-96b3-46cc-bce5-58520d3184e5" />
