### PR TITLE
fix: :bug: Use correct popover api attributes based on React version

### DIFF
--- a/.changeset/new-kangaroos-count.md
+++ b/.changeset/new-kangaroos-count.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+fix: Use correct DOM property for Popover API when used in React 19

--- a/packages/react/src/components/Popover/PopoverTrigger.tsx
+++ b/packages/react/src/components/Popover/PopoverTrigger.tsx
@@ -21,8 +21,6 @@ export const PopoverTrigger = forwardRef<
   const { popoverId } = useContext(Context);
   const Component = asChild ? Slot : inline ? 'button' : Button;
 
-  console.log('version', version);
-
   const popoverProps = Object.assign(
     {
       [version.startsWith('19') ? 'popoverTarget' : 'popovertarget']: popoverId,

--- a/packages/react/src/components/Popover/PopoverTrigger.tsx
+++ b/packages/react/src/components/Popover/PopoverTrigger.tsx
@@ -1,5 +1,5 @@
 import { Slot } from '@radix-ui/react-slot';
-import { type HTMLAttributes, forwardRef, useContext } from 'react';
+import { type HTMLAttributes, forwardRef, useContext, version } from 'react';
 import type { DefaultProps } from '../../types';
 import { Button, type ButtonProps } from '../Button/Button';
 import { Context } from './PopoverTriggerContext';
@@ -21,16 +21,19 @@ export const PopoverTrigger = forwardRef<
   const { popoverId } = useContext(Context);
   const Component = asChild ? Slot : inline ? 'button' : Button;
 
-  return (
-    <Component
-      ref={ref}
-      popovertarget={popoverId}
-      {...(inline
+  console.log('version', version);
+
+  const popoverProps = Object.assign(
+    {
+      [version.startsWith('19') ? 'popoverTarget' : 'popovertarget']: popoverId,
+      ...(inline
         ? {
             'data-popover': 'inline',
           }
-        : {})}
-      {...rest}
-    />
+        : {}),
+    },
+    rest,
   );
+
+  return <Component ref={ref} {...popoverProps} />;
 });

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -16,6 +16,7 @@ import {
   useId,
   useRef,
   useState,
+  version,
 } from 'react';
 
 import { useMergeRefs } from '@floating-ui/react';
@@ -142,14 +143,19 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       return null;
     }
 
+    const popoverProps = {
+      [version.startsWith('19') ? 'popoverTarget' : 'popovertarget']:
+        id ?? randomTooltipId,
+      [version.startsWith('19')
+        ? 'popoverTargetAction'
+        : 'popovertargetaction']: 'show',
+    };
+
     return (
       <>
         <ChildContainer
           ref={triggerRef}
-          popovertarget={id ?? randomTooltipId}
-          // We set this to not close on click, since it should always show on hover
-          // @ts-ignore @types/react-dom does not understand popovertargetaction yet
-          popovertargetaction='show'
+          {...popoverProps}
           onMouseEnter={setOpen}
           onMouseLeave={setClose}
           onFocus={setOpen}


### PR DESCRIPTION
Fixes the errors flagged by nextjs of "invalid" react props.

![image (9)](https://github.com/user-attachments/assets/a3becfe1-e765-4737-a178-1217ad07dec3)
