### PR TITLE
refactor(.ds-input): split class into smaller pieces

### DIFF
--- a/packages/css/src/button.css
+++ b/packages/css/src/button.css
@@ -47,26 +47,6 @@
     --dsc-button-border-color: currentColor;
   }
 
-  &[data-color] {
-    --dsc-button-background--active: var(--ds-color-base-active);
-    --dsc-button-background--hover: var(--ds-color-base-hover);
-    --dsc-button-background: var(--ds-color-base-default);
-    --dsc-button-color: var(--ds-color-base-contrast-default);
-    --dsc-button-color--hover: var(--ds-color-base-contrast-default);
-
-    &[data-variant='secondary'],
-    &[data-variant='tertiary'] {
-      --dsc-button-background: transparent;
-      --dsc-button-background--active: var(--ds-color-surface-active);
-      --dsc-button-background--hover: var(--ds-color-surface-hover);
-      --dsc-button-color: var(--ds-color-text-subtle);
-      --dsc-button-color--hover: var(--ds-color-text-default);
-    }
-    &[data-variant='secondary'] {
-      --dsc-button-border-color: var(--ds-color-border-strong);
-    }
-  }
-
   &:not([data-size]) {
     font-size: inherit; /* Ensure inheriting font-size when <button> */
   }

--- a/packages/css/src/button.css
+++ b/packages/css/src/button.css
@@ -44,7 +44,7 @@
     --dsc-button-color--hover: var(--ds-color-text-default);
   }
   &[data-variant='secondary'] {
-    --dsc-button-border-color: currentColor;
+    --dsc-button-border-color: var(--ds-color-text-subtle);
   }
 
   &[data-color] {
@@ -63,7 +63,7 @@
       --dsc-button-color--hover: var(--ds-color-text-default);
     }
     &[data-variant='secondary'] {
-      --dsc-button-border-color: currentColor;
+      --dsc-button-border-color: var(--ds-color-text-subtle);
     }
   }
 

--- a/packages/css/src/button.css
+++ b/packages/css/src/button.css
@@ -44,7 +44,7 @@
     --dsc-button-color--hover: var(--ds-color-text-default);
   }
   &[data-variant='secondary'] {
-    --dsc-button-border-color: var(--ds-color-text-subtle);
+    --dsc-button-border-color: currentColor;
   }
 
   &[data-color] {
@@ -63,7 +63,7 @@
       --dsc-button-color--hover: var(--ds-color-text-default);
     }
     &[data-variant='secondary'] {
-      --dsc-button-border-color: var(--ds-color-text-subtle);
+      --dsc-button-border-color: currentColor;
     }
   }
 

--- a/packages/css/src/button.css
+++ b/packages/css/src/button.css
@@ -47,6 +47,26 @@
     --dsc-button-border-color: currentColor;
   }
 
+  &[data-color] {
+    --dsc-button-background--active: var(--ds-color-base-active);
+    --dsc-button-background--hover: var(--ds-color-base-hover);
+    --dsc-button-background: var(--ds-color-base-default);
+    --dsc-button-color: var(--ds-color-base-contrast-default);
+    --dsc-button-color--hover: var(--ds-color-base-contrast-default);
+
+    &[data-variant='secondary'],
+    &[data-variant='tertiary'] {
+      --dsc-button-background: transparent;
+      --dsc-button-background--active: var(--ds-color-surface-active);
+      --dsc-button-background--hover: var(--ds-color-surface-hover);
+      --dsc-button-color: var(--ds-color-text-subtle);
+      --dsc-button-color--hover: var(--ds-color-text-default);
+    }
+    &[data-variant='secondary'] {
+      --dsc-button-border-color: var(--ds-color-border-strong);
+    }
+  }
+
   &:not([data-size]) {
     font-size: inherit; /* Ensure inheriting font-size when <button> */
   }

--- a/packages/css/src/button.css
+++ b/packages/css/src/button.css
@@ -47,26 +47,6 @@
     --dsc-button-border-color: currentColor;
   }
 
-  &[data-color] {
-    --dsc-button-background--active: var(--ds-color-base-active);
-    --dsc-button-background--hover: var(--ds-color-base-hover);
-    --dsc-button-background: var(--ds-color-base-default);
-    --dsc-button-color: var(--ds-color-base-contrast-default);
-    --dsc-button-color--hover: var(--ds-color-base-contrast-default);
-
-    &[data-variant='secondary'],
-    &[data-variant='tertiary'] {
-      --dsc-button-background: transparent;
-      --dsc-button-background--active: var(--ds-color-surface-active);
-      --dsc-button-background--hover: var(--ds-color-surface-hover);
-      --dsc-button-color: var(--ds-color-text-subtle);
-      --dsc-button-color--hover: var(--ds-color-text-default);
-    }
-    &[data-variant='secondary'] {
-      --dsc-button-border-color: currentColor;
-    }
-  }
-
   &:not([data-size]) {
     font-size: inherit; /* Ensure inheriting font-size when <button> */
   }

--- a/packages/css/src/button.css
+++ b/packages/css/src/button.css
@@ -44,7 +44,7 @@
     --dsc-button-color--hover: var(--ds-color-text-default);
   }
   &[data-variant='secondary'] {
-    --dsc-button-border-color: var(--ds-color-border-strong);
+    --dsc-button-border-color: currentColor;
   }
 
   &[data-color] {
@@ -63,7 +63,7 @@
       --dsc-button-color--hover: var(--ds-color-text-default);
     }
     &[data-variant='secondary'] {
-      --dsc-button-border-color: var(--ds-color-border-strong);
+      --dsc-button-border-color: currentColor;
     }
   }
 

--- a/packages/css/src/chip.css
+++ b/packages/css/src/chip.css
@@ -10,7 +10,7 @@
   --dsc-chip-border-color: var(--ds-color-border-subtle);
   --dsc-chip-border-color--checked: transparent;
   --dsc-chip-color: var(--ds-color-text-default);
-  --dsc-chip-color--checked: var(--ds-color-contrast-default);
+  --dsc-chip-color--checked: var(--ds-color-base-contrast-default);
   --dsc-chip-input-color: var(--ds-color-text-subtle);
   --dsc-chip-input-color--checked: var(--ds-color-base-default);
   --dsc-chip-border-radius: var(--ds-border-radius-full);

--- a/packages/css/src/chip.css
+++ b/packages/css/src/chip.css
@@ -81,10 +81,10 @@
     padding-inline: var(--dsc-chip-spacing);
   }
 
-  & > input {
+  & > .ds-input {
     --dsc-input-background: trasparent;
     --dsc-input-border-color: var(--dsc-chip-input-color);
-    --dsc-input-color--checked: var(--dsc-chip-color--checked);
+    --dsc-input-background--checked: var(--dsc-chip-color--checked);
     --dsc-input-stroke-color--checked: var(--dsc-chip-input-stroke-color--checked);
     --dsc-input-size--toggle: var(--dsc-chip-input-size);
   }

--- a/packages/css/src/chip.css
+++ b/packages/css/src/chip.css
@@ -82,9 +82,10 @@
   }
 
   & > input {
-    --dsc-input-background--checked: var(--dsc-chip-color--checked);
+    /* --dsc-input-background--checked: var(--dsc-chip-color--checked);
+    --dsc-input-border-color--checked: var(--dsc-chip-color--checked); */
+
     --dsc-input-background: transparent;
-    --dsc-input-border-color--checked: var(--dsc-chip-color--checked);
     --dsc-input-border-color: var(--dsc-chip-input-color);
     --dsc-input-color--checked: var(--dsc-chip-input-color--checked);
     --dsc-input-size--toggle: var(--dsc-chip-input-size);

--- a/packages/css/src/chip.css
+++ b/packages/css/src/chip.css
@@ -12,7 +12,7 @@
   --dsc-chip-color: var(--ds-color-text-default);
   --dsc-chip-color--checked: var(--ds-color-base-contrast-default);
   --dsc-chip-input-color: var(--ds-color-text-subtle);
-  --dsc-chip-input-color--checked: var(--ds-color-base-default);
+  --dsc-chip-input-stroke-color--checked: var(--ds-color-base-default);
   --dsc-chip-border-radius: var(--ds-border-radius-full);
   --dsc-chip-border-radius--checkbox: var(--ds-border-radius-md);
   --dsc-chip-height: var(--ds-size-8);
@@ -82,12 +82,10 @@
   }
 
   & > input {
-    /* --dsc-input-background--checked: var(--dsc-chip-color--checked);
-    --dsc-input-border-color--checked: var(--dsc-chip-color--checked); */
-
-    --dsc-input-background: transparent;
+    --dsc-input-background: trasparent;
     --dsc-input-border-color: var(--dsc-chip-input-color);
-    --dsc-input-color--checked: var(--dsc-chip-input-color--checked);
+    --dsc-input-color--checked: var(--dsc-chip-color--checked);
+    --dsc-input-stroke-color--checked: var(--dsc-chip-input-stroke-color--checked);
     --dsc-input-size--toggle: var(--dsc-chip-input-size);
   }
 

--- a/packages/css/src/chip.css
+++ b/packages/css/src/chip.css
@@ -10,8 +10,8 @@
   --dsc-chip-border-color: var(--ds-color-border-subtle);
   --dsc-chip-border-color--checked: transparent;
   --dsc-chip-color: var(--ds-color-text-default);
-  --dsc-chip-color--checked: var(--ds-color-base-contrast-default);
-  --dsc-chip-input-color: var(--ds-color-border-strong);
+  --dsc-chip-color--checked: var(--ds-color-contrast-default);
+  --dsc-chip-input-color: var(--ds-color-text-subtle);
   --dsc-chip-input-color--checked: var(--ds-color-base-default);
   --dsc-chip-border-radius: var(--ds-border-radius-full);
   --dsc-chip-border-radius--checkbox: var(--ds-border-radius-md);

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -13,7 +13,7 @@
   --dsc-input-stroke-color--invalid: var(--ds-color-danger-base-contrast-default);
   --dsc-input-color: var(--ds-color-neutral-text-default);
   --dsc-input-color--readonly: var(--ds-color-neutral-text-subtle);
-  --dsc-input-color--invalid: var(--ds-color-danger-text-subtle); /* Used to color stroke in invalid state. Border for text input and background for checkbox */
+  --dsc-input-color--invalid: var(--ds-color-danger-text-subtle);
   --dsc-input-color--checked: var(--ds-color-base-default);
   --dsc-input-padding: var(--ds-size-2) var(--ds-size-3);
   --dsc-input-size--toggle: var(--ds-size-6);

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -5,8 +5,8 @@
 /* Root class with shared variables and base input styles */
 .ds-input {
   /* Core variables */
-  --dsc-input-background: var(--ds-color-neutral-background-default);
-  --dsc-input-background--readonly: var(--ds-color-neutral-background-tinted);
+  --dsc-input-background-color: var(--ds-color-neutral-background-default);
+  --dsc-input-background-color--readonly: var(--ds-color-neutral-background-tinted);
   --dsc-input-color: var(--ds-color-neutral-text-default);
   --dsc-input-color--readonly: var(--ds-color-neutral-text-subtle);
   --dsc-input-border-color: var(--ds-color-neutral-border-default);
@@ -19,7 +19,7 @@
 
   /* Base styles */
   appearance: none;
-  background-color: var(--dsc-input-background);
+  background-color: var(--dsc-input-background-color);
   border-radius: var(--ds-border-radius-md);
   border-width: var(--dsc-input-border-width);
   border-style: var(--dsc-input-border-style);
@@ -75,7 +75,7 @@
   }
 
   &[readonly] {
-    background-color: var(--dsc-input-background--readonly);
+    background-color: var(--dsc-input-background-color--readonly);
     border-color: var(--dsc-input-border-color--readonly);
     color: var(--dsc-input-color--readonly);
 
@@ -122,9 +122,8 @@
   --dsc-input-stroke-color--checked: var(--ds-color-base-contrast-default);
   --dsc-input-stroke-color--invalid: var(--ds-color-danger-base-contrast-default);
   --dsc-input-stroke-width: 0.05em;
-  --dsc-input-background--checked: var(--ds-color-base-default);
-  --dsc-input-background--invalid: var(--ds-color-danger-text-subtle);
-  --dsc-input-background--readonly: var(--ds-color-neutral-background-tinted);
+  --dsc-input-background-color--checked: var(--ds-color-base-default);
+  --dsc-input-background-color--invalid: var(--ds-color-danger-text-subtle);
   --_dsc-input-spacing--toggle: calc(var(--ds-size-1) / 2);
 
   border-width: var(--dsc-input-border-width--toggle);
@@ -136,19 +135,19 @@
   cursor: pointer;
 
   &:checked {
-    background-color: var(--dsc-input-background--checked);
-    border-color: var(--dsc-input-background--checked);
+    background-color: var(--dsc-input-background-color--checked);
+    border-color: var(--dsc-input-background-color--checked);
     color: var(--dsc-input-stroke-color--checked);
   }
 
   &[aria-invalid='true']:where(:checked, :indeterminate) {
-    background-color: var(--dsc-input-background--invalid);
+    background-color: var(--dsc-input-background-color--invalid);
     color: var(--dsc-input-stroke-color--invalid);
     border-color: var(--dsc-input-border-color--invalid);
   }
 
   &[readonly] {
-    background-color: var(--dsc-input-background--readonly);
+    background-color: var(--dsc-input-background-color--readonly);
     border-color: var(--dsc-input-border-color--readonly);
     color: var(--dsc-input-color--readonly);
 
@@ -209,8 +208,8 @@
   }
 
   &:indeterminate {
-    background-color: var(--dsc-input-background--checked);
-    border-color: var(--dsc-input-background--checked);
+    background-color: var(--dsc-input-background-color--checked);
+    border-color: var(--dsc-input-background-color--checked);
     color: var(--dsc-input-stroke-color--checked);
     background-origin: content-box;
     background-position: center;
@@ -226,12 +225,12 @@
     &[readonly] {
       color: var(--dsc-input-color--readonly);
       border-color: var(--dsc-input-border-color--readonly);
-      background-color: var(--dsc-input-background--readonly);
+      background-color: var(--dsc-input-background-color--readonly);
     }
 
     &[aria-invalid='true'] {
       border-color: var(--dsc-input-border-color--invalid);
-      background-color: var(--dsc-input-background--invalid);
+      background-color: var(--dsc-input-background-color--invalid);
     }
 
     @media (forced-colors: active) {

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -7,7 +7,7 @@
   --dsc-input-background--readonly: var(--ds-color-neutral-background-tinted);
   --dsc-input-background: var(--ds-color-neutral-background-default);
   --dsc-input-border-color--checked: var(--ds-color-base-default);
-  --dsc-input-border-color--invalid: currentColor;
+  --dsc-input-border-color--invalid: var(--ds-color-danger-text-subtle);
   --dsc-input-border-color--readonly: var(--ds-color-neutral-border-subtle);
   --dsc-input-border-color: var(--ds-color-neutral-border-default);
   --dsc-input-border-width--toggle: max(1px, calc(var(--ds-size-1) / 2)); /* Allow border-width to grow with font-size */

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -6,25 +6,26 @@
   --dsc-input-background: var(--ds-color-neutral-background-default);
   --dsc-input-border-color--readonly: var(--ds-color-neutral-border-subtle);
   --dsc-input-border-color: var(--ds-color-neutral-border-default);
+  --dsc-input-border-style: solid;
   --dsc-input-border-width--toggle: max(1px, calc(var(--ds-size-1) / 2)); /* Allow border-width to grow with font-size */
   --dsc-input-border-width: 1px;
-  --dsc-input-border-style: solid;
-  --dsc-input-color: var(--ds-color-neutral-text-default);
-  --dsc-input-color--readonly: var(--ds-color-neutral-text-subtle);
   --dsc-input-color--checked: var(--ds-color-base-default);
-  --dsc-input-color--checked-contrast: var(--ds-color-base-contrast-default);
   --dsc-input-color--invalid: var(--ds-color-danger-text-subtle);
-  --dsc-input-color--invalid-contrast: var(--ds-color-danger-base-contrast-default);
+  --dsc-input-color--readonly: var(--ds-color-neutral-text-subtle);
+  --dsc-input-color: var(--ds-color-neutral-text-default);
   --dsc-input-padding: var(--ds-size-2) var(--ds-size-3);
   --dsc-input-size--toggle: var(--ds-size-6);
   --dsc-input-size: var(--ds-size-12);
-  --dsc-input-stroke: 0.05em;
+  /* Stroke is used as the dot in radio, and checkmark in checkboxes */
+  --dsc-input-stroke-color--checked: var(--ds-color-base-contrast-default);
+  --dsc-input-stroke-color--invalid: var(--ds-color-danger-base-contrast-default);
+  --dsc-input-stroke-width: 0.05em;
 
   /* Checkmark with antialiasing is achieved by percentages 48% / 50% / 52% */
-  --diagonal-1: transparent calc(48% - var(--dsc-input-stroke));
-  --diagonal-2: currentcolor calc(50% - var(--dsc-input-stroke));
-  --diagonal-3: currentcolor calc(50% + var(--dsc-input-stroke));
-  --diagonal-4: transparent calc(52% + var(--dsc-input-stroke));
+  --diagonal-1: transparent calc(48% - var(--dsc-input-stroke-width));
+  --diagonal-2: currentcolor calc(50% - var(--dsc-input-stroke-width));
+  --diagonal-3: currentcolor calc(50% + var(--dsc-input-stroke-width));
+  --diagonal-4: transparent calc(52% + var(--dsc-input-stroke-width));
   --spacing--toggle: calc(var(--ds-size-1) / 2);
 
   appearance: none;
@@ -48,11 +49,6 @@
   @composes ds-focus from './base.css';
 
   @media (forced-colors: active) {
-    /*     --diagonal-1: transparent calc(48% - var(--dsc-input-stroke));
-    --diagonal-2: Canvas calc(50% - var(--dsc-input-stroke));
-    --diagonal-3: Canvas calc(50% + var(--dsc-input-stroke));
-    --diagonal-4: transparent calc(52% + var(--dsc-input-stroke)); */
-
     border-color: ButtonText;
     background-color: Canvas;
 
@@ -76,7 +72,7 @@
     padding-right: 2.4em;
     background-image: linear-gradient(45deg, var(--diagonal-1), var(--diagonal-2), var(--diagonal-3), var(--diagonal-4)),
       linear-gradient(-45deg, var(--diagonal-1), var(--diagonal-2), var(--diagonal-3), var(--diagonal-4));
-    background-position: calc(100% - 1.2em + var(--dsc-input-stroke)), calc(100% - 0.8em);
+    background-position: calc(100% - 1.2em + var(--dsc-input-stroke-width)), calc(100% - 0.8em);
     background-size: .4em .4em;
     background-repeat: no-repeat;
 
@@ -107,7 +103,7 @@
   &:indeterminate:where([type='checkbox']) {
     background: var(--dsc-input-color--checked);
     border-color: var(--dsc-input-color--checked);
-    color: var(--dsc-input-color--checked-contrast);
+    color: var(--dsc-input-stroke-color--checked);
   }
 
   &:disabled,
@@ -121,7 +117,7 @@
   }
   &[aria-invalid='true']:where(:checked, :indeterminate) {
     background: var(--dsc-input-color--invalid);
-    color: var(--dsc-input-color--invalid-contrast);
+    color: var(--dsc-input-stroke-color--invalid);
   }
 
   /* Using attribute [readonly] since pseudo selector :read-only is always true for checkbox, radio and select */
@@ -203,10 +199,10 @@
     background-repeat: no-repeat;
     background-size: contain;
     background-image: linear-gradient(
-      transparent calc(48% - var(--dsc-input-stroke)),
-      currentcolor calc(50% - var(--dsc-input-stroke)),
-      currentcolor calc(50% + var(--dsc-input-stroke)),
-      transparent calc(52% + var(--dsc-input-stroke))
+      transparent calc(48% - var(--dsc-input-stroke-width)),
+      currentcolor calc(50% - var(--dsc-input-stroke-width)),
+      currentcolor calc(50% + var(--dsc-input-stroke-width)),
+      transparent calc(52% + var(--dsc-input-stroke-width))
     );
 
     @media (forced-colors: active) {

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -244,6 +244,7 @@
       &[readonly] {
         background-color: LinkText;
         border-color: LinkText;
+        color: Canvas;
       }
     }
   }

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -1,35 +1,25 @@
 :where(.ds-input) {
-  margin: 0; /* Reset native margin, but resepect parent selevtor `.someting > * { margin: ... }` */
+  margin: 0;
 }
+
+/* Root class with shared variables and base input styles */
 .ds-input {
-  --dsc-input-background--readonly: var(--ds-color-neutral-background-tinted);
+  /* Core variables */
   --dsc-input-background: var(--ds-color-neutral-background-default);
-  --dsc-input-border-color--readonly: var(--ds-color-neutral-border-subtle);
-  --dsc-input-border-color: var(--ds-color-neutral-border-default);
-  --dsc-input-border-style: solid;
-  --dsc-input-border-width--toggle: max(1px, calc(var(--ds-size-1) / 2)); /* Allow border-width to grow with font-size */
-  --dsc-input-border-width: 1px;
-  --dsc-input-color--checked: var(--ds-color-base-default);
-  --dsc-input-color--invalid: var(--ds-color-danger-text-subtle);
-  --dsc-input-color--readonly: var(--ds-color-neutral-text-subtle);
+  --dsc-input-background--readonly: var(--ds-color-neutral-background-tinted);
   --dsc-input-color: var(--ds-color-neutral-text-default);
+  --dsc-input-color--readonly: var(--ds-color-neutral-text-subtle);
+  --dsc-input-border-color: var(--ds-color-neutral-border-default);
+  --dsc-input-border-color--readonly: var(--ds-color-neutral-border-subtle);
+  --dsc-input-border-color--invalid: var(--ds-color-danger-border-strong);
+  --dsc-input-border-style: solid;
+  --dsc-input-border-width: 1px;
   --dsc-input-padding: var(--ds-size-2) var(--ds-size-3);
-  --dsc-input-size--toggle: var(--ds-size-6);
   --dsc-input-size: var(--ds-size-12);
-  /* Stroke is used as the dot in radio, and checkmark in checkboxes */
-  --dsc-input-stroke-color--checked: var(--ds-color-base-contrast-default);
-  --dsc-input-stroke-color--invalid: var(--ds-color-danger-base-contrast-default);
-  --dsc-input-stroke-width: 0.05em;
 
-  /* Checkmark with antialiasing is achieved by percentages 48% / 50% / 52% */
-  --diagonal-1: transparent calc(48% - var(--dsc-input-stroke-width));
-  --diagonal-2: currentcolor calc(50% - var(--dsc-input-stroke-width));
-  --diagonal-3: currentcolor calc(50% + var(--dsc-input-stroke-width));
-  --diagonal-4: transparent calc(52% + var(--dsc-input-stroke-width));
-  --spacing--toggle: calc(var(--ds-size-1) / 2);
-
+  /* Base styles */
   appearance: none;
-  background: var(--dsc-input-background);
+  background-color: var(--dsc-input-background);
   border-radius: var(--ds-border-radius-md);
   border-width: var(--dsc-input-border-width);
   border-style: var(--dsc-input-border-style);
@@ -40,11 +30,11 @@
   font-family: inherit;
   height: var(--dsc-input-size);
   line-height: inherit;
-  max-width: 100%; /* Ensure input does not grow outside bounds even with a high value in size="" or cols="" */
-  min-width: 0; /* Allow shrinking in flex container, see https://ishadeed.com/article/min-max-css/#setting-min-width-to-zero-with-flexbox */
+  max-width: 100%;
+  min-width: 0;
   padding: var(--dsc-input-padding);
-  position: relative; /* Ensure foucs outline renders on top */
-  vertical-align: middle; /* Remove space under when display: inline-block */
+  position: relative;
+  vertical-align: middle;
 
   @composes ds-focus from './base.css';
 
@@ -65,47 +55,15 @@
   }
 
   &:not([data-size]) {
-    font-size: inherit; /* Ensure inheriting font-size */
+    font-size: inherit;
   }
 
-  &:is(select) {
-    padding-right: 2.4em;
-    background-image: linear-gradient(45deg, var(--diagonal-1), var(--diagonal-2), var(--diagonal-3), var(--diagonal-4)),
-      linear-gradient(-45deg, var(--diagonal-1), var(--diagonal-2), var(--diagonal-3), var(--diagonal-4));
-    background-position: calc(100% - 1.2em + var(--dsc-input-stroke-width)), calc(100% - 0.8em);
-    background-size: .4em .4em;
-    background-repeat: no-repeat;
-
-    @media (forced-colors: active) {
-      appearance: auto; /* show chevron */
-    }
-  }
-
-  &:is(textarea) {
-    height: auto; /* Allow rows="" to set height */
-    min-height: calc(var(--dsc-input-size) * 1.5); /* Set a min-height to indicate this is a <textarea> and not an <input> */
-    resize: vertical; /* Allow resizing vertically only */
-
-    &:not([rows]) {
-      field-sizing: content;
-    }
-  }
-
-  /* Using select:where() to decrease specificity */
+  /* Width handling */
   &:not([size], [cols], select:where([data-width='auto'])) {
     width: 100%;
   }
 
-  /**
-   * States
-   */
-  &:checked,
-  &:indeterminate:where([type='checkbox']) {
-    background: var(--dsc-input-color--checked);
-    border-color: var(--dsc-input-color--checked);
-    color: var(--dsc-input-stroke-color--checked);
-  }
-
+  /* States */
   &:disabled,
   &[aria-disabled='true'] {
     cursor: not-allowed;
@@ -113,16 +71,84 @@
   }
 
   &[aria-invalid='true'] {
-    border-color: var(--dsc-input-color--invalid);
-  }
-  &[aria-invalid='true']:where(:checked, :indeterminate) {
-    background: var(--dsc-input-color--invalid);
-    color: var(--dsc-input-stroke-color--invalid);
+    border-color: var(--dsc-input-border-color--invalid);
   }
 
-  /* Using attribute [readonly] since pseudo selector :read-only is always true for checkbox, radio and select */
   &[readonly] {
-    background: var(--dsc-input-background--readonly);
+    background-color: var(--dsc-input-background--readonly);
+    border-color: var(--dsc-input-border-color--readonly);
+    color: var(--dsc-input-color--readonly);
+
+    @media (forced-colors: active) {
+      border-color: GrayText;
+    }
+  }
+}
+
+/* Select specific styles */
+.ds-input:is(select) {
+  padding-right: 2.4em;
+  background-image: linear-gradient(
+      45deg,
+      transparent calc(48% - 0.05em),
+      currentcolor calc(50% - 0.05em),
+      currentcolor calc(50% + 0.05em),
+      transparent calc(52% + 0.05em)
+    ), linear-gradient(-45deg, transparent calc(48% - 0.05em), currentcolor calc(50% - 0.05em), currentcolor calc(50% + 0.05em), transparent calc(52% + 0.05em));
+  background-position: calc(100% - 1.2em + 0.05em), calc(100% - 0.8em);
+  background-size: .4em .4em;
+  background-repeat: no-repeat;
+
+  @media (forced-colors: active) {
+    appearance: auto;
+  }
+}
+
+/* Textarea specific styles */
+.ds-input:is(textarea) {
+  height: auto;
+  min-height: calc(var(--dsc-input-size) * 1.5);
+  resize: vertical;
+
+  &:not([rows]) {
+    field-sizing: content;
+  }
+}
+
+/* Toggle inputs (checkbox/radio) shared styles */
+.ds-input:is([type='checkbox'], [type='radio']) {
+  --dsc-input-border-width--toggle: max(1px, calc(var(--ds-size-1) / 2));
+  --dsc-input-size--toggle: var(--ds-size-6);
+  --dsc-input-stroke-color--checked: var(--ds-color-base-contrast-default);
+  --dsc-input-stroke-color--invalid: var(--ds-color-danger-base-contrast-default);
+  --dsc-input-stroke-width: 0.05em;
+  --dsc-input-background--checked: var(--ds-color-base-default);
+  --dsc-input-background--invalid: var(--ds-color-danger-text-subtle);
+  --dsc-input-background--readonly: var(--ds-color-neutral-background-tinted);
+  --_dsc-input-spacing--toggle: calc(var(--ds-size-1) / 2);
+
+  border-width: var(--dsc-input-border-width--toggle);
+  padding: var(--_dsc-input-spacing--toggle);
+  flex-shrink: 0;
+  line-height: inherit;
+  height: var(--dsc-input-size--toggle);
+  width: var(--dsc-input-size--toggle);
+  cursor: pointer;
+
+  &:checked {
+    background-color: var(--dsc-input-background--checked);
+    border-color: var(--dsc-input-background--checked);
+    color: var(--dsc-input-stroke-color--checked);
+  }
+
+  &[aria-invalid='true']:where(:checked, :indeterminate) {
+    background-color: var(--dsc-input-background--invalid);
+    color: var(--dsc-input-stroke-color--invalid);
+    border-color: var(--dsc-input-border-color--invalid);
+  }
+
+  &[readonly] {
+    background-color: var(--dsc-input-background--readonly);
     border-color: var(--dsc-input-border-color--readonly);
     color: var(--dsc-input-color--readonly);
 
@@ -131,69 +157,60 @@
     }
   }
 
-  /**
-   * Toggle inputs and select
-   */
-  &:read-only:not([readonly], [aria-disabled='true'], :disabled) {
-    cursor: pointer;
-  }
+  @media (forced-colors: active) {
+    color: Canvas;
 
-  /**
-   * Toggle inputs
-   */
-  &[type='checkbox'],
-  &[type='radio'] {
-    border-width: var(--dsc-input-border-width--toggle);
-    padding: var(--spacing--toggle);
-
-    flex-shrink: 0; /* Never shrink a toggle input */
-    line-height: inherit; /* Inherit line height so we can use 1lh to align with first line of label */
-    height: var(--dsc-input-size--toggle);
-    width: var(--dsc-input-size--toggle);
-    /* forced-color-adjust: none; */ /* Prevent browser from applying forced colors, since we need the background */
-
-    @media (forced-colors: active) {
-      color: Canvas;
-
-      &:disabled,
-      &[aria-disabled='true'],
-      &[readonly] {
-        border-color: GrayText;
-      }
+    &:disabled,
+    &[aria-disabled='true'],
+    &[readonly] {
+      border-color: GrayText;
     }
   }
+}
 
-  &[type='radio'] {
-    border-radius: var(--ds-border-radius-full);
-  }
+/* Radio specific styles */
+.ds-input[type='radio'] {
+  border-radius: var(--ds-border-radius-full);
 
-  &[type='radio']:checked {
+  &:checked {
     background-image: radial-gradient(circle closest-side, currentcolor 45%, transparent 50%);
 
     @media (forced-colors: active) {
       background-color: LinkText;
       border-color: LinkText;
       color: Canvas;
-      forced-color-adjust: none; /* To be able to draw dot */
+      forced-color-adjust: none;
     }
   }
+}
 
-  &[type='checkbox']:checked {
+/* Checkbox specific styles */
+.ds-input[type='checkbox'] {
+  &:checked {
     background-origin: content-box;
     background-repeat: no-repeat;
     background-position: 10% 73%, 90% 50%;
     background-size: 35% 35%, 65% 65%;
-    background-image: linear-gradient(45deg, var(--diagonal-1), var(--diagonal-2), var(--diagonal-3), var(--diagonal-4)),
-      linear-gradient(-45deg, var(--diagonal-1), var(--diagonal-2), var(--diagonal-3), var(--diagonal-4));
+    background-image: linear-gradient(
+        45deg,
+        transparent calc(48% - 0.05em),
+        currentcolor calc(50% - 0.05em),
+        currentcolor calc(50% + 0.05em),
+        transparent calc(52% + 0.05em)
+      ),
+      linear-gradient(-45deg, transparent calc(48% - 0.05em), currentcolor calc(50% - 0.05em), currentcolor calc(50% + 0.05em), transparent calc(52% + 0.05em));
 
     @media (forced-colors: active) {
       background-color: LinkText;
       border-color: LinkText;
-      forced-color-adjust: none; /* To be able to draw check */
+      forced-color-adjust: none;
     }
   }
 
-  &[type='checkbox']:indeterminate {
+  &:indeterminate {
+    background-color: var(--dsc-input-background--checked);
+    border-color: var(--dsc-input-background--checked);
+    color: var(--dsc-input-stroke-color--checked);
     background-origin: content-box;
     background-position: center;
     background-repeat: no-repeat;
@@ -205,50 +222,59 @@
       transparent calc(52% + var(--dsc-input-stroke-width))
     );
 
+    &[readonly] {
+      color: var(--dsc-input-color--readonly);
+      border-color: var(--dsc-input-border-color--readonly);
+      background-color: var(--dsc-input-background--readonly);
+    }
+
+    &[aria-invalid='true'] {
+      border-color: var(--dsc-input-border-color--invalid);
+      background-color: var(--dsc-input-background--invalid);
+    }
+
     @media (forced-colors: active) {
       background-color: LinkText;
       border-color: LinkText;
-      forced-color-adjust: none; /* To be able to draw line */
+      forced-color-adjust: none;
+    }
+  }
+}
+
+/* Switch specific styles */
+.ds-input[role='switch']:is([type='radio'], [type='checkbox']) {
+  --_dsc-input-circle-position: left;
+
+  background-image: radial-gradient(circle closest-side, currentcolor 95%, transparent 100%);
+  background-origin: content-box;
+  background-position: var(--_dsc-input-circle-position);
+  background-repeat: no-repeat;
+  background-size: calc(var(--dsc-input-size--toggle) - var(--_dsc-input-spacing--toggle) * 2) 100%;
+  border-radius: var(--ds-border-radius-full);
+  padding-inline: 0;
+  transition: 0.2s background-position;
+  width: calc(var(--dsc-input-size--toggle) * 2);
+
+  &:checked {
+    --_dsc-input-circle-position: right;
+
+    @media (forced-colors: active) {
+      color: CanvasText;
     }
   }
 
-  /**
-   * Switch
-   */
-  &[role='switch']:is([type='radio'], [type='checkbox']) {
-    --circle-position: left;
+  @media (forced-colors: active) {
+    color: GrayText;
+    forced-color-adjust: none;
 
-    background-image: radial-gradient(circle closest-side, currentcolor 95%, transparent 100%);
-    background-origin: content-box;
-    background-position: var(--circle-position);
-    background-repeat: no-repeat;
-    background-size: calc(var(--dsc-input-size--toggle) - var(--spacing--toggle) * 2) 100%;
-    border-radius: var(--ds-border-radius-full);
-    padding-inline: 0; /* Reset to position circle correctly */
-    transition: 0.2s background-position;
-    width: calc(var(--dsc-input-size--toggle) * 2);
-
-    &:checked {
-      --circle-position: right;
-
-      @media (forced-colors: active) {
-        color: CanvasText;
-      }
+    &[readonly] {
+      color: GrayText;
     }
 
-    @media (forced-colors: active) {
-      color: GrayText;
-
-      forced-color-adjust: none; /* To be able to draw switch */
-      &[readonly] {
-        color: GrayText;
-      }
-
-      &:disabled,
-      &[aria-disabled='true'],
-      &[readonly] {
-        border-color: GrayText;
-      }
+    &:disabled,
+    &[aria-disabled='true'],
+    &[readonly] {
+      border-color: GrayText;
     }
   }
 }

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -7,7 +7,7 @@
   --dsc-input-background--readonly: var(--ds-color-neutral-background-tinted);
   --dsc-input-background: var(--ds-color-neutral-background-default);
   --dsc-input-border-color--checked: var(--ds-color-base-default);
-  --dsc-input-stroke-color--invalid: var(--ds-color-danger-text-subtle); /* Used to color stroke in invalid state. Border for text input and background for checkbox/radio */
+  --dsc-input-stroke-color--invalid: var(--ds-color-danger-text-subtle); /* Used to color stroke in invalid state. Border for text input and background for checkbox */
   --dsc-input-border-color--readonly: var(--ds-color-neutral-border-subtle);
   --dsc-input-border-color: var(--ds-color-neutral-border-default);
   --dsc-input-border-width--toggle: max(1px, calc(var(--ds-size-1) / 2)); /* Allow border-width to grow with font-size */

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -13,8 +13,8 @@
   --dsc-input-stroke-color--invalid: var(--ds-color-danger-base-contrast-default);
   --dsc-input-color: var(--ds-color-neutral-text-default);
   --dsc-input-color--readonly: var(--ds-color-neutral-text-subtle);
-  --dsc-input-color--invalid: var(--ds-color-danger-text-subtle);
   --dsc-input-color--checked: var(--ds-color-base-default);
+  --dsc-input-color--invalid: var(--ds-color-danger-text-subtle);
   --dsc-input-padding: var(--ds-size-2) var(--ds-size-3);
   --dsc-input-size--toggle: var(--ds-size-6);
   --dsc-input-size: var(--ds-size-12);

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -7,7 +7,7 @@
   --dsc-input-background--readonly: var(--ds-color-neutral-background-tinted);
   --dsc-input-background: var(--ds-color-neutral-background-default);
   --dsc-input-border-color--checked: var(--ds-color-base-default);
-  --dsc-input-border-color--invalid: var(--ds-color-danger-border-strong);
+  --dsc-input-border-color--invalid: currentColor;
   --dsc-input-border-color--readonly: var(--ds-color-neutral-border-subtle);
   --dsc-input-border-color: var(--ds-color-neutral-border-default);
   --dsc-input-border-width--toggle: max(1px, calc(var(--ds-size-1) / 2)); /* Allow border-width to grow with font-size */

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -2,21 +2,19 @@
   margin: 0; /* Reset native margin, but resepect parent selevtor `.someting > * { margin: ... }` */
 }
 .ds-input {
-  --dsc-input-background--checked: var(--dsc-input-border-color--checked);
-  --dsc-input-background--invalid: var(--dsc-input-stroke-color--invalid);
   --dsc-input-background--readonly: var(--ds-color-neutral-background-tinted);
   --dsc-input-background: var(--ds-color-neutral-background-default);
-  --dsc-input-border-color--checked: var(--ds-color-base-default);
-  --dsc-input-stroke-color--invalid: var(--ds-color-danger-text-subtle); /* Used to color stroke in invalid state. Border for text input and background for checkbox */
   --dsc-input-border-color--readonly: var(--ds-color-neutral-border-subtle);
   --dsc-input-border-color: var(--ds-color-neutral-border-default);
   --dsc-input-border-width--toggle: max(1px, calc(var(--ds-size-1) / 2)); /* Allow border-width to grow with font-size */
   --dsc-input-border-width: 1px;
   --dsc-input-border-style: solid;
-  --dsc-input-color--checked: var(--ds-color-base-contrast-default);
-  --dsc-input-color--invalid: var(--ds-color-danger-base-contrast-default);
-  --dsc-input-color--readonly: var(--ds-color-neutral-text-subtle);
+  --dsc-input-stroke-color--checked: var(--ds-color-base-contrast-default);
+  --dsc-input-stroke-color--invalid: var(--ds-color-danger-base-contrast-default);
   --dsc-input-color: var(--ds-color-neutral-text-default);
+  --dsc-input-color--readonly: var(--ds-color-neutral-text-subtle);
+  --dsc-input-color--invalid: var(--ds-color-danger-text-subtle); /* Used to color stroke in invalid state. Border for text input and background for checkbox */
+  --dsc-input-color--checked: var(--ds-color-base-default);
   --dsc-input-padding: var(--ds-size-2) var(--ds-size-3);
   --dsc-input-size--toggle: var(--ds-size-6);
   --dsc-input-size: var(--ds-size-12);
@@ -107,9 +105,9 @@
    */
   &:checked,
   &:indeterminate:where([type='checkbox']) {
-    background: var(--dsc-input-background--checked);
-    border-color: var(--dsc-input-border-color--checked);
-    color: var(--dsc-input-color--checked);
+    background: var(--dsc-input-color--checked);
+    border-color: var(--dsc-input-color--checked);
+    color: var(--dsc-input-stroke-color--checked);
   }
 
   &:disabled,
@@ -119,11 +117,11 @@
   }
 
   &[aria-invalid='true'] {
-    border-color: var(--dsc-input-border-color--invalid);
+    border-color: var(--dsc-input-color--invalid);
   }
   &[aria-invalid='true']:where(:checked, :indeterminate) {
-    background: var(--dsc-input-background--invalid);
-    color: var(--dsc-input-color--invalid);
+    background: var(--dsc-input-color--invalid);
+    color: var(--dsc-input-stroke-color--invalid);
   }
 
   /* Using attribute [readonly] since pseudo selector :read-only is always true for checkbox, radio and select */

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -9,12 +9,12 @@
   --dsc-input-border-width--toggle: max(1px, calc(var(--ds-size-1) / 2)); /* Allow border-width to grow with font-size */
   --dsc-input-border-width: 1px;
   --dsc-input-border-style: solid;
-  --dsc-input-stroke-color--checked: var(--ds-color-base-contrast-default);
-  --dsc-input-stroke-color--invalid: var(--ds-color-danger-base-contrast-default);
   --dsc-input-color: var(--ds-color-neutral-text-default);
   --dsc-input-color--readonly: var(--ds-color-neutral-text-subtle);
   --dsc-input-color--checked: var(--ds-color-base-default);
+  --dsc-input-color--checked-contrast: var(--ds-color-base-contrast-default);
   --dsc-input-color--invalid: var(--ds-color-danger-text-subtle);
+  --dsc-input-color--invalid-contrast: var(--ds-color-danger-base-contrast-default);
   --dsc-input-padding: var(--ds-size-2) var(--ds-size-3);
   --dsc-input-size--toggle: var(--ds-size-6);
   --dsc-input-size: var(--ds-size-12);
@@ -107,7 +107,7 @@
   &:indeterminate:where([type='checkbox']) {
     background: var(--dsc-input-color--checked);
     border-color: var(--dsc-input-color--checked);
-    color: var(--dsc-input-stroke-color--checked);
+    color: var(--dsc-input-color--checked-contrast);
   }
 
   &:disabled,
@@ -121,7 +121,7 @@
   }
   &[aria-invalid='true']:where(:checked, :indeterminate) {
     background: var(--dsc-input-color--invalid);
-    color: var(--dsc-input-stroke-color--invalid);
+    color: var(--dsc-input-color--invalid-contrast);
   }
 
   /* Using attribute [readonly] since pseudo selector :read-only is always true for checkbox, radio and select */

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -169,7 +169,7 @@
 }
 
 /* Radio specific styles */
-.ds-input[type='radio'] {
+.ds-input:is([type='radio']) {
   border-radius: var(--ds-border-radius-full);
 
   &:checked {
@@ -185,7 +185,7 @@
 }
 
 /* Checkbox specific styles */
-.ds-input[type='checkbox'] {
+.ds-input:is([type='checkbox']) {
   &:checked {
     background-origin: content-box;
     background-repeat: no-repeat;
@@ -251,7 +251,7 @@
 }
 
 /* Switch specific styles */
-.ds-input[role='switch']:is([type='radio'], [type='checkbox']) {
+.ds-input:is([role='switch']):is([type='radio'], [type='checkbox']) {
   --_dsc-input-circle-position: left;
 
   background-image: radial-gradient(circle closest-side, currentcolor 95%, transparent 100%);

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -3,11 +3,11 @@
 }
 .ds-input {
   --dsc-input-background--checked: var(--dsc-input-border-color--checked);
-  --dsc-input-background--invalid: var(--dsc-input-border-color--invalid);
+  --dsc-input-background--invalid: var(--dsc-input-stroke-color--invalid);
   --dsc-input-background--readonly: var(--ds-color-neutral-background-tinted);
   --dsc-input-background: var(--ds-color-neutral-background-default);
   --dsc-input-border-color--checked: var(--ds-color-base-default);
-  --dsc-input-border-color--invalid: var(--ds-color-danger-text-subtle);
+  --dsc-input-stroke-color--invalid: var(--ds-color-danger-text-subtle); /* Used to color stroke in invalid state. Border for text input and background for checkbox/radio */
   --dsc-input-border-color--readonly: var(--ds-color-neutral-border-subtle);
   --dsc-input-border-color: var(--ds-color-neutral-border-default);
   --dsc-input-border-width--toggle: max(1px, calc(var(--ds-size-1) / 2)); /* Allow border-width to grow with font-size */

--- a/packages/css/src/input.css
+++ b/packages/css/src/input.css
@@ -203,6 +203,7 @@
     @media (forced-colors: active) {
       background-color: LinkText;
       border-color: LinkText;
+      color: Canvas;
       forced-color-adjust: none;
     }
   }
@@ -236,7 +237,14 @@
     @media (forced-colors: active) {
       background-color: LinkText;
       border-color: LinkText;
+      color: Canvas;
       forced-color-adjust: none;
+
+      &[aria-invalid='true'],
+      &[readonly] {
+        background-color: LinkText;
+        border-color: LinkText;
+      }
     }
   }
 }


### PR DESCRIPTION
This is a PR with a suggestion on how we can split `.ds-input` to make it more maintainable and easier to name variables for different cases.

This one class currently handles textinput, textarea, radio, checkbox, switch, select.. 
By splitting it, and only setting variables where we need them, we make it easier to not get a lot of intersecting variables.

As for docs, I think this is something we should document right away, at least the selectors we use, It could be benefitial to not combine radio and checkbox, as I have done - we'll explore and discuss.