### PR TITLE
fix(theme): should pick correct color for cli snippet

### DIFF
--- a/apps/theme/components/TokenModal/TokenModal.tsx
+++ b/apps/theme/components/TokenModal/TokenModal.tsx
@@ -28,8 +28,11 @@ export const TokenModal = () => {
 
   const setCliColors = (colorTheme: ColorTheme[]) => {
     let str = '';
-    for (const color of colorTheme) {
-      str += `"${color.name}:${color.colors.light[8].hex}" `;
+    for (const theme of colorTheme) {
+      const baseColor = theme.colors.light.find(
+        (color) => color.name === 'baseDefault',
+      );
+      str += `"${theme.name}:${baseColor?.hex}" `;
     }
     return str;
   };
@@ -37,7 +40,7 @@ export const TokenModal = () => {
   const cliSnippet = [
     `npx @digdir/designsystemet@next tokens create`,
     `--${colorCliOptions.main} ${setCliColors(colors.main).trimEnd()}`,
-    `--${colorCliOptions.neutral} "${colors.neutral[0]?.colors.light[8].hex}"`,
+    `--${colorCliOptions.neutral} "${colors.neutral[0]?.colors.light[11].hex}"`,
     `${colors.support.length > 0 ? `--${colorCliOptions.support} ${setCliColors(colors.support).trimEnd()}` : ''}`,
     `--border-radius ${baseBorderRadius}`,
     `--theme "${themeName}"`,


### PR DESCRIPTION
fixes wrong hex color being picked for cli snippet

before:
<img width="1457" alt="image" src="https://github.com/user-attachments/assets/d03ed10d-22ac-4e78-b9ea-86c6738fb2e8" />


after:
<img width="1498" alt="image" src="https://github.com/user-attachments/assets/6ccff26f-a4a6-4150-8f5b-d1e1d6ecefa3" />
