### PR TITLE
fix(Dialog): add missing overflow: auto

### DIFF
--- a/.changeset/serious-readers-marry.md
+++ b/.changeset/serious-readers-marry.md
@@ -1,0 +1,7 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+Dialog:
+- Add missing `overflow: auto`
+- Position with `transform` for easier `translate` animation

--- a/packages/css/src/dialog.css
+++ b/packages/css/src/dialog.css
@@ -37,7 +37,7 @@
   position: fixed;
   right: auto;
   top: 50%;
-  translate: -50% -50%;
+  transform: translate(-50%, -50%);
   width: 100%;
 
   &::backdrop {
@@ -107,7 +107,7 @@ body:has(.ds-dialog:modal) {
 
 @keyframes slide-in {
   from {
-    translate: -50% calc(-50% + 3rem);
+    translate: 0 3rem;
   }
 }
 

--- a/packages/css/src/dialog.css
+++ b/packages/css/src/dialog.css
@@ -32,6 +32,7 @@
   margin: 0;
   max-height: var(--dsc-dialog-max-height);
   max-width: var(--dsc-dialog-max-width);
+  overflow: auto;
   padding: var(--dsc-dialog-spacing);
   position: fixed;
   right: auto;


### PR DESCRIPTION
- Add missing `overflow: auto`
- Position with `transform` so animation with `translate` is easier