### PR TITLE
feat(cli): better error messages for wrong or missing options

### DIFF
--- a/.changeset/funny-peaches-lie.md
+++ b/.changeset/funny-peaches-lie.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet": minor
+---
+
+cli: better error messages for wrong or missing options

--- a/apps/theme/app/result/page.tsx
+++ b/apps/theme/app/result/page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { colorCliOptions } from '@digdir/designsystemet/tokens';
+import { cliOptions } from '@digdir/designsystemet/tokens';
 import { CodeSnippet, Container } from '@repo/components';
 import cl from 'clsx/lite';
 import { type ColorTheme, useThemeStore } from '../../store';
 import classes from './page.module.css';
+
+const colorCliOptions = cliOptions.theme.colors;
 
 export default function Result() {
   const themeName = useThemeStore((state) => state.themeName);

--- a/apps/theme/components/TokenModal/TokenModal.tsx
+++ b/apps/theme/components/TokenModal/TokenModal.tsx
@@ -7,7 +7,7 @@ import {
   Modal,
   Paragraph,
 } from '@digdir/designsystemet-react';
-import { colorCliOptions } from '@digdir/designsystemet/tokens';
+import { cliOptions } from '@digdir/designsystemet/tokens';
 import { InformationSquareIcon, StarIcon } from '@navikt/aksel-icons';
 import { CodeSnippet } from '@repo/components';
 import { useRef } from 'react';
@@ -16,6 +16,8 @@ import cl from 'clsx/lite';
 
 import { type ColorTheme, useThemeStore } from '../../store';
 import classes from './TokenModal.module.css';
+
+const colorCliOptions = cliOptions.theme.colors;
 
 export const TokenModal = () => {
   const modalRef = useRef<HTMLDialogElement>(null);

--- a/packages/cli/bin/config.ts
+++ b/packages/cli/bin/config.ts
@@ -1,24 +1,36 @@
+import * as R from 'ramda';
 import { z } from 'zod';
 import { convertToHex } from '../src/colors/index.js';
+import { cliOptions } from '../src/tokens/create.js';
+
+export function mapPathToOptionName(path: (string | number)[]) {
+  // replace "themes.some-theme-name" with "theme" to match cliOptions object
+  const normalisedPath = path[0] === 'themes' ? ['theme', ...R.drop(2, path)] : path;
+  const option = R.path(normalisedPath, cliOptions);
+  if (typeof option !== 'string') {
+    return;
+  }
+  return option;
+}
+
+const themeSchema = z.object({
+  colors: z.object({
+    main: z.record(z.string().transform(convertToHex)),
+    support: z.record(z.string().transform(convertToHex)),
+    neutral: z.string().transform(convertToHex),
+  }),
+  typography: z.object({
+    fontFamily: z.string(),
+  }),
+  borderRadius: z.number(),
+});
 
 /**
  * This defines the structure of the JSON config file
  */
 export const configFileSchema = z.object({
   outDir: z.string().optional(),
-  themes: z.record(
-    z.object({
-      colors: z.object({
-        main: z.record(z.string().transform(convertToHex)),
-        support: z.record(z.string().transform(convertToHex)),
-        neutral: z.string().transform(convertToHex),
-      }),
-      typography: z.object({
-        fontFamily: z.string(),
-      }),
-      borderRadius: z.number(),
-    }),
-  ),
+  themes: z.record(themeSchema),
 });
 
 /**

--- a/packages/cli/src/tokens/create.ts
+++ b/packages/cli/src/tokens/create.ts
@@ -3,10 +3,19 @@ import { baseColors, generateColorScale } from '../colors/index.js';
 import type { ColorInfo, ColorScheme } from '../colors/types.js';
 import type { Colors, Theme, Tokens, Tokens1ary, TokensSet, Typography } from './types.js';
 
-export const colorCliOptions = {
-  main: 'main-colors',
-  support: 'support-colors',
-  neutral: 'neutral-color',
+export const cliOptions = {
+  outDir: 'out-dir',
+  theme: {
+    colors: {
+      main: 'main-colors',
+      support: 'support-colors',
+      neutral: 'neutral-color',
+    },
+    typography: {
+      fontFamily: 'font-family',
+    },
+    borderRadius: 'border-radius',
+  },
 } as const;
 
 const createColorTokens = (colorArray: ColorInfo[]): Tokens1ary => {

--- a/packages/cli/src/tokens/index.ts
+++ b/packages/cli/src/tokens/index.ts
@@ -1,2 +1,2 @@
-export { createTokens, colorCliOptions } from './create.js';
+export { createTokens, cliOptions } from './create.js';
 export type { Theme as CreateTokensOptions } from './types.js';

--- a/plugins/figma/src/ui/pages/Theme/Theme.tsx
+++ b/plugins/figma/src/ui/pages/Theme/Theme.tsx
@@ -11,7 +11,7 @@ import { useEffect, useId, useState } from 'react';
 import { Link as RouterLink, useParams } from 'react-router-dom';
 
 import { getDummyTheme } from '@common/dummyTheme';
-import { colorCliOptions } from '@digdir/designsystemet';
+import { cliOptions } from '@digdir/designsystemet';
 import {
   type CssColor,
   generateColorSchemes,
@@ -19,6 +19,8 @@ import {
 import { type ColorTheme, useThemeStore } from '../../../common/store';
 import { themeToFigmaFormat } from '../../../common/utils';
 import classes from './Theme.module.css';
+
+const colorCliOptions = cliOptions.theme.colors;
 
 function Theme() {
   const { themeId } = useParams();


### PR DESCRIPTION
To facilitate better errors, the CLI option names that also exist in JSON config are now defined in a `cliOptions` object that we can use to look up the mapping between JSON path and CLI option through `mapPathToOptionName(path)`

Before this change:
<img width="634" alt="Screenshot 2025-01-09 at 10 45 47" src="https://github.com/user-attachments/assets/220d40d1-99a9-4856-800e-38ccd40fcd58" />

After:
<img width="717" alt="Screenshot 2025-01-09 at 10 49 27" src="https://github.com/user-attachments/assets/7d40f02d-915a-4464-93e4-078477620093" />
