### PR TITLE
fix(Dialog): non-modal and support position in display: flex

### DIFF
--- a/.changeset/gorgeous-lizards-begin.md
+++ b/.changeset/gorgeous-lizards-begin.md
@@ -1,0 +1,7 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**Dialog**:
+- Correctly centers position also when placed in `display: flex`
+- Only prevents scroll if opened with `.showModal()`

--- a/packages/css/src/dialog.css
+++ b/packages/css/src/dialog.css
@@ -18,7 +18,7 @@
   --_dsc-dialog-icon-top-right-margin: calc(var(--dsc-dialog-spacing) * -1 + var(--dsc-dialog-icon-spacing));
 
   /* Center with top+left+translate to support placement inside display: flex */
-  animation: _fadein .2s forwards;
+  animation: fade-in .2s forwards;
   background: var(--dsc-dialog-background);
   border-color: var(--dsc-dialog-border-color);
   border-radius: var(--ds-border-radius-lg);

--- a/packages/css/src/dialog.css
+++ b/packages/css/src/dialog.css
@@ -17,17 +17,26 @@
   /* Internal */
   --_dsc-dialog-icon-top-right-margin: calc(var(--dsc-dialog-spacing) * -1 + var(--dsc-dialog-icon-spacing));
 
+  /* Center with top+left+translate to support placement inside display: flex */
+  animation: _fadein .2s forwards;
   background: var(--dsc-dialog-background);
-  border-radius: var(--ds-border-radius-lg);
-  border-width: var(--dsc-dialog-border-width);
-  border-style: var(--dsc-dialog-border-style);
   border-color: var(--dsc-dialog-border-color);
+  border-radius: var(--ds-border-radius-lg);
+  border-style: var(--dsc-dialog-border-style);
+  border-width: var(--dsc-dialog-border-width);
+  bottom: auto;
   box-shadow: var(--ds-shadow-xl);
   box-sizing: border-box;
   color: var(--dsc-dialog-color);
+  left: 50%;
+  margin: 0;
   max-height: var(--dsc-dialog-max-height);
   max-width: var(--dsc-dialog-max-width);
   padding: var(--dsc-dialog-spacing);
+  position: fixed;
+  right: auto;
+  top: 50%;
+  translate: -50% -50%;
   width: 100%;
 
   &::backdrop {
@@ -91,13 +100,13 @@
 }
 
 /* Prevent scroll when open */
-body:has(.ds-dialog[open]) {
+body:has(.ds-dialog:modal) {
   overflow: hidden;
 }
 
 @keyframes slide-in {
   from {
-    translate: 0 50px;
+    translate: -50% calc(-50% + 3rem);
   }
 }
 


### PR DESCRIPTION
- Only add `overflow: hidden` to `<body>` if opened by `.showModal()` (not when non-modal `.show()`)
- Use `top: 50%; left: 50%; transform: -50% -50%` for positioning instead of `margin: auto; inset: 0` as the latter does not center `<dialog>` if placed inside a `display: flex`