### PR TITLE
fix: details marker safari

### DIFF
--- a/packages/css/src/details.css
+++ b/packages/css/src/details.css
@@ -36,11 +36,11 @@
   }
 
   /* Hide default marker in Safari */
-  & summary::-webkit-details-marker {
+  & > summary::-webkit-details-marker {
     display: none;
   }
 
-  & :is(summary, u-summary) {
+  & > :is(summary, u-summary) {
     color: var(--dsc-details-summary-color);
     align-items: center;
     background: var(--dsc-details-summary-background);

--- a/packages/css/src/details.css
+++ b/packages/css/src/details.css
@@ -35,6 +35,11 @@
     --dsc-details-border-color: var(--ds-color-border-subtle);
   }
 
+  /* Hide default marker in Safari */
+  & summary::-webkit-details-marker {
+    display: none;
+  }
+
   & :is(summary, u-summary) {
     color: var(--dsc-details-summary-color);
     align-items: center;


### PR DESCRIPTION
- Add fix to hide marker (triangle ▶) in Safari ([see MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary#default_style))