### PR TITLE
fix: focus-outer -> neutral.text.default

### DIFF
--- a/.changeset/fast-cows-impress.md
+++ b/.changeset/fast-cows-impress.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet": patch
+---
+
+tokens: fix wrong reference for focus color. Now uses neutral color

--- a/.changeset/fast-cows-impress.md
+++ b/.changeset/fast-cows-impress.md
@@ -2,4 +2,4 @@
 "@digdir/designsystemet": patch
 ---
 
-tokens: fix wrong reference for focus color. Now uses neutral color
+tokens: fix wrong reference for focus color.

--- a/.changeset/modern-hats-destroy.md
+++ b/.changeset/modern-hats-destroy.md
@@ -1,0 +1,7 @@
+---
+"@digdir/designsystemet-theme": patch
+"@digdir/designsystemet": patch
+"@digdir/designsystemet-css": patch
+---
+
+Changed focus color to use neutral instead of accent color

--- a/apps/storefront/tokens/altinn/dark.ts
+++ b/apps/storefront/tokens/altinn/dark.ts
@@ -2317,12 +2317,12 @@ export const  color = [
   },
   {
     $type: "color",
-    $value: "#d8e7f4",
+    $value: "#e3e5e7",
     filePath: "../../design-tokens/semantic/color.json",
     isSource: false,
     original: {
       $type: "color",
-      $value: "{color.accent.text-default}"
+      $value: "{color.neutral.text-default}"
     },
     name: "--ds-color-focus-outer",
     attributes: {},

--- a/apps/storefront/tokens/altinn/light.ts
+++ b/apps/storefront/tokens/altinn/light.ts
@@ -2317,12 +2317,12 @@ export const  color = [
   },
   {
     $type: "color",
-    $value: "#002c54",
+    $value: "#1f2c3d",
     filePath: "../../design-tokens/semantic/color.json",
     isSource: false,
     original: {
       $type: "color",
-      $value: "{color.accent.text-default}"
+      $value: "{color.neutral.text-default}"
     },
     name: "--ds-color-focus-outer",
     attributes: {},

--- a/apps/storefront/tokens/digdir/dark.ts
+++ b/apps/storefront/tokens/digdir/dark.ts
@@ -2317,12 +2317,12 @@ export const  color = [
   },
   {
     $type: "color",
-    $value: "#d7e7f4",
+    $value: "#e3e5e7",
     filePath: "../../design-tokens/semantic/color.json",
     isSource: false,
     original: {
       $type: "color",
-      $value: "{color.accent.text-default}"
+      $value: "{color.neutral.text-default}"
     },
     name: "--ds-color-focus-outer",
     attributes: {},

--- a/apps/storefront/tokens/digdir/light.ts
+++ b/apps/storefront/tokens/digdir/light.ts
@@ -2317,12 +2317,12 @@ export const  color = [
   },
   {
     $type: "color",
-    $value: "#002c54",
+    $value: "#1f2c3d",
     filePath: "../../design-tokens/semantic/color.json",
     isSource: false,
     original: {
       $type: "color",
-      $value: "{color.accent.text-default}"
+      $value: "{color.neutral.text-default}"
     },
     name: "--ds-color-focus-outer",
     attributes: {},

--- a/apps/storefront/tokens/portal/dark.ts
+++ b/apps/storefront/tokens/portal/dark.ts
@@ -2317,12 +2317,12 @@ export const  color = [
   },
   {
     $type: "color",
-    $value: "#e9e2ef",
+    $value: "#e3e5e7",
     filePath: "../../design-tokens/semantic/color.json",
     isSource: false,
     original: {
       $type: "color",
-      $value: "{color.accent.text-default}"
+      $value: "{color.neutral.text-default}"
     },
     name: "--ds-color-focus-outer",
     attributes: {},

--- a/apps/storefront/tokens/portal/light.ts
+++ b/apps/storefront/tokens/portal/light.ts
@@ -2317,12 +2317,12 @@ export const  color = [
   },
   {
     $type: "color",
-    $value: "#410d69",
+    $value: "#1f2c3d",
     filePath: "../../design-tokens/semantic/color.json",
     isSource: false,
     original: {
       $type: "color",
-      $value: "{color.accent.text-default}"
+      $value: "{color.neutral.text-default}"
     },
     name: "--ds-color-focus-outer",
     attributes: {},

--- a/apps/storefront/tokens/uutilsynet/dark.ts
+++ b/apps/storefront/tokens/uutilsynet/dark.ts
@@ -2317,12 +2317,12 @@ export const  color = [
   },
   {
     $type: "color",
-    $value: "#d8e7f4",
+    $value: "#e3e5e7",
     filePath: "../../design-tokens/semantic/color.json",
     isSource: false,
     original: {
       $type: "color",
-      $value: "{color.accent.text-default}"
+      $value: "{color.neutral.text-default}"
     },
     name: "--ds-color-focus-outer",
     attributes: {},

--- a/apps/storefront/tokens/uutilsynet/light.ts
+++ b/apps/storefront/tokens/uutilsynet/light.ts
@@ -2317,12 +2317,12 @@ export const  color = [
   },
   {
     $type: "color",
-    $value: "#002c54",
+    $value: "#1f2c3d",
     filePath: "../../design-tokens/semantic/color.json",
     isSource: false,
     original: {
       $type: "color",
-      $value: "{color.accent.text-default}"
+      $value: "{color.neutral.text-default}"
     },
     name: "--ds-color-focus-outer",
     attributes: {},

--- a/design-tokens/semantic/color.json
+++ b/design-tokens/semantic/color.json
@@ -565,7 +565,7 @@
       },
       "outer": {
         "$type": "color",
-        "$value": "{color.accent.text-default}"
+        "$value": "{color.neutral.text-default}"
       }
     }
   }

--- a/packages/cli/src/tokens/design-tokens/template/semantic/color-base-file.json
+++ b/packages/cli/src/tokens/design-tokens/template/semantic/color-base-file.json
@@ -255,7 +255,7 @@
       },
       "outer": {
         "$type": "color",
-        "$value": "{color.<accent-color>.text-default}"
+        "$value": "{color.neutral.text-default}"
       }
     }
   }

--- a/packages/theme/brand/altinn.css
+++ b/packages/theme/brand/altinn.css
@@ -234,7 +234,7 @@
   --ds-color-warning-contrast-default: #ffffff;
   --ds-color-warning-contrast-subtle: #fdf9f8;
   --ds-color-focus-inner: #ffffff;
-  --ds-color-focus-outer: #002c54;
+  --ds-color-focus-outer: #1f2c3d;
 
   color-scheme: light;
 }
@@ -467,7 +467,7 @@
   --ds-color-warning-contrast-default: #ffffff;
   --ds-color-warning-contrast-subtle: #fdf9f8;
   --ds-color-focus-inner: #ffffff;
-  --ds-color-focus-outer: #002c54;
+  --ds-color-focus-outer: #1f2c3d;
 
   color-scheme: light;
 }
@@ -903,7 +903,7 @@
   --ds-color-warning-contrast-default: #000000;
   --ds-color-warning-contrast-subtle: #070301;
   --ds-color-focus-inner: #141d29;
-  --ds-color-focus-outer: #d8e7f4;
+  --ds-color-focus-outer: #e3e5e7;
 
   color-scheme: dark;
 }
@@ -1136,7 +1136,7 @@
   --ds-color-warning-contrast-default: #000000;
   --ds-color-warning-contrast-subtle: #070301;
   --ds-color-focus-inner: #141d29;
-  --ds-color-focus-outer: #d8e7f4;
+  --ds-color-focus-outer: #e3e5e7;
 
   color-scheme: dark;
 }

--- a/packages/theme/brand/altinn/color-scheme/dark.css
+++ b/packages/theme/brand/altinn/color-scheme/dark.css
@@ -230,7 +230,7 @@
   --ds-color-warning-contrast-default: #000000;
   --ds-color-warning-contrast-subtle: #070301;
   --ds-color-focus-inner: #141d29;
-  --ds-color-focus-outer: #d8e7f4;
+  --ds-color-focus-outer: #e3e5e7;
 
   color-scheme: dark;
 }
@@ -463,7 +463,7 @@
   --ds-color-warning-contrast-default: #000000;
   --ds-color-warning-contrast-subtle: #070301;
   --ds-color-focus-inner: #141d29;
-  --ds-color-focus-outer: #d8e7f4;
+  --ds-color-focus-outer: #e3e5e7;
 
   color-scheme: dark;
 }

--- a/packages/theme/brand/altinn/color-scheme/light.css
+++ b/packages/theme/brand/altinn/color-scheme/light.css
@@ -230,7 +230,7 @@
   --ds-color-warning-contrast-default: #ffffff;
   --ds-color-warning-contrast-subtle: #fdf9f8;
   --ds-color-focus-inner: #ffffff;
-  --ds-color-focus-outer: #002c54;
+  --ds-color-focus-outer: #1f2c3d;
 
   color-scheme: light;
 }
@@ -463,7 +463,7 @@
   --ds-color-warning-contrast-default: #ffffff;
   --ds-color-warning-contrast-subtle: #fdf9f8;
   --ds-color-focus-inner: #ffffff;
-  --ds-color-focus-outer: #002c54;
+  --ds-color-focus-outer: #1f2c3d;
 
   color-scheme: light;
 }

--- a/packages/theme/brand/digdir.css
+++ b/packages/theme/brand/digdir.css
@@ -234,7 +234,7 @@
   --ds-color-warning-contrast-default: #ffffff;
   --ds-color-warning-contrast-subtle: #fdf9f8;
   --ds-color-focus-inner: #ffffff;
-  --ds-color-focus-outer: #002c54;
+  --ds-color-focus-outer: #1f2c3d;
 
   color-scheme: light;
 }
@@ -467,7 +467,7 @@
   --ds-color-warning-contrast-default: #ffffff;
   --ds-color-warning-contrast-subtle: #fdf9f8;
   --ds-color-focus-inner: #ffffff;
-  --ds-color-focus-outer: #002c54;
+  --ds-color-focus-outer: #1f2c3d;
 
   color-scheme: light;
 }
@@ -903,7 +903,7 @@
   --ds-color-warning-contrast-default: #000000;
   --ds-color-warning-contrast-subtle: #070301;
   --ds-color-focus-inner: #141d29;
-  --ds-color-focus-outer: #d7e7f4;
+  --ds-color-focus-outer: #e3e5e7;
 
   color-scheme: dark;
 }
@@ -1136,7 +1136,7 @@
   --ds-color-warning-contrast-default: #000000;
   --ds-color-warning-contrast-subtle: #070301;
   --ds-color-focus-inner: #141d29;
-  --ds-color-focus-outer: #d7e7f4;
+  --ds-color-focus-outer: #e3e5e7;
 
   color-scheme: dark;
 }

--- a/packages/theme/brand/digdir/color-scheme/dark.css
+++ b/packages/theme/brand/digdir/color-scheme/dark.css
@@ -230,7 +230,7 @@
   --ds-color-warning-contrast-default: #000000;
   --ds-color-warning-contrast-subtle: #070301;
   --ds-color-focus-inner: #141d29;
-  --ds-color-focus-outer: #d7e7f4;
+  --ds-color-focus-outer: #e3e5e7;
 
   color-scheme: dark;
 }
@@ -463,7 +463,7 @@
   --ds-color-warning-contrast-default: #000000;
   --ds-color-warning-contrast-subtle: #070301;
   --ds-color-focus-inner: #141d29;
-  --ds-color-focus-outer: #d7e7f4;
+  --ds-color-focus-outer: #e3e5e7;
 
   color-scheme: dark;
 }

--- a/packages/theme/brand/digdir/color-scheme/light.css
+++ b/packages/theme/brand/digdir/color-scheme/light.css
@@ -230,7 +230,7 @@
   --ds-color-warning-contrast-default: #ffffff;
   --ds-color-warning-contrast-subtle: #fdf9f8;
   --ds-color-focus-inner: #ffffff;
-  --ds-color-focus-outer: #002c54;
+  --ds-color-focus-outer: #1f2c3d;
 
   color-scheme: light;
 }
@@ -463,7 +463,7 @@
   --ds-color-warning-contrast-default: #ffffff;
   --ds-color-warning-contrast-subtle: #fdf9f8;
   --ds-color-focus-inner: #ffffff;
-  --ds-color-focus-outer: #002c54;
+  --ds-color-focus-outer: #1f2c3d;
 
   color-scheme: light;
 }

--- a/packages/theme/brand/portal.css
+++ b/packages/theme/brand/portal.css
@@ -234,7 +234,7 @@
   --ds-color-warning-contrast-default: #ffffff;
   --ds-color-warning-contrast-subtle: #fdf9f8;
   --ds-color-focus-inner: #ffffff;
-  --ds-color-focus-outer: #410d69;
+  --ds-color-focus-outer: #1f2c3d;
 
   color-scheme: light;
 }
@@ -467,7 +467,7 @@
   --ds-color-warning-contrast-default: #ffffff;
   --ds-color-warning-contrast-subtle: #fdf9f8;
   --ds-color-focus-inner: #ffffff;
-  --ds-color-focus-outer: #410d69;
+  --ds-color-focus-outer: #1f2c3d;
 
   color-scheme: light;
 }
@@ -903,7 +903,7 @@
   --ds-color-warning-contrast-default: #000000;
   --ds-color-warning-contrast-subtle: #070301;
   --ds-color-focus-inner: #141d29;
-  --ds-color-focus-outer: #e9e2ef;
+  --ds-color-focus-outer: #e3e5e7;
 
   color-scheme: dark;
 }
@@ -1136,7 +1136,7 @@
   --ds-color-warning-contrast-default: #000000;
   --ds-color-warning-contrast-subtle: #070301;
   --ds-color-focus-inner: #141d29;
-  --ds-color-focus-outer: #e9e2ef;
+  --ds-color-focus-outer: #e3e5e7;
 
   color-scheme: dark;
 }

--- a/packages/theme/brand/portal/color-scheme/dark.css
+++ b/packages/theme/brand/portal/color-scheme/dark.css
@@ -230,7 +230,7 @@
   --ds-color-warning-contrast-default: #000000;
   --ds-color-warning-contrast-subtle: #070301;
   --ds-color-focus-inner: #141d29;
-  --ds-color-focus-outer: #e9e2ef;
+  --ds-color-focus-outer: #e3e5e7;
 
   color-scheme: dark;
 }
@@ -463,7 +463,7 @@
   --ds-color-warning-contrast-default: #000000;
   --ds-color-warning-contrast-subtle: #070301;
   --ds-color-focus-inner: #141d29;
-  --ds-color-focus-outer: #e9e2ef;
+  --ds-color-focus-outer: #e3e5e7;
 
   color-scheme: dark;
 }

--- a/packages/theme/brand/portal/color-scheme/light.css
+++ b/packages/theme/brand/portal/color-scheme/light.css
@@ -230,7 +230,7 @@
   --ds-color-warning-contrast-default: #ffffff;
   --ds-color-warning-contrast-subtle: #fdf9f8;
   --ds-color-focus-inner: #ffffff;
-  --ds-color-focus-outer: #410d69;
+  --ds-color-focus-outer: #1f2c3d;
 
   color-scheme: light;
 }
@@ -463,7 +463,7 @@
   --ds-color-warning-contrast-default: #ffffff;
   --ds-color-warning-contrast-subtle: #fdf9f8;
   --ds-color-focus-inner: #ffffff;
-  --ds-color-focus-outer: #410d69;
+  --ds-color-focus-outer: #1f2c3d;
 
   color-scheme: light;
 }

--- a/packages/theme/brand/uutilsynet.css
+++ b/packages/theme/brand/uutilsynet.css
@@ -234,7 +234,7 @@
   --ds-color-warning-contrast-default: #ffffff;
   --ds-color-warning-contrast-subtle: #fdf9f8;
   --ds-color-focus-inner: #ffffff;
-  --ds-color-focus-outer: #002c54;
+  --ds-color-focus-outer: #1f2c3d;
 
   color-scheme: light;
 }
@@ -467,7 +467,7 @@
   --ds-color-warning-contrast-default: #ffffff;
   --ds-color-warning-contrast-subtle: #fdf9f8;
   --ds-color-focus-inner: #ffffff;
-  --ds-color-focus-outer: #002c54;
+  --ds-color-focus-outer: #1f2c3d;
 
   color-scheme: light;
 }
@@ -903,7 +903,7 @@
   --ds-color-warning-contrast-default: #000000;
   --ds-color-warning-contrast-subtle: #070301;
   --ds-color-focus-inner: #141d29;
-  --ds-color-focus-outer: #d8e7f4;
+  --ds-color-focus-outer: #e3e5e7;
 
   color-scheme: dark;
 }
@@ -1136,7 +1136,7 @@
   --ds-color-warning-contrast-default: #000000;
   --ds-color-warning-contrast-subtle: #070301;
   --ds-color-focus-inner: #141d29;
-  --ds-color-focus-outer: #d8e7f4;
+  --ds-color-focus-outer: #e3e5e7;
 
   color-scheme: dark;
 }

--- a/packages/theme/brand/uutilsynet/color-scheme/dark.css
+++ b/packages/theme/brand/uutilsynet/color-scheme/dark.css
@@ -230,7 +230,7 @@
   --ds-color-warning-contrast-default: #000000;
   --ds-color-warning-contrast-subtle: #070301;
   --ds-color-focus-inner: #141d29;
-  --ds-color-focus-outer: #d8e7f4;
+  --ds-color-focus-outer: #e3e5e7;
 
   color-scheme: dark;
 }
@@ -463,7 +463,7 @@
   --ds-color-warning-contrast-default: #000000;
   --ds-color-warning-contrast-subtle: #070301;
   --ds-color-focus-inner: #141d29;
-  --ds-color-focus-outer: #d8e7f4;
+  --ds-color-focus-outer: #e3e5e7;
 
   color-scheme: dark;
 }

--- a/packages/theme/brand/uutilsynet/color-scheme/light.css
+++ b/packages/theme/brand/uutilsynet/color-scheme/light.css
@@ -230,7 +230,7 @@
   --ds-color-warning-contrast-default: #ffffff;
   --ds-color-warning-contrast-subtle: #fdf9f8;
   --ds-color-focus-inner: #ffffff;
-  --ds-color-focus-outer: #002c54;
+  --ds-color-focus-outer: #1f2c3d;
 
   color-scheme: light;
 }
@@ -463,7 +463,7 @@
   --ds-color-warning-contrast-default: #ffffff;
   --ds-color-warning-contrast-subtle: #fdf9f8;
   --ds-color-focus-inner: #ffffff;
-  --ds-color-focus-outer: #002c54;
+  --ds-color-focus-outer: #1f2c3d;
 
   color-scheme: light;
 }


### PR DESCRIPTION
resolves #2985 

`focus-outer` referenced the accent scale, this scale is not static and can change. Neutral is a safer scale to use as a reference here. 