### PR TITLE
fix: `ref` type on `useCheckboxGroup` and `useRadioGroup`

### DIFF
--- a/.changeset/long-taxis-tease.md
+++ b/.changeset/long-taxis-tease.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+Fix `ref` type on `useCheckboxGroup` and `useRadioGroup`

--- a/packages/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.ts
+++ b/packages/react/src/utilities/hooks/useCheckboxGroup/useCheckboxGroup.ts
@@ -60,7 +60,8 @@ export type GetCheckboxProps = Omit<
 > & {
   /** Enables indeterminate handling for this `Checkbox` and `CheckboxGroup` */
   allowIndeterminate?: boolean;
-  ref?: React.Ref<HTMLInputElement | null>;
+  ref?: React.ForwardedRef<HTMLInputElement>; // Use this to match Ref from `Checkbox`, remove when `Checkbox` no longer uses `forwardRef`
+  checked?: boolean;
   value?: string;
 };
 

--- a/packages/react/src/utilities/hooks/useRadioGroup/useRadioGroup.ts
+++ b/packages/react/src/utilities/hooks/useRadioGroup/useRadioGroup.ts
@@ -41,7 +41,7 @@ export type GetRadioProps = Omit<
   | 'checked'
   | 'value'
 > & {
-  ref?: React.Ref<HTMLInputElement | null>;
+  ref?: React.ForwardedRef<HTMLInputElement>; // Use this to match Ref from `Radio`, remove when `Radio` no longer uses `forwardRef`
   value?: string;
 };
 


### PR DESCRIPTION
Fixes bug reported in by slack, when using our `useCheckboxGroup` and `useRadioGroup` with respective `Checkbox` and `Radio` component.

This was probably due to changes in types used for `forwardRef` in React 19.

```sh
Type '{ name?: string | undefined; title?: string | undefined; description?: ReactNode; placeholder?: string | undefined; form?: string | undefined; onChange?: ChangeEventHandler<HTMLInputElement> | undefined; ... 288 more ...; label: string; }' is not assignable to type 'RefAttributes<HTMLInputElement>'.
Types of property ref are incompatible.
```