### PR TITLE
chore: fix wrong color name returned from CLI func

### DIFF
--- a/packages/cli/src/colors/utils.ts
+++ b/packages/cli/src/colors/utils.ts
@@ -272,13 +272,13 @@ export const getColorInfoFromPosition = (position: ColorNumber) => {
       group: 'base',
     },
     15: {
-      name: 'contrastSubtle',
-      displayName: 'Contrast Subtle',
+      name: 'baseContrastSubtle',
+      displayName: 'Base Contrast Subtle',
       group: 'base',
     },
     16: {
-      name: 'contrastDefault',
-      displayName: 'Contrast Default',
+      name: 'baseContrastDefault',
+      displayName: 'Base Contrast Default',
       group: 'base',
     },
   } as const;


### PR DESCRIPTION
Add the base prefix to the contrast color names in the `getColorInfoFromPosition` function.

In the themebuilder the preview examples loop through the function to set unique tokens for each card. Now the contrast colors are not applied because the base prefix is missing. When a very light color is selected in the themebuilder, the text in the Button on the preview Cards are white.