### PR TITLE
fix(Select): disabled option no longer disables select

### DIFF
--- a/packages/css/src/field.css
+++ b/packages/css/src/field.css
@@ -14,7 +14,7 @@
   /**
    * States
    */
-  &:has([aria-disabled='true'], :disabled) > * {
+  &:has(> [aria-disabled='true'], > :disabled) > * {
     cursor: not-allowed;
     opacity: var(--ds-disabled-opacity);
   }

--- a/packages/css/src/field.css
+++ b/packages/css/src/field.css
@@ -14,7 +14,7 @@
   /**
    * States
    */
-  &:has(> [aria-disabled='true'], > :disabled) > * {
+  &:has([aria-disabled='true']:not(u-option), :disabled:not(option)) > * {
     cursor: not-allowed;
     opacity: var(--ds-disabled-opacity);
   }

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -84,7 +84,7 @@
       appearance: auto; /* show chevron */
     }
 
-    &:has(option:checked:disabled) {
+    &:not(:disabled):has(option:checked:disabled) {
       color: color-mix(in srgb, currentColor var(--ds-disabled-opacity), transparent);
     }
   }

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -20,8 +20,8 @@
 
   /* Checkmark with antialiasing is achieved by percentages 48% / 50% / 52% */
   --diagonal-1: transparent calc(48% - var(--dsc-input-stroke));
-  --diagonal-2: currentcolor calc(50% - var(--dsc-input-stroke));
-  --diagonal-3: currentcolor calc(50% + var(--dsc-input-stroke));
+  --diagonal-2: var(--dsc-input-color) calc(50% - var(--dsc-input-stroke));
+  --diagonal-3: var(--dsc-input-color) calc(50% + var(--dsc-input-stroke));
   --diagonal-4: transparent calc(52% + var(--dsc-input-stroke));
   --check-left: 10% 73% / 35% 35% no-repeat content-box linear-gradient(45deg, var(--diagonal-1), var(--diagonal-2), var(--diagonal-3), var(--diagonal-4));
   --check-right: 90% 50% / 65% 65% no-repeat content-box linear-gradient(-45deg, var(--diagonal-1), var(--diagonal-2), var(--diagonal-3), var(--diagonal-4));
@@ -82,6 +82,10 @@
 
     @media (forced-colors: active) {
       appearance: auto; /* show chevron */
+    }
+
+    &:has(option:checked:disabled) {
+      color: color-mix(in srgb, currentColor var(--ds-disabled-opacity), transparent);
     }
   }
 


### PR DESCRIPTION
Saw there already was a pr, this one handles disabled options rendering as disabled aswell

![image](https://github.com/user-attachments/assets/1e8d965f-a3f1-43f2-a784-cc250d960757)
![image](https://github.com/user-attachments/assets/ea390200-2795-40e1-a5e6-88ab6f542e07)
![image](https://github.com/user-attachments/assets/351b610f-401e-41d6-94ce-ce914e4fb94b)
