### PR TITLE
refactor(color): :label: better type safety using colors in code

### DIFF
--- a/apps/_components/src/ColorModal/ColorModal.tsx
+++ b/apps/_components/src/ColorModal/ColorModal.tsx
@@ -1,10 +1,6 @@
 import { Dialog, Heading, Paragraph } from '@digdir/designsystemet-react';
-import type { ColorNumber, HexColor } from '@digdir/designsystemet/color';
-import {
-  getColorByNumber,
-  getCssVariable,
-  hexToHsluv,
-} from '@digdir/designsystemet/color';
+import type { Color } from '@digdir/designsystemet/color';
+import { getCssVariable, hexToHsluv } from '@digdir/designsystemet/color';
 import { ClipboardButton } from '@repo/components';
 
 import classes from './ColorModal.module.css';
@@ -36,18 +32,16 @@ const Field = ({
 
 type ColorModalProps = {
   colorModalRef: React.Ref<HTMLDialogElement> | null;
-  hex: HexColor;
   namespace: string;
-  number: ColorNumber;
+  color: Color;
 };
 
 export const ColorModal = ({
   colorModalRef,
-  hex,
   namespace,
-  number,
+  color,
 }: ColorModalProps) => {
-  const color = getColorByNumber(number);
+  const { displayName, description, number, hex } = color;
   return (
     <Dialog
       ref={colorModalRef}
@@ -58,11 +52,11 @@ export const ColorModal = ({
     >
       <Dialog.Block>
         <Heading data-size='xs'>
-          {`${capitalizeFirstLetter(namespace)} ${capitalizeFirstLetter(color.displayName)}`}
+          {`${capitalizeFirstLetter(namespace)} ${displayName}`}
         </Heading>
       </Dialog.Block>
       <Dialog.Block className={classes.modalContent}>
-        <div className={classes.description}>{color.description}</div>
+        <div className={classes.description}>{description}</div>
         <div className={classes.container}>
           <table className={classes.infoTable}>
             <tbody>

--- a/apps/_components/src/ColorModal/ColorModal.tsx
+++ b/apps/_components/src/ColorModal/ColorModal.tsx
@@ -1,8 +1,7 @@
 import { Dialog, Heading, Paragraph } from '@digdir/designsystemet-react';
 import type { ColorNumber, HexColor } from '@digdir/designsystemet/color';
 import {
-  colorMetadata,
-  getColorInfoFromPosition,
+  getColorByNumber,
   getCssVariable,
   hexToHsluv,
 } from '@digdir/designsystemet/color';
@@ -48,6 +47,7 @@ export const ColorModal = ({
   namespace,
   number,
 }: ColorModalProps) => {
+  const color = getColorByNumber(number);
   return (
     <Dialog
       ref={colorModalRef}
@@ -58,13 +58,11 @@ export const ColorModal = ({
     >
       <Dialog.Block>
         <Heading data-size='xs'>
-          {`${capitalizeFirstLetter(namespace)} ${capitalizeFirstLetter(getColorInfoFromPosition(number).displayName)}`}
+          {`${capitalizeFirstLetter(namespace)} ${capitalizeFirstLetter(color.displayName)}`}
         </Heading>
       </Dialog.Block>
       <Dialog.Block className={classes.modalContent}>
-        <div className={classes.description}>
-          {colorMetadata[number].description}
-        </div>
+        <div className={classes.description}>{color.description}</div>
         <div className={classes.container}>
           <table className={classes.infoTable}>
             <tbody>

--- a/apps/storefront/components/Tokens/TokenColor/TokenColor.module.css
+++ b/apps/storefront/components/Tokens/TokenColor/TokenColor.module.css
@@ -18,7 +18,7 @@
   outline-offset: 2px;
 }
 
-.test {
+.colorBox {
   --color: #cfcfcf;
 
   background-color: #e5e5f7;

--- a/apps/storefront/components/Tokens/TokenColor/TokenColor.tsx
+++ b/apps/storefront/components/Tokens/TokenColor/TokenColor.tsx
@@ -1,4 +1,4 @@
-import { getColorInfoFromPosition } from '@digdir/designsystemet/color';
+import { getColorByNumber } from '@digdir/designsystemet/color';
 import { ColorModal } from '@repo/components';
 import cl from 'clsx/lite';
 import { useRef } from 'react';
@@ -44,7 +44,7 @@ const TokenColor = ({ value, token }: TokenColorProps) => {
           onClick={() => number && colorModalRef.current?.showModal()}
           aria-label={
             number &&
-            `Se mer om ${token.path[1]} ${getColorInfoFromPosition(number).displayName}`
+            `Se mer om ${token.path[1]} ${getColorByNumber(number).displayName}`
           }
         ></Element>
       </div>

--- a/apps/storefront/components/Tokens/TokenColor/TokenColor.tsx
+++ b/apps/storefront/components/Tokens/TokenColor/TokenColor.tsx
@@ -1,10 +1,14 @@
-import { getColorByNumber } from '@digdir/designsystemet/color';
+import { getColorMetadataByNumber } from '@digdir/designsystemet/color';
 import { ColorModal } from '@repo/components';
 import cl from 'clsx/lite';
 import { useRef } from 'react';
 import type { TransformedToken } from 'style-dictionary';
 
-import type { ColorNumber, HexColor } from '@digdir/designsystemet/color';
+import type {
+  Color,
+  ColorNumber,
+  HexColor,
+} from '@digdir/designsystemet/color';
 
 import classes from './TokenColor.module.css';
 interface TokenColorProps {
@@ -14,9 +18,8 @@ interface TokenColorProps {
 
 /* The original.value is something like "{global.yellow.1}", and we need to get the weight between the last . and } */
 export function getColorNumber(value: string): ColorNumber | undefined {
-  const firstSplit = value.split('.').pop()?.replace('}', '');
-
-  const parsed = parseInt(firstSplit as string);
+  const digit = value.match(/^\d+$/)?.[0];
+  const parsed = parseInt(digit || '');
 
   return Number.isNaN(parsed) ? undefined : (parsed as ColorNumber);
 }
@@ -25,30 +28,39 @@ const TokenColor = ({ value, token }: TokenColorProps) => {
   const colorModalRef = useRef<HTMLDialogElement>(null);
 
   const number = getColorNumber(token.original.$value as string);
-  const Element = number ? 'button' : 'div';
+  const color: Color | undefined = number
+    ? {
+        ...getColorMetadataByNumber(number),
+        number,
+        hex: value,
+      }
+    : undefined;
 
-  return (
+  const namespace = token.path[1];
+
+  return color ? (
     <>
-      {number ? (
-        <ColorModal
-          number={number}
-          hex={value}
-          namespace={token.path[1]}
-          colorModalRef={colorModalRef}
-        />
-      ) : null}
-      <div className={classes.test}>
-        <Element
+      <ColorModal
+        namespace={namespace}
+        colorModalRef={colorModalRef}
+        color={color}
+      />
+      <div className={classes.colorBox}>
+        <button
           style={{ backgroundColor: value }}
           className={cl(classes.color, 'ds-focus')}
-          onClick={() => number && colorModalRef.current?.showModal()}
-          aria-label={
-            number &&
-            `Se mer om ${token.path[1]} ${getColorByNumber(number).displayName}`
-          }
-        ></Element>
+          onClick={() => colorModalRef.current?.showModal()}
+          aria-label={`Se mer om ${namespace} ${color?.displayName}`}
+        ></button>
       </div>
     </>
+  ) : (
+    <div className={classes.colorBox}>
+      <div
+        style={{ backgroundColor: value }}
+        className={cl(classes.color, 'ds-focus')}
+      ></div>
+    </div>
   );
 };
 

--- a/apps/theme/app/page.tsx
+++ b/apps/theme/app/page.tsx
@@ -56,8 +56,7 @@ export default function Home() {
   return (
     <div>
       <ColorModal
-        number={selectedColor.color.number}
-        hex={selectedColor.color.hex}
+        color={selectedColor.color}
         namespace={'d'}
         colorModalRef={colorModalRef}
       />

--- a/apps/theme/app/testside/BackgroundSurface/BackgroundSurface.tsx
+++ b/apps/theme/app/testside/BackgroundSurface/BackgroundSurface.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Heading } from '@digdir/designsystemet-react';
-import type { ColorInfo, ThemeInfo } from '@digdir/designsystemet/color';
+import type { Color, ThemeInfo } from '@digdir/designsystemet/color';
 
 import classes from './BackgroundSurface.module.css';
 
@@ -75,7 +75,7 @@ export const BackgroundSurface = ({
 
 type ColumnProps = {
   title: string;
-  scales: ColorInfo[][];
+  scales: Color[][];
 };
 
 const Column = ({ title, scales }: ColumnProps) => {
@@ -94,9 +94,9 @@ const Column = ({ title, scales }: ColumnProps) => {
 };
 
 type BoxProps = {
-  colorScale: ColorInfo[];
+  colorScale: Color[];
   backgroundIndex: 0 | 1;
-  scales: ColorInfo[][];
+  scales: Color[][];
 };
 
 const Box = ({ colorScale, backgroundIndex, scales }: BoxProps) => {

--- a/apps/theme/app/testside/BaseContrast/BaseContrast.tsx
+++ b/apps/theme/app/testside/BaseContrast/BaseContrast.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { Heading } from '@digdir/designsystemet-react';
-import type { ColorInfo, ThemeInfo } from '@digdir/designsystemet/color';
+import type { Color, ThemeInfo } from '@digdir/designsystemet/color';
 
 import { ContrastBox } from '../ContrastBox/ContrastBox';
 
@@ -44,7 +44,7 @@ const BaseColumn = ({ colorTheme, title }: BaseColumnProps) => {
 };
 
 type BaseBoxProps = {
-  colorScale: ColorInfo[];
+  colorScale: Color[];
   title: string;
 };
 

--- a/apps/theme/app/testside/Interaction/Interaction.tsx
+++ b/apps/theme/app/testside/Interaction/Interaction.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { Heading } from '@digdir/designsystemet-react';
-import type { ColorInfo, ThemeInfo } from '@digdir/designsystemet/color';
+import type { Color, ThemeInfo } from '@digdir/designsystemet/color';
 import cl from 'clsx/lite';
 import { useEffect } from 'react';
 
@@ -96,7 +96,7 @@ export const Interaction = ({
 
 type ColumnProps = {
   title: string;
-  scales: ColorInfo[][];
+  scales: Color[][];
 };
 
 const Column = ({ title, scales }: ColumnProps) => {
@@ -128,7 +128,7 @@ const Column = ({ title, scales }: ColumnProps) => {
 
 type BoxProps = {
   colorIndex: number;
-  scales: ColorInfo[][];
+  scales: Color[][];
   type: 'base' | 'surface';
   columnTitle: string;
 };

--- a/apps/theme/app/testside/page.tsx
+++ b/apps/theme/app/testside/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Heading } from '@digdir/designsystemet-react';
-import type { ColorInfo, CssColor } from '@digdir/designsystemet/color';
+import type { Color, CssColor } from '@digdir/designsystemet/color';
 import { generateColorSchemes } from '@digdir/designsystemet/color';
 import { Container } from '@repo/components';
 import cl from 'clsx/lite';
@@ -28,7 +28,7 @@ const Box = (name: string, color1: CssColor, color2: CssColor) => {
   );
 };
 
-const Row = (title: string, colors: ColorInfo[], whiteText = false) => {
+const Row = (title: string, colors: Color[], whiteText = false) => {
   return (
     <div className={cl(whiteText && classes.whiteText)}>
       <Heading data-size='xs' className={classes.mainTitle}>

--- a/apps/theme/app/themebuilder/_components/ThemePages.tsx
+++ b/apps/theme/app/themebuilder/_components/ThemePages.tsx
@@ -3,7 +3,7 @@
 import {
   type Color,
   type ColorNumber,
-  getColorByNumber,
+  getColorMetadataByNumber,
 } from '@digdir/designsystemet';
 import cl from 'clsx/lite';
 import { useEffect, useRef } from 'react';
@@ -59,7 +59,7 @@ export const ThemePages = () => {
     for (let i = 0; i < lightColors.length; i++) {
       const number = (i + 1) as ColorNumber;
       style[
-        `--ds-color-neutral-${getColorByNumber(number)
+        `--ds-color-neutral-${getColorMetadataByNumber(number)
           .displayName.replace(/\s+/g, '-')
           .toLowerCase()}`
       ] = lightColors[i].hex;
@@ -83,7 +83,7 @@ export const ThemePages = () => {
     for (let i = 0; i < lightColors.length; i++) {
       const number = (i + 1) as ColorNumber;
       style[
-        `--ds-color-${getColorByNumber(number)
+        `--ds-color-${getColorMetadataByNumber(number)
           .displayName.replace(/\s+/g, '-')
           .toLowerCase()}`
       ] = lightColors[i].hex;

--- a/apps/theme/app/themebuilder/_components/ThemePages.tsx
+++ b/apps/theme/app/themebuilder/_components/ThemePages.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import {
-  type ColorInfo,
+  type Color,
   type ColorNumber,
-  getColorInfoFromPosition,
+  getColorByNumber,
 } from '@digdir/designsystemet';
 import cl from 'clsx/lite';
 import { useEffect, useRef } from 'react';
@@ -45,8 +45,8 @@ export const ThemePages = () => {
   }, [baseBorderRadius]);
 
   const getDsVars = (colors: {
-    light: ColorInfo[];
-    dark: ColorInfo[];
+    light: Color[];
+    dark: Color[];
   }) => {
     const style = {} as Record<string, string>;
 
@@ -59,7 +59,7 @@ export const ThemePages = () => {
     for (let i = 0; i < lightColors.length; i++) {
       const number = (i + 1) as ColorNumber;
       style[
-        `--ds-color-neutral-${getColorInfoFromPosition(number)
+        `--ds-color-neutral-${getColorByNumber(number)
           .displayName.replace(/\s+/g, '-')
           .toLowerCase()}`
       ] = lightColors[i].hex;
@@ -69,8 +69,8 @@ export const ThemePages = () => {
   };
 
   const getDsMainVars = (colors: {
-    light: ColorInfo[];
-    dark: ColorInfo[];
+    light: Color[];
+    dark: Color[];
   }) => {
     const style = {} as Record<string, string>;
 
@@ -83,7 +83,7 @@ export const ThemePages = () => {
     for (let i = 0; i < lightColors.length; i++) {
       const number = (i + 1) as ColorNumber;
       style[
-        `--ds-color-${getColorInfoFromPosition(number)
+        `--ds-color-${getColorByNumber(number)
           .displayName.replace(/\s+/g, '-')
           .toLowerCase()}`
       ] = lightColors[i].hex;

--- a/apps/theme/components/ColorContrasts/ColorContrasts.tsx
+++ b/apps/theme/components/ColorContrasts/ColorContrasts.tsx
@@ -1,7 +1,7 @@
 import {
-  type ColorInfo,
+  type Color,
   generateColorSchemes,
-  getColorInfoFromPosition,
+  getColorByNumber,
   getContrastFromHex,
 } from '@digdir/designsystemet';
 import {
@@ -79,21 +79,18 @@ export const ColorContrasts = () => {
     });
   }, [selectedBaseColor, colors, colorScheme]);
 
-  const ThCell = ({ color }: { color: ColorInfo }) => {
+  const ThCell = ({ color }: { color: Color }) => {
     return (
       <th className={classes.th}>
         <div className={classes.header}>
-          {getColorInfoFromPosition(color.number).displayName}
+          {getColorByNumber(color.number).displayName}
           <div className={classes.headerHex}>{color.hex}</div>
         </div>
       </th>
     );
   };
 
-  const Tag = ({
-    color1,
-    color2,
-  }: { color1: ColorInfo; color2: ColorInfo }) => {
+  const Tag = ({ color1, color2 }: { color1: Color; color2: Color }) => {
     const contrast = getContrastFromHex(color1.hex, color2.hex);
     let type = 'AAA';
 
@@ -108,10 +105,7 @@ export const ColorContrasts = () => {
     return <div className={cl(classes.tag, classes[type])}>{type}</div>;
   };
 
-  const TdCell = ({
-    color1,
-    color2,
-  }: { color1: ColorInfo; color2: ColorInfo }) => {
+  const TdCell = ({ color1, color2 }: { color1: Color; color2: Color }) => {
     return (
       <div className={classes.cell}>
         <div className={classes.colors}>

--- a/apps/theme/components/ColorContrasts/ColorContrasts.tsx
+++ b/apps/theme/components/ColorContrasts/ColorContrasts.tsx
@@ -1,7 +1,7 @@
 import {
   type Color,
   generateColorSchemes,
-  getColorByNumber,
+  getColorMetadataByNumber,
   getContrastFromHex,
 } from '@digdir/designsystemet';
 import {
@@ -83,7 +83,7 @@ export const ColorContrasts = () => {
     return (
       <th className={classes.th}>
         <div className={classes.header}>
-          {getColorByNumber(color.number).displayName}
+          {getColorMetadataByNumber(color.number).displayName}
           <div className={classes.headerHex}>{color.hex}</div>
         </div>
       </th>

--- a/apps/theme/components/ColorPreview/ColorPreview.tsx
+++ b/apps/theme/components/ColorPreview/ColorPreview.tsx
@@ -1,7 +1,7 @@
 import {
-  type ColorInfo,
+  type Color,
   type ColorNumber,
-  getColorInfoFromPosition,
+  getColorByNumber,
 } from '@digdir/designsystemet';
 import {
   Button,
@@ -28,15 +28,15 @@ export const ColorPreview = () => {
     color: {
       name: string;
       colors: {
-        light: ColorInfo[];
-        dark: ColorInfo[];
+        light: Color[];
+        dark: Color[];
       };
     };
   };
 
   const setStyle = (colors: {
-    light: ColorInfo[];
-    dark: ColorInfo[];
+    light: Color[];
+    dark: Color[];
   }) => {
     const style = {} as Record<string, string>;
 
@@ -49,12 +49,12 @@ export const ColorPreview = () => {
     for (let i = 0; i < lightColors.length; i++) {
       const number = (i + 1) as ColorNumber;
       style[
-        `--ds-color-accent-${getColorInfoFromPosition(number)
+        `--ds-color-accent-${getColorByNumber(number)
           .displayName.replace(/\s+/g, '-')
           .toLowerCase()}`
       ] = lightColors[i].hex;
       style[
-        `--ds-color-${getColorInfoFromPosition(number)
+        `--ds-color-${getColorByNumber(number)
           .displayName.replace(/\s+/g, '-')
           .toLowerCase()}`
       ] = lightColors[i].hex;

--- a/apps/theme/components/ColorPreview/ColorPreview.tsx
+++ b/apps/theme/components/ColorPreview/ColorPreview.tsx
@@ -1,7 +1,7 @@
 import {
   type Color,
   type ColorNumber,
-  getColorByNumber,
+  getColorMetadataByNumber,
 } from '@digdir/designsystemet';
 import {
   Button,
@@ -49,12 +49,12 @@ export const ColorPreview = () => {
     for (let i = 0; i < lightColors.length; i++) {
       const number = (i + 1) as ColorNumber;
       style[
-        `--ds-color-accent-${getColorByNumber(number)
+        `--ds-color-accent-${getColorMetadataByNumber(number)
           .displayName.replace(/\s+/g, '-')
           .toLowerCase()}`
       ] = lightColors[i].hex;
       style[
-        `--ds-color-${getColorByNumber(number)
+        `--ds-color-${getColorMetadataByNumber(number)
           .displayName.replace(/\s+/g, '-')
           .toLowerCase()}`
       ] = lightColors[i].hex;

--- a/apps/theme/components/ContrastChart/ContrastChart.tsx
+++ b/apps/theme/components/ContrastChart/ContrastChart.tsx
@@ -1,7 +1,6 @@
 import {
-  type ColorInfo,
+  type Color,
   generateColorSchemes,
-  getColorInfoFromPosition,
   getContrastFromHex,
 } from '@digdir/designsystemet';
 
@@ -22,10 +21,7 @@ export const ContrastChart = ({ type = 'light' }: ContrastChartProps) => {
     includedColorIndexes.includes(color.number),
   );
 
-  const Tag = ({
-    color1,
-    color2,
-  }: { color1: ColorInfo; color2: ColorInfo }) => {
+  const Tag = ({ color1, color2 }: { color1: Color; color2: Color }) => {
     const contrast = getContrastFromHex(color1.hex, color2.hex);
     let type = 'AAA';
 
@@ -40,10 +36,7 @@ export const ContrastChart = ({ type = 'light' }: ContrastChartProps) => {
     return <div className={cl(classes.tag, classes[type])}>{type}</div>;
   };
 
-  const TdCell = ({
-    color1,
-    color2,
-  }: { color1: ColorInfo; color2: ColorInfo }) => {
+  const TdCell = ({ color1, color2 }: { color1: Color; color2: Color }) => {
     return (
       <div className={classes.cell}>
         <div className={classes.colors}>
@@ -67,11 +60,11 @@ export const ContrastChart = ({ type = 'light' }: ContrastChartProps) => {
     );
   };
 
-  const ThCell = ({ color }: { color: ColorInfo }) => {
+  const ThCell = ({ color }: { color: Color }) => {
     return (
       <th className={classes.th}>
         <div className={classes.header}>
-          {getColorInfoFromPosition(color.number).displayName}
+          {color.displayName}
           <div className={classes.headerHex}>{color.hex}</div>
         </div>
       </th>
@@ -82,12 +75,12 @@ export const ContrastChart = ({ type = 'light' }: ContrastChartProps) => {
   const themeColors = type === 'light' ? theme.light : theme.dark;
 
   return (
-    <div data-ds-color-mode={type} className={classes.contrastChart}>
+    <div data-color-scheme={type} className={classes.contrastChart}>
       <table className={classes.table}>
         <tr>
           <th />
           {reducedColors.map((color, index) => (
-            <ThCell key={index} color={reducedColors[index]} />
+            <ThCell key={index} color={color} />
           ))}
         </tr>
 

--- a/apps/theme/components/Group/Group.tsx
+++ b/apps/theme/components/Group/Group.tsx
@@ -16,7 +16,7 @@ import classes from './Group.module.css';
 
 type GroupProps = {
   header: string;
-  colors: ColorNumber[];
+  colorNumbers: ColorNumber[];
   colorScale: ThemeInfo;
   showColorMeta?: boolean;
   names?: string[];
@@ -25,7 +25,7 @@ type GroupProps = {
 
 export const Group = ({
   header,
-  colors,
+  colorNumbers,
   showColorMeta,
   names,
   colorScale,
@@ -36,8 +36,8 @@ export const Group = ({
   const colorModalRefs = useRef<React.RefObject<HTMLDialogElement | null>[]>(
     [],
   );
-  if (colorModalRefs.current.length !== colors.length) {
-    colorModalRefs.current = Array(colors.length)
+  if (colorModalRefs.current.length !== colorNumbers.length) {
+    colorModalRefs.current = Array(colorNumbers.length)
       .fill(null)
       .map(() => createRef<HTMLDialogElement>());
   }
@@ -54,8 +54,8 @@ export const Group = ({
       )}
 
       <div className={cl(classes.colors)}>
-        {colors.map((item, index) => {
-          const { number, hex } = colorScale[colorScheme][item];
+        {colorNumbers.map((colorNumber, index) => {
+          const { number, hex } = colorScale[colorScheme][colorNumber - 1];
           const color: Color = {
             ...getColorMetadataByNumber(number),
             number,
@@ -71,7 +71,7 @@ export const Group = ({
               <RovingFocusItem value={namespace + number} asChild>
                 <ColorPreview
                   color={hex}
-                  colorNumber={item}
+                  colorNumber={colorNumber}
                   contrast={'dd'}
                   lightness={'dd'}
                   showColorMeta={showColorMeta}

--- a/apps/theme/components/Group/Group.tsx
+++ b/apps/theme/components/Group/Group.tsx
@@ -1,8 +1,13 @@
 import { RovingFocusItem } from '@digdir/designsystemet-react';
-import type { ThemeInfo } from '@digdir/designsystemet/color';
+import {
+  type Color,
+  type ColorNumber,
+  type ThemeInfo,
+  getColorMetadataByNumber,
+} from '@digdir/designsystemet/color';
 import cl from 'clsx/lite';
 
-import { Color } from '../Color/Color';
+import { Color as ColorPreview } from '../Color/Color';
 
 import { ColorModal } from '@repo/components';
 import { Fragment, createRef, useRef } from 'react';
@@ -11,7 +16,7 @@ import classes from './Group.module.css';
 
 type GroupProps = {
   header: string;
-  colors: number[];
+  colors: ColorNumber[];
   colorScale: ThemeInfo;
   showColorMeta?: boolean;
   names?: string[];
@@ -50,20 +55,22 @@ export const Group = ({
 
       <div className={cl(classes.colors)}>
         {colors.map((item, index) => {
+          const { number, hex } = colorScale[colorScheme][item];
+          const color: Color = {
+            ...getColorMetadataByNumber(number),
+            number,
+            hex,
+          };
           return (
             <Fragment key={index + 'fragment' + namespace}>
               <ColorModal
                 colorModalRef={colorModalRefs.current[index]}
-                hex={colorScale[colorScheme][item].hex}
                 namespace={namespace}
-                number={colorScale[colorScheme][item].number}
+                color={color}
               />
-              <RovingFocusItem
-                value={namespace + colorScale[colorScheme][item].number}
-                asChild
-              >
-                <Color
-                  color={colorScale[colorScheme][item].hex}
+              <RovingFocusItem value={namespace + number} asChild>
+                <ColorPreview
+                  color={hex}
                   colorNumber={item}
                   contrast={'dd'}
                   lightness={'dd'}

--- a/apps/theme/components/Previews/Previews.tsx
+++ b/apps/theme/components/Previews/Previews.tsx
@@ -7,7 +7,7 @@ import {
   type ColorScheme,
   type CssColor,
   generateColorSchemes,
-  getColorByNumber,
+  getColorMetadataByNumber,
 } from '@digdir/designsystemet';
 import { ToggleGroup } from '@digdir/designsystemet-react';
 import { OverviewComponents } from '../OverviewComponents/OverviewComponents';
@@ -66,7 +66,7 @@ export const Previews = () => {
     for (let i = 0; i < lightColors.length; i++) {
       const number = (i + 1) as ColorNumber;
       style[
-        `--ds-color-${getColorByNumber(number)
+        `--ds-color-${getColorMetadataByNumber(number)
           .displayName.replace(/\s+/g, '-')
           .toLowerCase()}`
       ] = lightColors[i].hex;

--- a/apps/theme/components/Previews/Previews.tsx
+++ b/apps/theme/components/Previews/Previews.tsx
@@ -2,12 +2,12 @@
 import { useState } from 'react';
 
 import {
-  type ColorInfo,
+  type Color,
   type ColorNumber,
   type ColorScheme,
   type CssColor,
   generateColorSchemes,
-  getColorInfoFromPosition,
+  getColorByNumber,
 } from '@digdir/designsystemet';
 import { ToggleGroup } from '@digdir/designsystemet-react';
 import { OverviewComponents } from '../OverviewComponents/OverviewComponents';
@@ -52,8 +52,8 @@ export const Previews = () => {
   const [colorScheme, setColorScheme] = useState<ColorScheme>('light');
 
   const getDsMainVars = (colors: {
-    light: ColorInfo[];
-    dark: ColorInfo[];
+    light: Color[];
+    dark: Color[];
   }) => {
     const style = {} as Record<string, string>;
 
@@ -66,7 +66,7 @@ export const Previews = () => {
     for (let i = 0; i < lightColors.length; i++) {
       const number = (i + 1) as ColorNumber;
       style[
-        `--ds-color-${getColorInfoFromPosition(number)
+        `--ds-color-${getColorByNumber(number)
           .displayName.replace(/\s+/g, '-')
           .toLowerCase()}`
       ] = lightColors[i].hex;

--- a/apps/theme/components/Scale/Scale.tsx
+++ b/apps/theme/components/Scale/Scale.tsx
@@ -18,12 +18,13 @@ export const Scale = ({
   namespace,
 }: ScaleProps) => {
   return (
+    // TODO: Use colorMetadata instead of hardcoding the names and color numbers
     <div className={classes.themes}>
       <RovingFocusRoot activeValue={namespace + '1'} asChild>
         <div className={classes.test}>
           <Group
             header={showHeader ? 'Background' : ''}
-            colors={[0, 1]}
+            colors={[1, 2]}
             colorScale={colorScale}
             showColorMeta={showColorMeta}
             names={['Default', 'Tinted']}
@@ -31,7 +32,7 @@ export const Scale = ({
           />
           <Group
             header={showHeader ? 'Surface' : ''}
-            colors={[2, 3, 4, 5]}
+            colors={[3, 4, 5, 6]}
             colorScale={colorScale}
             showColorMeta={showColorMeta}
             names={['Default', 'Tinted', 'Hover', 'Active']}
@@ -40,7 +41,7 @@ export const Scale = ({
           <Group
             showColorMeta={showColorMeta}
             header={showHeader ? 'Border' : ''}
-            colors={[6, 7, 8]}
+            colors={[7, 8, 9]}
             colorScale={colorScale}
             names={['Subtle', 'Default', 'Strong']}
             namespace={namespace}
@@ -48,7 +49,7 @@ export const Scale = ({
           <Group
             showColorMeta={showColorMeta}
             header={showHeader ? 'Text' : ''}
-            colors={[9, 10]}
+            colors={[10, 11]}
             colorScale={colorScale}
             names={['Subtle', 'Default']}
             namespace={namespace}
@@ -56,7 +57,7 @@ export const Scale = ({
           <Group
             showColorMeta={showColorMeta}
             header={showHeader ? 'Base' : ''}
-            colors={[11, 12, 13, 14, 15]}
+            colors={[12, 13, 14, 15, 16]}
             colorScale={colorScale}
             names={[
               'Default',

--- a/apps/theme/components/Scale/Scale.tsx
+++ b/apps/theme/components/Scale/Scale.tsx
@@ -24,7 +24,7 @@ export const Scale = ({
         <div className={classes.test}>
           <Group
             header={showHeader ? 'Background' : ''}
-            colors={[1, 2]}
+            colorNumbers={[1, 2]}
             colorScale={colorScale}
             showColorMeta={showColorMeta}
             names={['Default', 'Tinted']}
@@ -32,7 +32,7 @@ export const Scale = ({
           />
           <Group
             header={showHeader ? 'Surface' : ''}
-            colors={[3, 4, 5, 6]}
+            colorNumbers={[3, 4, 5, 6]}
             colorScale={colorScale}
             showColorMeta={showColorMeta}
             names={['Default', 'Tinted', 'Hover', 'Active']}
@@ -41,7 +41,7 @@ export const Scale = ({
           <Group
             showColorMeta={showColorMeta}
             header={showHeader ? 'Border' : ''}
-            colors={[7, 8, 9]}
+            colorNumbers={[7, 8, 9]}
             colorScale={colorScale}
             names={['Subtle', 'Default', 'Strong']}
             namespace={namespace}
@@ -49,7 +49,7 @@ export const Scale = ({
           <Group
             showColorMeta={showColorMeta}
             header={showHeader ? 'Text' : ''}
-            colors={[10, 11]}
+            colorNumbers={[10, 11]}
             colorScale={colorScale}
             names={['Subtle', 'Default']}
             namespace={namespace}
@@ -57,7 +57,7 @@ export const Scale = ({
           <Group
             showColorMeta={showColorMeta}
             header={showHeader ? 'Base' : ''}
-            colors={[12, 13, 14, 15, 16]}
+            colorNumbers={[12, 13, 14, 15, 16]}
             colorScale={colorScale}
             names={[
               'Default',

--- a/apps/theme/components/TokenModal/TokenModal.tsx
+++ b/apps/theme/components/TokenModal/TokenModal.tsx
@@ -13,10 +13,14 @@ import { InformationSquareIcon, StarIcon } from '@navikt/aksel-icons';
 import { CodeSnippet } from '@repo/components';
 import { useRef, useState } from 'react';
 
+import type { Color } from '@digdir/designsystemet/color';
 import { type ColorTheme, useThemeStore } from '../../store';
 import classes from './TokenModal.module.css';
 
 const colorCliOptions = cliOptions.theme.colors;
+
+const getBaseDefault = (colorTheme: Color[]) =>
+  colorTheme.find((color) => color.name === 'base-default');
 
 export const TokenModal = () => {
   const modalRef = useRef<HTMLDialogElement>(null);
@@ -29,9 +33,7 @@ export const TokenModal = () => {
   const setCliColors = (colorTheme: ColorTheme[]) => {
     let str = '';
     for (const theme of colorTheme) {
-      const baseColor = theme.colors.light.find(
-        (color) => color.name === 'baseDefault',
-      );
+      const baseColor = getBaseDefault(theme.colors.light);
       str += `"${theme.name}:${baseColor?.hex}" `;
     }
     return str;
@@ -40,7 +42,7 @@ export const TokenModal = () => {
   const cliSnippet = [
     `npx @digdir/designsystemet@next tokens create`,
     `--${colorCliOptions.main} ${setCliColors(colors.main).trimEnd()}`,
-    `--${colorCliOptions.neutral} "${colors.neutral[0]?.colors.light[11].hex}"`,
+    `--${colorCliOptions.neutral} "${getBaseDefault(colors.neutral[0]?.colors.light)?.hex}"`,
     `${colors.support.length > 0 ? `--${colorCliOptions.support} ${setCliColors(colors.support).trimEnd()}` : ''}`,
     `--border-radius ${baseBorderRadius}`,
     `--theme "${themeName}"`,

--- a/apps/theme/store.ts
+++ b/apps/theme/store.ts
@@ -1,5 +1,5 @@
 import {
-  type ColorInfo,
+  type Color,
   type ColorScheme,
   type ThemeInfo,
   generateColorSchemes,
@@ -34,8 +34,8 @@ type ColorStore = {
   ) => void;
   resetColors: () => void;
   removeColor: (index: number, type: 'main' | 'neutral' | 'support') => void;
-  selectedColor: { color: ColorInfo; name: string };
-  setSelectedColor: (color: ColorInfo, name: string) => void;
+  selectedColor: { color: Color; name: string };
+  setSelectedColor: (color: Color, name: string) => void;
   baseBorderRadius: BaseBorderRadius;
   setBaseBorderRadius: (radius: BaseBorderRadius) => void;
   colorScheme: ColorScheme;
@@ -52,7 +52,7 @@ export const useThemeStore = create(
       color: {
         hex: '#ffffff',
         number: 1,
-        name: 'Default',
+        name: 'background-default',
         displayName: 'Default',
         group: 'neutral',
       },

--- a/apps/theme/store.ts
+++ b/apps/theme/store.ts
@@ -55,6 +55,12 @@ export const useThemeStore = create(
         name: 'background-default',
         displayName: 'Default',
         group: 'neutral',
+        description: '',
+        luminance: {
+          light: 0,
+          dark: 0,
+          contrast: 0,
+        },
       },
       name: 'Default',
     },

--- a/packages/cli/src/colors/colorMetadata.ts
+++ b/packages/cli/src/colors/colorMetadata.ts
@@ -1,11 +1,4 @@
-import type {
-  ColorMetadata,
-  ColorMetadataByName,
-  ColorMetadataByNumber,
-  ColorNumber,
-  CssColor,
-  GlobalColors,
-} from './types.js';
+import type { ColorMetadataByName, ColorMetadataByNumber, ColorNumber, CssColor, GlobalColors } from './types.js';
 
 export const baseColors: Record<GlobalColors, CssColor> = {
   blue: '#0A71C0',
@@ -220,6 +213,6 @@ export const colorMetadataByNumber = Object.entries(colorMetadata).reduce((acc, 
   return acc;
 }, {} as ColorMetadataByNumber);
 
-export const getColorMetadataByNumber = (number: ColorNumber): ColorMetadata => {
+export const getColorMetadataByNumber = (number: ColorNumber) => {
   return colorMetadataByNumber[number];
 };

--- a/packages/cli/src/colors/colorMetadata.ts
+++ b/packages/cli/src/colors/colorMetadata.ts
@@ -1,4 +1,5 @@
-import type { ColorMetadata, ColorNumber, CssColor, GlobalColors } from './types.js';
+import * as R from 'ramda';
+import type { ColorMetadataByName, ColorMetadataByNumber, CssColor, GlobalColors } from './types.js';
 
 export const baseColors: Record<GlobalColors, CssColor> = {
   blue: '#0A71C0',
@@ -8,9 +9,10 @@ export const baseColors: Record<GlobalColors, CssColor> = {
   red: '#C01B1B',
 };
 
-export const colorMetadata: Record<ColorNumber, ColorMetadata> = {
-  1: {
-    name: 'backgroundDefault',
+export const colorMetadata: ColorMetadataByName = {
+  'background-default': {
+    number: 1,
+    name: 'background-default',
     group: 'background',
     displayName: 'Background Default',
     description: 'Background Default er den mest nøytrale bakgrunnsfargen.',
@@ -20,8 +22,9 @@ export const colorMetadata: Record<ColorNumber, ColorMetadata> = {
       contrast: 0.001,
     },
   },
-  2: {
-    name: 'backgroundTinted',
+  'background-tinted': {
+    number: 2,
+    name: 'background-tinted',
     group: 'background',
     displayName: 'Background Tinted',
     description: 'Background Tinted er en bakgrunnsfarge som har et hint av farge i seg.',
@@ -31,8 +34,9 @@ export const colorMetadata: Record<ColorNumber, ColorMetadata> = {
       contrast: 0.0065,
     },
   },
-  3: {
-    name: 'surfaceDefault',
+  'surface-default': {
+    number: 3,
+    name: 'surface-default',
     group: 'surface',
     displayName: 'Surface Default',
     description:
@@ -43,8 +47,9 @@ export const colorMetadata: Record<ColorNumber, ColorMetadata> = {
       contrast: 0.015,
     },
   },
-  4: {
-    name: 'surfaceTinted',
+  'surface-tinted': {
+    number: 4,
+    name: 'surface-tinted',
     group: 'surface',
     displayName: 'Surface Tinted',
     description: 'Surface Tinted brukes på flater som ligger oppå bakgrunnsfargene. Denne har et hint av farge i seg.',
@@ -54,8 +59,9 @@ export const colorMetadata: Record<ColorNumber, ColorMetadata> = {
       contrast: 0.015,
     },
   },
-  5: {
-    name: 'surfaceHover',
+  'surface-hover': {
+    number: 5,
+    name: 'surface-hover',
     group: 'surface',
     displayName: 'Surface Hover',
     description: 'Surface Hover brukes på interaktive flater som ligger oppå bakgrunnsfargene i en hover state.',
@@ -65,8 +71,9 @@ export const colorMetadata: Record<ColorNumber, ColorMetadata> = {
       contrast: 0.028,
     },
   },
-  6: {
-    name: 'surfaceActive',
+  'surface-active': {
+    number: 6,
+    name: 'surface-active',
     group: 'surface',
     displayName: 'Surface Active',
     description: 'Surface Active brukes på interaktive flater som ligger oppå bakgrunnsfargene i en active state.',
@@ -76,8 +83,9 @@ export const colorMetadata: Record<ColorNumber, ColorMetadata> = {
       contrast: 0.045,
     },
   },
-  7: {
-    name: 'borderSubtle',
+  'border-subtle': {
+    number: 7,
+    name: 'border-subtle',
     group: 'border',
     displayName: 'Border Subtle',
     description: 'Border Subtle er den lyseste border-fargen og brukes for å skille elementer fra hverandre.',
@@ -87,8 +95,9 @@ export const colorMetadata: Record<ColorNumber, ColorMetadata> = {
       contrast: 0.26,
     },
   },
-  8: {
-    name: 'borderDefault',
+  'border-default': {
+    number: 8,
+    name: 'border-default',
     group: 'border',
     displayName: 'Border Default',
     description: 'Border Default er en border-farge som brukes når man ønsker god kontrast mot bakgrunnsfargene.',
@@ -98,8 +107,9 @@ export const colorMetadata: Record<ColorNumber, ColorMetadata> = {
       contrast: 0.4,
     },
   },
-  9: {
-    name: 'borderStrong',
+  'border-strong': {
+    number: 9,
+    name: 'border-strong',
     group: 'border',
     displayName: 'Border Strong',
     description:
@@ -110,8 +120,9 @@ export const colorMetadata: Record<ColorNumber, ColorMetadata> = {
       contrast: 0.6,
     },
   },
-  10: {
-    name: 'textSubtle',
+  'text-subtle': {
+    number: 10,
+    name: 'text-subtle',
     group: 'text',
     displayName: 'Text Subtle',
     description:
@@ -122,8 +133,9 @@ export const colorMetadata: Record<ColorNumber, ColorMetadata> = {
       contrast: 0.57,
     },
   },
-  11: {
-    name: 'textDefault',
+  'text-default': {
+    number: 11,
+    name: 'text-default',
     group: 'text',
     displayName: 'Text Default',
     description:
@@ -134,8 +146,9 @@ export const colorMetadata: Record<ColorNumber, ColorMetadata> = {
       contrast: 0.86,
     },
   },
-  12: {
-    name: 'baseDefault',
+  'base-default': {
+    number: 12,
+    name: 'base-default',
     group: 'base',
     displayName: 'Base Default',
     description:
@@ -146,8 +159,9 @@ export const colorMetadata: Record<ColorNumber, ColorMetadata> = {
       contrast: 1,
     },
   },
-  13: {
-    name: 'baseHover',
+  'base-hover': {
+    number: 13,
+    name: 'base-hover',
     group: 'base',
     displayName: 'Base Hover',
     description: 'Base Hover brukes som hover farge på elementer som bruker Base Default fargen.',
@@ -157,8 +171,9 @@ export const colorMetadata: Record<ColorNumber, ColorMetadata> = {
       contrast: 1,
     },
   },
-  14: {
-    name: 'baseActive',
+  'base-active': {
+    number: 14,
+    name: 'base-active',
     group: 'base',
     displayName: 'Base Active',
     description: 'Base Active brukes som active farge på elementer som bruker Base Default fargen.',
@@ -168,8 +183,9 @@ export const colorMetadata: Record<ColorNumber, ColorMetadata> = {
       contrast: 1,
     },
   },
-  15: {
-    name: 'contrastSubtle',
+  'base-contrast-subtle': {
+    number: 15,
+    name: 'base-contrast-subtle',
     group: 'base',
     displayName: 'Contrast Subtle',
     description: 'Contrast Subtle brukes som en viktig meningsbærende farge oppå Base Default fargen.',
@@ -179,8 +195,9 @@ export const colorMetadata: Record<ColorNumber, ColorMetadata> = {
       contrast: 1,
     },
   },
-  16: {
-    name: 'contrastDefault',
+  'base-contrast-default': {
+    number: 16,
+    name: 'base-contrast-default',
     group: 'base',
     displayName: 'Contrast Default',
     description: 'Contrast Default brukes som en viktig meningsbærende farge oppå alle Base fargane.',
@@ -190,4 +207,9 @@ export const colorMetadata: Record<ColorNumber, ColorMetadata> = {
       contrast: 1,
     },
   },
-} as const;
+};
+
+export const colorMetadataByNumber = Object.entries(colorMetadata).reduce((acc, [, metadata]) => {
+  R.assoc(metadata.number, metadata, acc);
+  return acc;
+}, {} as ColorMetadataByNumber);

--- a/packages/cli/src/colors/colorMetadata.ts
+++ b/packages/cli/src/colors/colorMetadata.ts
@@ -1,4 +1,5 @@
-import type { ColorMetadataByName, ColorMetadataByNumber, ColorNumber, CssColor, GlobalColors } from './types.js';
+import * as R from 'ramda';
+import type { ColorMetadataByName, ColorNumber, CssColor, GlobalColors } from './types.js';
 
 export const baseColors: Record<GlobalColors, CssColor> = {
   blue: '#0A71C0',
@@ -208,10 +209,7 @@ export const colorMetadata: ColorMetadataByName = {
   },
 };
 
-export const colorMetadataByNumber = Object.entries(colorMetadata).reduce((acc, [_, metadata]) => {
-  acc[metadata.number] = metadata;
-  return acc;
-}, {} as ColorMetadataByNumber);
+const colorMetadataByNumber = R.indexBy((metadata) => metadata.number, Object.values(colorMetadata));
 
 export const getColorMetadataByNumber = (number: ColorNumber) => {
   return colorMetadataByNumber[number];

--- a/packages/cli/src/colors/colorMetadata.ts
+++ b/packages/cli/src/colors/colorMetadata.ts
@@ -1,5 +1,11 @@
-import * as R from 'ramda';
-import type { ColorMetadataByName, ColorMetadataByNumber, CssColor, GlobalColors } from './types.js';
+import type {
+  ColorMetadata,
+  ColorMetadataByName,
+  ColorMetadataByNumber,
+  ColorNumber,
+  CssColor,
+  GlobalColors,
+} from './types.js';
 
 export const baseColors: Record<GlobalColors, CssColor> = {
   blue: '#0A71C0',
@@ -209,7 +215,11 @@ export const colorMetadata: ColorMetadataByName = {
   },
 };
 
-export const colorMetadataByNumber = Object.entries(colorMetadata).reduce((acc, [, metadata]) => {
-  R.assoc(metadata.number, metadata, acc);
+export const colorMetadataByNumber = Object.entries(colorMetadata).reduce((acc, [_, metadata]) => {
+  acc[metadata.number] = metadata;
   return acc;
 }, {} as ColorMetadataByNumber);
+
+export const getColorMetadataByNumber = (number: ColorNumber): ColorMetadata => {
+  return colorMetadataByNumber[number];
+};

--- a/packages/cli/src/colors/theme.ts
+++ b/packages/cli/src/colors/theme.ts
@@ -1,9 +1,9 @@
 import chroma from 'chroma-js';
 import * as R from 'ramda';
-import { colorMetadata } from './colorMetadata.js';
+import { colorMetadata, getColorMetadataByNumber } from './colorMetadata.js';
 import type { CssColor } from './types.js';
 import type { Color, ColorNumber, ColorScheme, ThemeInfo } from './types.js';
-import { getColorByNumber, getLightnessFromHex, getLuminanceFromLightness } from './utils.js';
+import { getLightnessFromHex, getLuminanceFromLightness } from './utils.js';
 
 /**
  * Generates a color scale based on a base color and a color mode.
@@ -109,5 +109,5 @@ export const generateColorContrast = (color: CssColor, type: 'default' | 'subtle
  * @param colorNumber The number of the color
  */
 export const getCssVariable = (colorType: string, colorNumber: ColorNumber) => {
-  return `--ds-color-${colorType}-${getColorByNumber(colorNumber).displayName.toLowerCase().replace(/\s/g, '-')}`;
+  return `--ds-color-${colorType}-${getColorMetadataByNumber(colorNumber).displayName.toLowerCase().replace(/\s/g, '-')}`;
 };

--- a/packages/cli/src/colors/theme.ts
+++ b/packages/cli/src/colors/theme.ts
@@ -2,8 +2,8 @@ import chroma from 'chroma-js';
 import * as R from 'ramda';
 import { colorMetadata } from './colorMetadata.js';
 import type { CssColor } from './types.js';
-import type { ColorInfo, ColorNumber, ColorScheme, ThemeInfo } from './types.js';
-import { getColorInfoFromPosition, getLightnessFromHex, getLuminanceFromLightness } from './utils.js';
+import type { Color, ColorNumber, ColorScheme, ThemeInfo } from './types.js';
+import { getColorByNumber, getLightnessFromHex, getLuminanceFromLightness } from './utils.js';
 
 /**
  * Generates a color scale based on a base color and a color mode.
@@ -11,23 +11,28 @@ import { getColorInfoFromPosition, getLightnessFromHex, getLuminanceFromLightnes
  * @param color The base color that is used to generate the color scale
  * @param colorScheme The color scheme to generate a scale for
  */
-export const generateColorScale = (color: CssColor, colorScheme: ColorScheme): ColorInfo[] => {
-  const colors = R.mapObjIndexed((colorData, key) => {
+export const generateColorScale = (color: CssColor, colorScheme: ColorScheme): Color[] => {
+  const colors = R.mapObjIndexed((colorData) => {
     const luminance = colorData.luminance[colorScheme];
     return {
       ...colorData,
       hex: chroma(color).luminance(luminance).hex() as CssColor,
-      number: parseInt(key) as ColorNumber,
     };
   }, colorMetadata);
 
   // Generate base colors
   const baseColors = generateBaseColors(color, colorScheme);
-  colors['12'] = { ...colors['12'], hex: baseColors.default };
-  colors['13'] = { ...colors['13'], hex: baseColors.hover };
-  colors['14'] = { ...colors['14'], hex: baseColors.active };
-  colors['15'] = { ...colors['15'], hex: generateColorContrast(baseColors.default, 'subtle') };
-  colors['16'] = { ...colors['16'], hex: generateColorContrast(baseColors.default, 'default') };
+  colors['base-default'] = { ...colors['base-default'], hex: baseColors.default };
+  colors['base-hover'] = { ...colors['base-hover'], hex: baseColors.hover };
+  colors['base-active'] = { ...colors['base-active'], hex: baseColors.active };
+  colors['base-contrast-subtle'] = {
+    ...colors['base-contrast-subtle'],
+    hex: generateColorContrast(baseColors.default, 'subtle'),
+  };
+  colors['base-contrast-default'] = {
+    ...colors['base-contrast-default'],
+    hex: generateColorContrast(baseColors.default, 'default'),
+  };
 
   return Object.values(colors);
 };
@@ -104,5 +109,5 @@ export const generateColorContrast = (color: CssColor, type: 'default' | 'subtle
  * @param colorNumber The number of the color
  */
 export const getCssVariable = (colorType: string, colorNumber: ColorNumber) => {
-  return `--ds-color-${colorType}-${getColorInfoFromPosition(colorNumber).displayName.toLowerCase().replace(/\s/g, '-')}`;
+  return `--ds-color-${colorType}-${getColorByNumber(colorNumber).displayName.toLowerCase().replace(/\s/g, '-')}`;
 };

--- a/packages/cli/src/colors/types.ts
+++ b/packages/cli/src/colors/types.ts
@@ -1,11 +1,88 @@
 export type ColorScheme = 'light' | 'dark' | 'contrast';
 export type ContrastMode = 'aa' | 'aaa';
 export type ColorNumber = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16;
+export type ColorNames = keyof SemanticColorMapping;
 export type GlobalColors = 'red' | 'blue' | 'green' | 'orange' | 'purple';
 export type ColorError = 'none' | 'decorative' | 'interaction';
 
+type SemanticColorMapping = {
+  'background-default': {
+    name: 'background-default';
+    number: 1;
+  };
+  'background-tinted': {
+    name: 'background-tinted';
+    number: 2;
+  };
+  'surface-default': {
+    name: 'surface-default';
+    number: 3;
+  };
+  'surface-tinted': {
+    name: 'surface-tinted';
+    number: 4;
+  };
+  'surface-hover': {
+    name: 'surface-hover';
+    number: 5;
+  };
+  'surface-active': {
+    name: 'surface-active';
+    number: 6;
+  };
+  'border-subtle': {
+    name: 'border-subtle';
+    number: 7;
+  };
+  'border-default': {
+    name: 'border-default';
+    number: 8;
+  };
+  'border-strong': {
+    name: 'border-strong';
+    number: 9;
+  };
+  'text-subtle': {
+    name: 'text-subtle';
+    number: 10;
+  };
+  'text-default': {
+    name: 'text-default';
+    number: 11;
+  };
+  'base-default': {
+    name: 'base-default';
+    number: 12;
+  };
+  'base-hover': {
+    name: 'base-hover';
+    number: 13;
+  };
+  'base-active': {
+    name: 'base-active';
+    number: 14;
+  };
+  'base-contrast-subtle': {
+    name: 'base-contrast-subtle';
+    number: 15;
+  };
+  'base-contrast-default': {
+    name: 'base-contrast-default';
+    number: 16;
+  };
+};
+
+export type ColorMetadataByName = {
+  [Property in keyof SemanticColorMapping]: SemanticColorMapping[Property] & ColorMetadata;
+};
+
+export type ColorMetadataByNumber = {
+  [Property in keyof SemanticColorMapping as SemanticColorMapping[Property]['number']]: SemanticColorMapping[Property] &
+    ColorMetadata;
+};
+
 export type ColorMetadata = {
-  name: string;
+  name: ColorNames;
   displayName: string;
   description: string;
   group: string;
@@ -16,15 +93,15 @@ export type ColorMetadata = {
   };
 };
 
-export type ColorInfo = Partial<ColorMetadata> & {
-  number: ColorNumber;
+export type Color = Partial<ColorMetadata> & {
   hex: CssColor;
+  number: ColorNumber;
 };
 
 export type ThemeInfo = {
-  light: ColorInfo[];
-  dark: ColorInfo[];
-  contrast: ColorInfo[];
+  light: Color[];
+  dark: Color[];
+  contrast: Color[];
 };
 
 /**

--- a/packages/cli/src/colors/types.ts
+++ b/packages/cli/src/colors/types.ts
@@ -77,12 +77,10 @@ export type ColorMetadataByName = {
 };
 
 export type ColorMetadataByNumber = {
-  [P in keyof SemanticColorMapping as SemanticColorMapping[P]['number']]: SemanticColorMapping[P] &
-    Omit<ColorMetadata, 'name'>;
+  [P in keyof SemanticColorMapping as SemanticColorMapping[P]['number']]: SemanticColorMapping[P] & ColorMetadata;
 };
 
 export type ColorMetadata = {
-  name: ColorNames;
   displayName: string;
   description: string;
   group: string;
@@ -95,6 +93,7 @@ export type ColorMetadata = {
 
 export type Color = Partial<ColorMetadata> & {
   hex: CssColor;
+  name: ColorNames;
   number: ColorNumber;
 };
 

--- a/packages/cli/src/colors/types.ts
+++ b/packages/cli/src/colors/types.ts
@@ -1,74 +1,33 @@
 export type ColorScheme = 'light' | 'dark' | 'contrast';
 export type ContrastMode = 'aa' | 'aaa';
-export type ColorNumber = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16;
-export type ColorNames = keyof SemanticColorMapping;
+export type ColorNumber = SemanticColorNumberMap[keyof SemanticColorNumberMap];
+export type ColorNames = keyof SemanticColorNumberMap;
 export type GlobalColors = 'red' | 'blue' | 'green' | 'orange' | 'purple';
 export type ColorError = 'none' | 'decorative' | 'interaction';
 
+type SemanticColorNumberMap = {
+  'background-default': 1;
+  'background-tinted': 2;
+  'surface-default': 3;
+  'surface-tinted': 4;
+  'surface-hover': 5;
+  'surface-active': 6;
+  'border-subtle': 7;
+  'border-default': 8;
+  'border-strong': 9;
+  'text-subtle': 10;
+  'text-default': 11;
+  'base-default': 12;
+  'base-hover': 13;
+  'base-active': 14;
+  'base-contrast-subtle': 15;
+  'base-contrast-default': 16;
+};
+
 type SemanticColorMapping = {
-  'background-default': {
-    name: 'background-default';
-    number: 1;
-  };
-  'background-tinted': {
-    name: 'background-tinted';
-    number: 2;
-  };
-  'surface-default': {
-    name: 'surface-default';
-    number: 3;
-  };
-  'surface-tinted': {
-    name: 'surface-tinted';
-    number: 4;
-  };
-  'surface-hover': {
-    name: 'surface-hover';
-    number: 5;
-  };
-  'surface-active': {
-    name: 'surface-active';
-    number: 6;
-  };
-  'border-subtle': {
-    name: 'border-subtle';
-    number: 7;
-  };
-  'border-default': {
-    name: 'border-default';
-    number: 8;
-  };
-  'border-strong': {
-    name: 'border-strong';
-    number: 9;
-  };
-  'text-subtle': {
-    name: 'text-subtle';
-    number: 10;
-  };
-  'text-default': {
-    name: 'text-default';
-    number: 11;
-  };
-  'base-default': {
-    name: 'base-default';
-    number: 12;
-  };
-  'base-hover': {
-    name: 'base-hover';
-    number: 13;
-  };
-  'base-active': {
-    name: 'base-active';
-    number: 14;
-  };
-  'base-contrast-subtle': {
-    name: 'base-contrast-subtle';
-    number: 15;
-  };
-  'base-contrast-default': {
-    name: 'base-contrast-default';
-    number: 16;
+  [K in keyof SemanticColorNumberMap]: {
+    name: K;
+    number: SemanticColorNumberMap[K];
   };
 };
 

--- a/packages/cli/src/colors/types.ts
+++ b/packages/cli/src/colors/types.ts
@@ -73,12 +73,12 @@ type SemanticColorMapping = {
 };
 
 export type ColorMetadataByName = {
-  [Property in keyof SemanticColorMapping]: SemanticColorMapping[Property] & ColorMetadata;
+  [P in keyof SemanticColorMapping]: SemanticColorMapping[P] & ColorMetadata;
 };
 
 export type ColorMetadataByNumber = {
-  [Property in keyof SemanticColorMapping as SemanticColorMapping[Property]['number']]: SemanticColorMapping[Property] &
-    ColorMetadata;
+  [P in keyof SemanticColorMapping as SemanticColorMapping[P]['number']]: SemanticColorMapping[P] &
+    Omit<ColorMetadata, 'name'>;
 };
 
 export type ColorMetadata = {

--- a/packages/cli/src/colors/types.ts
+++ b/packages/cli/src/colors/types.ts
@@ -76,11 +76,9 @@ export type ColorMetadataByName = {
   [P in keyof SemanticColorMapping]: SemanticColorMapping[P] & ColorMetadata;
 };
 
-export type ColorMetadataByNumber = {
-  [P in keyof SemanticColorMapping as SemanticColorMapping[P]['number']]: SemanticColorMapping[P] & ColorMetadata;
-};
-
 export type ColorMetadata = {
+  name: ColorNames;
+  number: ColorNumber;
   displayName: string;
   description: string;
   group: string;
@@ -91,10 +89,8 @@ export type ColorMetadata = {
   };
 };
 
-export type Color = Partial<ColorMetadata> & {
+export type Color = ColorMetadata & {
   hex: CssColor;
-  name: ColorNames;
-  number: ColorNumber;
 };
 
 export type ThemeInfo = {

--- a/packages/cli/src/colors/utils.ts
+++ b/packages/cli/src/colors/utils.ts
@@ -1,7 +1,6 @@
 import chroma from 'chroma-js';
 import { Hsluv } from 'hsluv';
-import { colorMetadataByNumber } from './colorMetadata.js';
-import type { ColorNumber, CssColor, HexColor } from './types.js';
+import type { CssColor, HexColor } from './types.js';
 
 /**
  * Converts a HEX color '#xxxxxx' into a CSS HSL string 'hsl(x,x,x)'
@@ -170,10 +169,6 @@ export const getLightnessFromHex = (hex: HexColor) => {
   conv.hexToHsluv();
 
   return conv.hsluv_l;
-};
-
-export const getColorByNumber = (position: ColorNumber) => {
-  return colorMetadataByNumber[position];
 };
 
 /**

--- a/packages/cli/src/colors/utils.ts
+++ b/packages/cli/src/colors/utils.ts
@@ -1,6 +1,6 @@
 import chroma from 'chroma-js';
 import { Hsluv } from 'hsluv';
-import { colorMetadata } from './colorMetadata.js';
+import { colorMetadataByNumber } from './colorMetadata.js';
 import type { ColorNumber, CssColor, HexColor } from './types.js';
 
 /**
@@ -172,8 +172,8 @@ export const getLightnessFromHex = (hex: HexColor) => {
   return conv.hsluv_l;
 };
 
-export const getColorInfoFromPosition = (position: ColorNumber) => {
-  return colorMetadata[position];
+export const getColorByNumber = (position: ColorNumber) => {
+  return colorMetadataByNumber[position];
 };
 
 /**

--- a/packages/cli/src/tokens/create.ts
+++ b/packages/cli/src/tokens/create.ts
@@ -1,6 +1,6 @@
 import * as R from 'ramda';
 import { baseColors, generateColorScale } from '../colors/index.js';
-import type { ColorInfo, ColorScheme } from '../colors/types.js';
+import type { Color, ColorScheme } from '../colors/types.js';
 import type { Colors, Theme, Tokens, Tokens1ary, TokensSet, Typography } from './types.js';
 
 export const cliOptions = {
@@ -19,7 +19,7 @@ export const cliOptions = {
   },
 } as const;
 
-const createColorTokens = (colorArray: ColorInfo[]): Tokens1ary => {
+const createColorTokens = (colorArray: Color[]): Tokens1ary => {
   const obj: Tokens1ary = {};
   const $type = 'color';
   for (const index in colorArray) {


### PR DESCRIPTION
In an effort to prevent bugs related to using indexs for fetching arbitary colors I have introduces stricter types for colorMetaData making safer lookups by name or number