### PR TITLE
fix(cli): :ambulance: include missing build files in for `designsystemet`bin

### DIFF
--- a/.changeset/hip-weeks-fetch.md
+++ b/.changeset/hip-weeks-fetch.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet": patch
+---
+
+**fix(cli):** 🚑 include missing build files in for designsystemet bin

--- a/.changeset/hip-weeks-fetch.md
+++ b/.changeset/hip-weeks-fetch.md
@@ -2,4 +2,4 @@
 "@digdir/designsystemet": patch
 ---
 
-**fix(cli):** 🚑 include missing build files in for designsystemet bin
+**fix(cli)**: 🚑 include missing build files for designsystemet bin

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['./src', './bin/designsystemet.ts'],
+  entry: ['./src', './bin'],
   splitting: false,
   sourcemap: false,
   clean: true,


### PR DESCRIPTION
Fix bug with missing files in dist build

<img width="1279" alt="image" src="https://github.com/user-attachments/assets/cdb654de-846b-4c20-9b47-4a16fef943e3" />
