### PR TITLE
fix(Badge): allow empty badge

### DIFF
--- a/.changeset/fluffy-pears-pull.md
+++ b/.changeset/fluffy-pears-pull.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**Badge**: Fix empty badge not being displayed

--- a/packages/css/src/badge.css
+++ b/packages/css/src/badge.css
@@ -5,7 +5,7 @@
   --dsc-badge-size: calc(var(--ds-size-3) + calc(var(--ds-size-1) / 2));
 
   &::before {
-    content: attr(data-count);
+    content: attr(data-count, '');
     background: var(--dsc-badge-background);
     border-radius: var(--ds-border-radius-full);
     box-sizing: border-box;

--- a/packages/css/src/badge.css
+++ b/packages/css/src/badge.css
@@ -5,7 +5,7 @@
   --dsc-badge-size: calc(var(--ds-size-3) + calc(var(--ds-size-1) / 2));
 
   &::before {
-    content: attr(data-count, '');
+    content: attr(data-count);
     background: var(--dsc-badge-background);
     border-radius: var(--ds-border-radius-full);
     box-sizing: border-box;
@@ -19,6 +19,10 @@
     box-sizing: border-box;
     line-height: var(--ds-line-height-sm);
     width: fit-content;
+
+    @supports (content: attr(data-count, '')) {
+      content: attr(data-count, '');
+    }
   }
 
   &[data-variant='base'] {


### PR DESCRIPTION
fixes an empty badge not being displayed:
![image](https://github.com/user-attachments/assets/75a3b37c-dc36-44f1-8ec4-112086d99baa)
