### PR TITLE
chore: update release ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Rebase next to main if we publised outside of prerelease
+        # If not pre.json is present and we published, we asume a new version to latest has been published
+        # Update main with latest changes
         if: ${{ hashFiles('.changeset/pre.json') == '' && steps.changesets.outputs.published == 'true' }}
         run: |
           git fetch origin main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      # - main
       - next
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/gh-setup
       - name: Create Release Pull Request or Publish to npm
+        id: changesets
         # https://github.com/changesets/action
         uses: changesets/action@v1
         with:
@@ -29,3 +30,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Rebase next to main if we publised outside of prerelease
+        if: ${{ hashFiles('.changeset/pre.json') == '' && steps.changesets.outputs.published == 'true' }}
+        run: |
+          git fetch origin main
+          git checkout main
+          git rebase next
+          git push origin main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           stable_branch: 'main'
           development_branch: 'next'
+          allow_ff: true
           user_name: github_actions
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,8 @@ jobs:
           # this expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: yarn publish
           version: yarn version-packages
-          commit: 'chore: new ${{ github.base_ref }} release'
-          title: 'chore: new ${{ github.base_ref }} release'
+          commit: 'chore: new release'
+          title: 'chore: new release'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Rebase next to main if we publised outside of prerelease
+      - name: Merge next into main if we publised outside of prerelease
         # If not pre.json is present and we published, we asume a new version to latest has been published
         # Update main with latest changes
         if: ${{ hashFiles('.changeset/pre.json') == '' && steps.changesets.outputs.published == 'true' }}
         run: |
           git fetch origin main
           git checkout main
-          git rebase next
+          git merge next
           git push origin main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Merge next into main if we publised outside of prerelease
+        uses: robotology/gh-action-nightly-merge@v1.5.2
         # If not pre.json is present and we published, we asume a new version to latest has been published
         # Update main with latest changes
         if: ${{ hashFiles('.changeset/pre.json') == '' && steps.changesets.outputs.published == 'true' }}
-        run: |
-          git fetch origin main
-          git checkout main
-          git merge next
-          git push origin main
+        with:
+          stable_branch: 'main'
+          development_branch: 'next'
+          user_name: github_actions
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digdir/designsystemet",
-  "version": "1.0.0-next.51",
+  "version": "0.100.51-next.51",
   "description": "CLI for Designsystemet",
   "author": "Designsystemet team",
   "engines": {

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digdir/designsystemet-css",
-  "version": "1.0.0-next.51",
+  "version": "0.100.51-next.51",
   "description": "CSS for Designsystemet",
   "author": "Designsystemet team",
   "repository": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@digdir/designsystemet-react",
   "type": "module",
-  "version": "1.0.0-next.51",
+  "version": "0.100.51-next.51",
   "description": "React components for Designsystemet",
   "author": "Designsystemet team",
   "repository": {

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digdir/designsystemet-theme",
-  "version": "1.0.0-next.51",
+  "version": "0.100.51-next.51",
   "description": "Predefined themes for Designsystemet",
   "author": "Designsystemet team",
   "repository": {


### PR DESCRIPTION
Update release ci to work as follows.

We work primarily against `next` and release to `latest` from `next` to make sure everything stays in sync with using [changesets prerelease mode](https://github.com/changesets/changesets/blob/main/docs/prereleases.md) and its files used for tracking whats prerelease and release. 

- Commits to `next` enters prerelease mode if we are not in prerelease mode
- All changesets made into `next` will by default make a new `@next` release
- When we want to release to `latest`, we use then "Exit prerelease mode" (`release-pre-exit.yml`)
  - Changesets bot will then detect our intention to exit-prerelease and make a new release PR that will publish to `latest`
- If we are no longer in prerelease mode and changesets have published, we assume a new version to latest have been published.
  - We then rebase `next` onto `main` to keep `main` in sync with `latest`
  
Remains to be tested
- How does github release behave with rebasing/merge? Commits should keep sha.
- How are tags affected? 