### PR TITLE
fix(field): :lipstick: fix broken invalid styling for `ds-input` inside `Field`

### DIFF
--- a/packages/css/src/field.css
+++ b/packages/css/src/field.css
@@ -130,7 +130,7 @@
     }
   }
 
-  &:where(.ds-input) {
+  & :where(.ds-input) {
     border: var(--dsc-field-affix-border);
     border-color: var(--dsc-field-affix-border-color);
     flex: 1 1 auto;

--- a/packages/css/src/field.css
+++ b/packages/css/src/field.css
@@ -130,7 +130,7 @@
     }
   }
 
-  & *:where(.ds-input) {
+  & :where(.ds-input) {
     border: var(--dsc-field-affix-border);
     border-color: var(--dsc-field-affix-border-color);
     flex: 1 1 auto;

--- a/packages/css/src/field.css
+++ b/packages/css/src/field.css
@@ -88,6 +88,7 @@
  */
 .ds-field-affixes {
   --dsc-field-affix-border-width: 1px;
+  --dsc-field-affix-border-style: solid;
   --dsc-field-affix-border-color: var(--ds-color-neutral-border-default);
   --dsc-field-affix-padding-inline: var(--ds-size-4);
 
@@ -109,7 +110,7 @@
   & .ds-field-affix {
     align-items: center;
     border-width: var(--dsc-field-affix-border-width);
-    border-style: solid;
+    border-style: var(--dsc-field-affix-border-style);
     border-color: var(--dsc-field-affix-border-color);
     flex-shrink: 0;
     padding-inline: var(--dsc-field-affix-padding-inline);
@@ -133,7 +134,7 @@
 
   & .ds-input {
     border-width: var(--dsc-field-affix-border-width);
-    border-style: solid;
+    border-style: var(--dsc-field-affix-border-style);
     flex: 1 1 auto;
 
     /* if it has affix after */

--- a/packages/css/src/field.css
+++ b/packages/css/src/field.css
@@ -130,7 +130,7 @@
     }
   }
 
-  & .ds-input {
+  &:where(.ds-input) {
     border: var(--dsc-field-affix-border);
     border-color: var(--dsc-field-affix-border-color);
     flex: 1 1 auto;

--- a/packages/css/src/field.css
+++ b/packages/css/src/field.css
@@ -130,7 +130,7 @@
     }
   }
 
-  & :where(.ds-input) {
+  & :has(.ds-input) {
     border: var(--dsc-field-affix-border);
     border-color: var(--dsc-field-affix-border-color);
     flex: 1 1 auto;

--- a/packages/css/src/field.css
+++ b/packages/css/src/field.css
@@ -130,7 +130,7 @@
     }
   }
 
-  & :where(.ds-input) {
+  & *:where(.ds-input) {
     border: var(--dsc-field-affix-border);
     border-color: var(--dsc-field-affix-border-color);
     flex: 1 1 auto;

--- a/packages/css/src/field.css
+++ b/packages/css/src/field.css
@@ -87,7 +87,7 @@
  * Affix
  */
 .ds-field-affixes {
-  --dsc-field-affix-border: 1px solid;
+  --dsc-field-affix-border-width: 1px;
   --dsc-field-affix-border-color: var(--ds-color-neutral-border-default);
   --dsc-field-affix-padding-inline: var(--ds-size-4);
 
@@ -108,7 +108,8 @@
 
   & .ds-field-affix {
     align-items: center;
-    border: var(--dsc-field-affix-border);
+    border-width: var(--dsc-field-affix-border-width);
+    border-style: solid;
     border-color: var(--dsc-field-affix-border-color);
     flex-shrink: 0;
     padding-inline: var(--dsc-field-affix-padding-inline);
@@ -130,9 +131,9 @@
     }
   }
 
-  & :has(.ds-input) {
-    border: var(--dsc-field-affix-border);
-    border-color: var(--dsc-field-affix-border-color);
+  & .ds-input {
+    border-width: var(--dsc-field-affix-border-width);
+    border-style: solid;
     flex: 1 1 auto;
 
     /* if it has affix after */


### PR DESCRIPTION
Just fixing this one off, but we should have a closer look at other components for this use-case.

- `ds-input` should probably be updated to use less re-assignments for variants
- split use of `border` into the 3 separate CSS props