### PR TITLE
fix(field): don't show as disabled when option is disabled

### DIFF
--- a/.changeset/mean-starfishes-hear.md
+++ b/.changeset/mean-starfishes-hear.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+Field: Don't show as disabled when option is disabled

--- a/packages/css/src/field.css
+++ b/packages/css/src/field.css
@@ -14,7 +14,7 @@
   /**
    * States
    */
-  &:has([aria-disabled='true'], :disabled:not(select option)) > * {
+  &:has([aria-disabled='true']:not(u-option), :disabled:not(select option)) > * {
     cursor: not-allowed;
     opacity: var(--ds-disabled-opacity);
   }
@@ -51,7 +51,7 @@
       grid-row: 1; /* Always place input in row 1 */
     }
 
-    &:not(:has([readonly], [aria-disabled='true'], :disabled)) label {
+    &:not(:has([readonly], [aria-disabled='true']:not(u-option), :disabled:not(option))) label {
       cursor: pointer;
     }
 

--- a/packages/css/src/field.css
+++ b/packages/css/src/field.css
@@ -14,7 +14,7 @@
   /**
    * States
    */
-  &:has([aria-disabled='true']:not(u-option), :disabled:not(select option)) > * {
+  &:has([aria-disabled='true']:not(u-option), :disabled:not(option)) > * {
     cursor: not-allowed;
     opacity: var(--ds-disabled-opacity);
   }

--- a/packages/css/src/field.css
+++ b/packages/css/src/field.css
@@ -14,7 +14,7 @@
   /**
    * States
    */
-  &:has([aria-disabled='true'], :disabled) > * {
+  &:has([aria-disabled='true'], :disabled:not(select option)) > * {
     cursor: not-allowed;
     opacity: var(--ds-disabled-opacity);
   }

--- a/packages/react/src/components/Select/Select.stories.tsx
+++ b/packages/react/src/components/Select/Select.stories.tsx
@@ -13,8 +13,10 @@ export default {
 export const Preview: StoryFn<typeof Select> = (args) => (
   <Field>
     <Label>Velg et fjell</Label>
-    <Select {...args}>
-      <Select.Option value='blank'>Velg &hellip;</Select.Option>
+    <Select {...args} defaultValue=''>
+      <Select.Option value='' disabled>
+        Velg et fjell &hellip;
+      </Select.Option>
       <Select.Option value='everest'>Mount Everest</Select.Option>
       <Select.Option value='aconcagua'>Aconcagua</Select.Option>
       <Select.Option value='denali'>Denali</Select.Option>


### PR DESCRIPTION
reported on slack.
If an option was inside `disabled`, `Field` would show everything as disabled.