### PR TITLE
chore: fix metadata for newest blog article

### DIFF
--- a/apps/storefront/app/bloggen/2025/generering-av-fargar-i-fargesystemet/page.mdx
+++ b/apps/storefront/app/bloggen/2025/generering-av-fargar-i-fargesystemet/page.mdx
@@ -17,9 +17,9 @@ export default ({ children }) => (
 export const metadata = {
   title: 'Generering av fargar i fargesystemet',
   description:
-    'desc',
+    'Dette innlegget tek deg med på reisa me gjekk gjennom for å utvikle vår eigen tilnærming til fargegenerering, og korleis dette systemet fungerer i dag.',
   openGraph: {
-    images: '/img/bloggen/helptext.png',
+    images: '/img/bloggen/fargepallet.png',
   },
 };
 


### PR DESCRIPTION
fix this:
![image](https://github.com/user-attachments/assets/eacdfc54-0f04-4cc4-9a11-bf078a3177f6)
