### PR TITLE
fix(storybook): Set children type and docs

### DIFF
--- a/packages/react/src/components/Alert/Alert.stories.tsx
+++ b/packages/react/src/components/Alert/Alert.stories.tsx
@@ -12,6 +12,11 @@ const meta: Meta = {
   parameters: {
     layout: 'padded',
   },
+  argTypes: {
+    children: {
+      type: 'string',
+    },
+  },
 };
 
 export default meta;

--- a/packages/react/src/components/Alert/Alert.tsx
+++ b/packages/react/src/components/Alert/Alert.tsx
@@ -1,5 +1,5 @@
 import cl from 'clsx/lite';
-import type { HTMLAttributes } from 'react';
+import type { HTMLAttributes, ReactNode } from 'react';
 import { forwardRef } from 'react';
 import type { SeverityColors } from '../../colors';
 import type { DefaultProps } from '../../types';
@@ -14,6 +14,8 @@ export type AlertProps = MergeRight<
      * @default 'info'
      */
     'data-color'?: SeverityColors;
+    /** Anything renderable. Recommended with a `Heading` and `Paragraph` */
+    children: ReactNode;
   }
 >;
 

--- a/packages/react/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/react/src/components/Avatar/Avatar.stories.tsx
@@ -19,6 +19,11 @@ const meta: Meta<typeof Avatar> = {
       alignItems: 'center',
     },
   },
+  argTypes: {
+    children: {
+      type: 'string',
+    },
+  },
 };
 
 export default meta;

--- a/packages/react/src/components/Badge/Badge.tsx
+++ b/packages/react/src/components/Badge/Badge.tsx
@@ -21,13 +21,8 @@ export type BadgeProps = MergeRight<
 /**
  * `Badge` is a non-interactive component for displaying status with or without numbers.
  *
- * @example without children
+ * @example
  * <Badge count={5} maxCount={10} />
- *
- * @example with children
- * <Badge count={5} maxCount={10}>
- *   <Icon />
- * </Badge>
  */
 export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(function Badge(
   { className, count, maxCount, ...rest },

--- a/packages/react/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/react/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -2,14 +2,25 @@ import type { Meta, StoryFn } from '@storybook/react';
 
 import { Breadcrumbs } from '.';
 
+type Story = StoryFn<typeof Breadcrumbs>;
+
 export default {
   title: 'Komponenter/Breadcrumbs',
   component: Breadcrumbs,
+  argTypes: {
+    children: {
+      control: false,
+    },
+  },
 } as Meta;
 
-export const Preview: StoryFn<typeof Breadcrumbs> = (args) => (
-  <>
-    <Breadcrumbs aria-label='Du er her:' {...args}>
+export const Preview: Story = (args) => (
+  <Breadcrumbs aria-label='Du er her:' {...args}></Breadcrumbs>
+);
+
+Preview.args = {
+  children: (
+    <>
       <Breadcrumbs.Link href='#' aria-label='Tilbake til Nivå 3'>
         Nivå 3
       </Breadcrumbs.Link>
@@ -27,9 +38,9 @@ export const Preview: StoryFn<typeof Breadcrumbs> = (args) => (
           <Breadcrumbs.Link href='#'>Nivå 4</Breadcrumbs.Link>
         </Breadcrumbs.Item>
       </Breadcrumbs.List>
-    </Breadcrumbs>
-  </>
-);
+    </>
+  ),
+};
 
 export const ListOnly: StoryFn<typeof Breadcrumbs> = (args) => (
   <Breadcrumbs aria-label='Du er her:'>

--- a/packages/react/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/react/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,5 +1,5 @@
 import cl from 'clsx/lite';
-import { type HTMLAttributes, forwardRef } from 'react';
+import { type HTMLAttributes, type ReactNode, forwardRef } from 'react';
 import type { DefaultProps } from '../../types';
 import type { MergeRight } from '../../utilities';
 
@@ -11,6 +11,8 @@ export type BreadcrumbsProps = MergeRight<
      * @default 'Du er her'
      */
     'aria-label'?: string;
+    /** Instance of `Breadcrumbs.link`, `Breadcrumbs.List` */
+    children: ReactNode;
   }
 >;
 

--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -11,11 +11,13 @@ export type ButtonProps = MergeRight<
   {
     /**
      * Specify which variant to use
+     *
      * @default 'primary'
      */
     variant?: 'primary' | 'secondary' | 'tertiary';
     /**
      * Toggle icon only styling, pass icon as children
+     *
      * @default false
      */
     icon?: boolean;
@@ -32,10 +34,15 @@ export type ButtonProps = MergeRight<
      */
     asChild?: boolean;
     /**
-     * Specify the type of button. Unset when `asChild` is true
+     * Specify the type of button. Unset when `asChild` is true.
+     *
      * @default 'button'
      */
     type?: ButtonHTMLAttributes<HTMLButtonElement>['type'];
+    /**
+     * An `Icon`, `string` or combination of the two.
+     */
+    children?: ReactNode;
   }
 >;
 

--- a/packages/react/src/components/Card/Card.tsx
+++ b/packages/react/src/components/Card/Card.tsx
@@ -19,7 +19,9 @@ export type CardProps = MergeRight<
      * @default false
      */
     asChild?: boolean;
-    /** Instances of `Card.Block`, `Divider` or other React nodes */
+    /**
+     * Instances of `Card.Block`, `Divider` or other React nodes.
+     */
     children: ReactNode;
   }
 >;

--- a/packages/react/src/components/Chip/Chip.stories.tsx
+++ b/packages/react/src/components/Chip/Chip.stories.tsx
@@ -8,18 +8,27 @@ export default {
   parameters: {
     customStyles: { display: 'flex', gap: 'var(--ds-size-2)' },
   },
+  argTypes: {
+    children: {
+      type: 'string',
+    },
+  },
 } satisfies Meta;
 
 export const Preview: StoryFn<typeof Chip.Radio> = (args) => (
   <>
     <Chip.Radio {...args} name='my-radio' value='nynorsk' defaultChecked>
-      Nynorsk
+      {args.children}
     </Chip.Radio>
     <Chip.Radio {...args} name='my-radio' value='bokmål'>
       Bokmål
     </Chip.Radio>
   </>
 );
+
+Preview.args = {
+  children: 'Nynorsk',
+};
 
 export const Checkbox: StoryFn<typeof Chip.Checkbox> = (args) => (
   <Chip.Checkbox {...args}>Nynorsk</Chip.Checkbox>

--- a/packages/react/src/components/Chip/Chips.tsx
+++ b/packages/react/src/components/Chip/Chips.tsx
@@ -1,7 +1,11 @@
 import { Slot, Slottable } from '@radix-ui/react-slot';
 import cl from 'clsx/lite';
 import { forwardRef } from 'react';
-import type { ButtonHTMLAttributes, InputHTMLAttributes } from 'react';
+import type {
+  ButtonHTMLAttributes,
+  InputHTMLAttributes,
+  ReactNode,
+} from 'react';
 import type { DefaultProps } from '../../types';
 import type { MergeRight } from '../../utilities';
 import { Input, type InputProps } from '../Input';
@@ -12,6 +16,10 @@ type ChipBaseProps = {
    * @default false
    */
   asChild?: boolean;
+  /**
+   * Set the text of the Chip `string`
+   */
+  children: ReactNode;
 };
 
 export type ChipRemovableProps = ChipButtonProps;

--- a/packages/react/src/components/Details/Details.tsx
+++ b/packages/react/src/components/Details/Details.tsx
@@ -35,7 +35,7 @@ export type DetailsProps = MergeRight<
     /**
      * Content should be one `<Details.Summary>` and `<Details.Content>`
      */
-    children?: ReactNode;
+    children: ReactNode;
   }
 > &
   (

--- a/packages/react/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.stories.tsx
@@ -24,6 +24,11 @@ export default {
       },
     },
   },
+  argTypes: {
+    children: {
+      control: false,
+    },
+  },
   play: async (ctx) => {
     // When not in Docs mode, automatically open the dropdown
     const button = within(ctx.canvasElement).getByRole('button');

--- a/packages/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.tsx
@@ -1,5 +1,5 @@
 import cl from 'clsx/lite';
-import { forwardRef } from 'react';
+import { type ReactNode, forwardRef } from 'react';
 
 import type { Placement } from '@floating-ui/react';
 import type { DefaultProps } from '../../types';
@@ -15,6 +15,10 @@ export type DropdownProps = MergeRight<
      * @default bottom-end
      */
     placement?: Placement;
+    /**
+     * `Dropdown.Heading` or `Dropdown.List`
+     */
+    children: ReactNode;
   }
 >;
 

--- a/packages/react/src/components/ErrorSummary/ErrorSummary.stories.tsx
+++ b/packages/react/src/components/ErrorSummary/ErrorSummary.stories.tsx
@@ -12,6 +12,11 @@ type Story = StoryFn<typeof ErrorSummary>;
 export default {
   title: 'Komponenter/ErrorSummary',
   component: ErrorSummary,
+  argTypes: {
+    children: {
+      control: false,
+    },
+  },
 } as Meta;
 
 export const Preview: Story = (args) => (

--- a/packages/react/src/components/ErrorSummary/ErrorSummary.tsx
+++ b/packages/react/src/components/ErrorSummary/ErrorSummary.tsx
@@ -1,7 +1,7 @@
 import { Slot } from '@radix-ui/react-slot';
 import cl from 'clsx/lite';
 import { createContext, forwardRef, useId, useState } from 'react';
-import type { HTMLAttributes } from 'react';
+import type { HTMLAttributes, ReactNode } from 'react';
 import type { DefaultProps } from '../../types';
 
 type ErrorSummaryContextType = {
@@ -16,6 +16,10 @@ export const ErrorSummaryContext = createContext<ErrorSummaryContextType>({
 
 export type ErrorSummaryProps = {
   asChild?: React.ReactNode;
+  /**
+   * `ErrorSummary.Heading` or `ErrorSummary.List`
+   */
+  children: ReactNode;
 } & Omit<HTMLAttributes<HTMLDivElement> & DefaultProps, 'data-color'>;
 
 /**

--- a/packages/react/src/components/Field/Field.tsx
+++ b/packages/react/src/components/Field/Field.tsx
@@ -1,6 +1,6 @@
 import { useMergeRefs } from '@floating-ui/react';
 import cl from 'clsx/lite';
-import type { HTMLAttributes } from 'react';
+import type { HTMLAttributes, ReactNode } from 'react';
 import { forwardRef, useEffect, useRef } from 'react';
 import type { DefaultProps } from '../../types';
 import { fieldObserver } from './fieldObserver';
@@ -11,6 +11,10 @@ export type FieldProps = {
    * @default start
    */
   position?: 'start' | 'end';
+  /**
+   * Any renderable element
+   */
+  children: ReactNode;
 } & HTMLAttributes<HTMLDivElement> &
   DefaultProps;
 

--- a/packages/react/src/components/Fieldset/Fieldset.stories.tsx
+++ b/packages/react/src/components/Fieldset/Fieldset.stories.tsx
@@ -7,6 +7,11 @@ type Story = StoryFn<typeof Fieldset>;
 export default {
   title: 'Komponenter/Fieldset',
   component: Fieldset,
+  argTypes: {
+    children: {
+      control: false,
+    },
+  },
 } as Meta;
 
 export const Preview: Story = (args) => (

--- a/packages/react/src/components/Fieldset/Fieldset.tsx
+++ b/packages/react/src/components/Fieldset/Fieldset.tsx
@@ -1,10 +1,15 @@
 import cl from 'clsx/lite';
-import type { FieldsetHTMLAttributes } from 'react';
+import type { FieldsetHTMLAttributes, ReactNode } from 'react';
 import { forwardRef } from 'react';
 
 import type { DefaultProps } from '../../types';
 
-export type FieldsetProps = DefaultProps &
+export type FieldsetProps = {
+  /**
+   * `Fieldset.Legend`, `Fieldset.Description` or `Field`
+   */
+  children: ReactNode;
+} & DefaultProps &
   FieldsetHTMLAttributes<HTMLFieldSetElement>;
 
 /**

--- a/packages/react/src/components/Heading/Heading.tsx
+++ b/packages/react/src/components/Heading/Heading.tsx
@@ -19,6 +19,7 @@ export type HeadingProps = {
    * @default false
    */
   asChild?: boolean;
+  children: string;
 } & HTMLAttributes<HTMLHeadingElement>;
 
 /**


### PR DESCRIPTION
Trying to solve #2760 
🚸 Added children and their correct types to components. 🚸 
Storybook seems to detect their type pretty decently. 📖 
It does struggle a bit with their control, its picked up from the stories default. 
Added argyTypes to the places where we want to control it. 

Some components did not have documentation on acceptable children (Like button)
When any ReactNode is available, we should document it. If its not part of the props table I would assume it does not support any children.
Not what is available, but what is supported. As we use ReactNode (by default?) this can be quite different.
Tried to set the known / supported elements in the description of children.
I could not find a good way to set a limited selection of ReactNode or a specific custom Element, but HTMDivElement works so there is probably a way to set a limit type selection.
(>.> Typescript and me don't always agree).

Did not manage to finish all components, a bit of work to set it up on all components with children.

Note:
- PropsWithChildren is something we can look into instead of adding it everywhere (typescript)
- I don't see how fixing the filter can solve this. Its quite complex to figure out if a component has children and what types should be supported if so. Not to talk about the control that needs to be added to the story for those then.