### PR TITLE
feat: ensure consistent usage of `data-*` vs `*` props in React

### DIFF
--- a/.changeset/nine-worms-spend.md
+++ b/.changeset/nine-worms-spend.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": minor
+---
+
+**`Badge`, `Card`, `Details`, `Popover`**: Rename `data-variant` prop to `variant`

--- a/.changeset/sour-tips-poke.md
+++ b/.changeset/sour-tips-poke.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": minor
+---
+
+**`ToggleGroup.Item`**: Disallow setting `variant` directly, it should only be set based on which item in the group is active

--- a/apps/storefront/app/bloggen/_components/Card/BlogCard.tsx
+++ b/apps/storefront/app/bloggen/_components/Card/BlogCard.tsx
@@ -42,7 +42,7 @@ export const BlogCard = ({
       data-featured={featured}
       className={cl(classes.card, className)}
       data-color='neutral'
-      data-variant='tinted'
+      variant='tinted'
       {...props}
     >
       <CardBlock>

--- a/apps/storefront/app/god-praksis/tilgjengelighet/kontrast/page.mdx
+++ b/apps/storefront/app/god-praksis/tilgjengelighet/kontrast/page.mdx
@@ -36,7 +36,7 @@ For å sikre god lesbarhet skal all tekst ha tilstrekkelig kontrast mot bakgrunn
 
 Alle brukerne, også de med svekket syn, skal kunne se innholdet i digitale tjenester. Web Content Accessibility Guidelines (WCAG) inneholder suksesskriterier og forslag til løsninger for å lykkes. Men det er ikke samsvar mellom dagens kontrastregler og kravet om at alle skal kunne se innholdet.
 
-<Card data-color='brand3' data-variant="tinted" data-unstyled>
+<Card data-color='brand3' variant="tinted" data-unstyled>
   <Heading
     level={3}
     data-size='xs'
@@ -60,7 +60,7 @@ Alle brukerne, også de med svekket syn, skal kunne se innholdet i digitale tjen
 
 <br />
 
-<Card data-color='brand2' data-variant="tinted" data-unstyled>
+<Card data-color='brand2' variant="tinted" data-unstyled>
   <Heading
     level={3}
     data-size='xs'
@@ -123,7 +123,7 @@ Vi vet at selv om en løsning oppfyller de konkrete kravene fra regelverket om u
 
 Hvis vi oppfyller metoden i WCAG 2, etterlever vi teknisk sett kravet til universell utforming, men det betyr ikke at innholdet er tilgjengelig eller universelt utformet. Derfor strekker vi oss langt i å også oppfylle de fremtidige WCAG-3 kravene som bruker APCA-metoden.
 
-<Card data-color='brand3' data-variant="tinted" data-unstyled>
+<Card data-color='brand3' variant="tinted" data-unstyled>
   **Kontrast i WCAG 2 «luminosity contrast algorithm** <br />
   _«I WCAG 2 er kontrast en måleenhet for forskjellen i den opplevde lysintensiteten
   mellom to farger. Denne forskjellen er beskrevet som et forhold fra 1:1 (for
@@ -135,7 +135,7 @@ Hvis vi oppfyller metoden i WCAG 2, etterlever vi teknisk sett kravet til univer
 
 <br />
 
-<Card data-color='brand2' data-variant="tinted" data-unstyled>
+<Card data-color='brand2' variant="tinted" data-unstyled>
   **Kontrast i WCAG 3 «visual contrast algorithm»** <br />I WCAG 3 benyttes en
   visuell-kontrast algoritme som kalles for APCA, det er fremdeles
   fargeverdiene som benyttes for å kalkulere kontrasten, men også om fargen er
@@ -175,7 +175,7 @@ I variant B er teksten svart, og bakgrunnen er farge #6D7879. Teksten er noe min
 
 <br />
 <br />
-<Card data-color='brand1' data-variant="tinted" data-unstyled>
+<Card data-color='brand1' variant="tinted" data-unstyled>
   **Bidra til artikkelen?** <br />
   Vi vil gjerne ha dine innspill og tilbakemeldinger på artikkelen. Send oss en
   e-post på: designsystem@digdir.no eller [kontakt oss i Github](https://github.com/digdir/designsystemet/issues/new).

--- a/apps/storefront/app/monstre/feilmeldinger/page.mdx
+++ b/apps/storefront/app/monstre/feilmeldinger/page.mdx
@@ -159,7 +159,7 @@ Vi viser feilmeldingen under feltet med feil. Dette er det vanligste mønsteret,
 
 <Card
   data-color='brand1'
-  data-variant="tinted"
+  variant="tinted"
   data-unstyled
 >
   Merk: Vi ønsker å holde oss oppdatert om andre anbefalinger om plassering, og har [pågående diskusjon om dette på Git](https://github.com/digdir/designsystemet/discussions/1684#discussioncomment-9339006).
@@ -246,7 +246,7 @@ Vi kan bruke disse aria-attributtene og rollene:
 - Vi setter `aria-invalid="true"` på felt med feil, for å si fra om at det er en feil der.
 - Vi bruker `aria-describedby` for å koble feilmelding til feltet.
 
-<Card data-color='brand1' data-variant="tinted" data-unstyled>
+<Card data-color='brand1' variant="tinted" data-unstyled>
   Vi unngår inntill videre å bruke `aria-errormessage` da den ikke har full støtte av hjelpemidler per nå. Men vi kommer til å oppdatere retningslinjene om støtten blir bedre i fremtiden. [Se diskusjon på github](https://github.com/digdir/designsystemet/discussions/1684)
 </Card>
 
@@ -272,7 +272,7 @@ For feilmeldinger som dukker opp dynamisk må vi bruke `aria-live` for at meldin
 <br />
 <br />
 
-<Card data-color='brand3' data-variant="tinted" data-unstyled>
+<Card data-color='brand3' variant="tinted" data-unstyled>
   Retningslinjene er utarbeidet i en tverretatlig arbeidsgruppe med deltakere fra Digdir, Nav, Skatt, Brreg, Politiet, KS DIF og Oslo kommune. Du kan påvirke arbeidet i [Github](https://github.com/digdir/designsystemet/discussions/1684) eller i [#Mønster-kanalen](https://designsystemet.slack.com/archives/C05RBGB92MC/p1712751837722749) på [Slack](https://designsystemet.no/slack).
 </Card>
 

--- a/apps/storefront/app/monstre/obligatoriske-og-valgfrie-felt/page.mdx
+++ b/apps/storefront/app/monstre/obligatoriske-og-valgfrie-felt/page.mdx
@@ -93,7 +93,7 @@ En kombinasjon av obligatoriske og valgfrie felt er ikke ideellt! Men det vil v�
 
 <Card
   data-color='brand3'
-  data-variant="tinted"
+  variant="tinted"
   data-unstyled
 >
   *Retningslinjene er utarbeidet i en tverretatlig arbeidsgruppe med deltakere fra Digdir, Nav, Skatt, Brreg og Oslo Origo. Du kan påvirke arbeidet i [Github](https://github.com/digdir/designsystemet/issues/new) eller i [#Mønster-kanalen](https://designsystemet.slack.com/archives/C05RBGB92MC/p1712751837722749) på [Slack](https://designsystemet.no/slack).

--- a/apps/storefront/app/monstre/systemvarsler/page.mdx
+++ b/apps/storefront/app/monstre/systemvarsler/page.mdx
@@ -252,7 +252,7 @@ Dette gjør at modaltittelen kan få fokus, selv om den normalt ikke er et inter
 
 <br/>
 
-<Card data-color='brand3' data-variant="tinted" data-unstyled>
+<Card data-color='brand3' variant="tinted" data-unstyled>
   Retningslinjene er utarbeidet i en tverretatlig arbeidsgruppe med deltakere fra Digdir, Nav, Skatteetaten, Brønnøysundregistrene, Politiet, KS, Entur, Mattilsynet og Oslo kommune. Du kan påvirke arbeidet i [Github](https://github.com/digdir/designsystemet/discussions/1801) eller i [#Mønster-kanalen](https://designsystemet.slack.com/archives/C05RBGB92MC/p1712751837722749) på [Slack](https://designsystemet.no/slack).
 </Card>
 

--- a/packages/react/src/components/Badge/Badge.mdx
+++ b/packages/react/src/components/Badge/Badge.mdx
@@ -43,7 +43,7 @@ Dette vil også fungere for `overlap="circle"`.
 ## Farger
 
 `Badge` kommer i alle farger, du kan endre den med `data-color`. 
-Du kan også sette `data-variant` direkte for å endre bakgrunnsfarge.
+Du kan også sette `variant` direkte for å endre bakgrunnsfarge.
 
 <Canvas of={BadgeStories.Variants} />
 

--- a/packages/react/src/components/Badge/Badge.stories.tsx
+++ b/packages/react/src/components/Badge/Badge.stories.tsx
@@ -198,28 +198,28 @@ const VariantsMap: {
   },
   neutralTinted: {
     'data-color': 'neutral',
-    'data-variant': 'tinted',
+    variant: 'tinted',
   },
   dangerBase: {
     'data-color': 'danger',
   },
   dangerTinted: {
     'data-color': 'danger',
-    'data-variant': 'tinted',
+    variant: 'tinted',
   },
   infoBase: {
     'data-color': 'info',
   },
   infoTinted: {
     'data-color': 'info',
-    'data-variant': 'tinted',
+    variant: 'tinted',
   },
   warningBase: {
     'data-color': 'warning',
   },
   warningTinted: {
     'data-color': 'warning',
-    'data-variant': 'tinted',
+    variant: 'tinted',
   },
 };
 

--- a/packages/react/src/components/Badge/Badge.tsx
+++ b/packages/react/src/components/Badge/Badge.tsx
@@ -23,7 +23,7 @@ export type BadgeProps = MergeRight<
      *
      * @default 'base'
      */
-    'data-variant'?: 'base' | 'tinted';
+    variant?: 'base' | 'tinted';
     /**
      * Change the color scheme of the badge
      */
@@ -44,7 +44,7 @@ export type BadgeProps = MergeRight<
  * </Badge>
  */
 export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(function Badge(
-  { className, count, maxCount, 'data-variant': variant = 'base', ...rest },
+  { className, count, maxCount, variant = 'base', ...rest },
   ref,
 ) {
   return (

--- a/packages/react/src/components/Card/Card.stories.tsx
+++ b/packages/react/src/components/Card/Card.stories.tsx
@@ -53,35 +53,35 @@ const VariantsMap: {
 } = {
   neutralDefault: {
     'data-color': 'neutral',
-    'data-variant': 'default',
+    variant: 'default',
   },
   neutralTinted: {
     'data-color': 'neutral',
-    'data-variant': 'tinted',
+    variant: 'tinted',
   },
   brand1Default: {
     'data-color': 'brand1',
-    'data-variant': 'default',
+    variant: 'default',
   },
   brand1Tinted: {
     'data-color': 'brand1',
-    'data-variant': 'tinted',
+    variant: 'tinted',
   },
   brand2Default: {
     'data-color': 'brand2',
-    'data-variant': 'default',
+    variant: 'default',
   },
   brand2Tinted: {
     'data-color': 'brand2',
-    'data-variant': 'tinted',
+    variant: 'tinted',
   },
   brand3Default: {
     'data-color': 'brand3',
-    'data-variant': 'default',
+    variant: 'default',
   },
   brand3Tinted: {
     'data-color': 'brand3',
-    'data-variant': 'tinted',
+    variant: 'tinted',
   },
 };
 

--- a/packages/react/src/components/Card/Card.tsx
+++ b/packages/react/src/components/Card/Card.tsx
@@ -14,7 +14,7 @@ export type CardProps = MergeRight<
      *
      * @default 'default'
      */
-    'data-variant'?: 'default' | 'tinted';
+    variant?: 'default' | 'tinted';
     /**
      * Change the default rendered element for the one passed as a child, merging their props and behavior.
      * @default false
@@ -36,7 +36,7 @@ export type CardProps = MergeRight<
  * </Card>
  */
 export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
-  { asChild = false, 'data-variant': variant = 'default', className, ...rest },
+  { asChild = false, variant = 'default', className, ...rest },
   ref,
 ) {
   const Component = asChild ? Slot : 'div';

--- a/packages/react/src/components/Details/Details.stories.tsx
+++ b/packages/react/src/components/Details/Details.stories.tsx
@@ -59,7 +59,7 @@ export const InCardWithColor: StoryFn<typeof Details> = () => (
       </Details>
     </Card>
     <br />
-    <Card data-color='accent' data-variant='tinted'>
+    <Card data-color='accent' variant='tinted'>
       <Details>
         <Details.Summary>
           Hvordan får jeg tildelt et jegernummer?

--- a/packages/react/src/components/Details/Details.tsx
+++ b/packages/react/src/components/Details/Details.tsx
@@ -14,7 +14,7 @@ export type DetailsProps = MergeRight<
      *
      * @default 'default'
      */
-    'data-variant'?: 'default' | 'tinted';
+    variant?: 'default' | 'tinted';
     /**
      * Controls open-state.
      *
@@ -58,7 +58,7 @@ export const Details = forwardRef<HTMLDetailsElement, DetailsProps>(
       className,
       open,
       defaultOpen = false,
-      'data-variant': variant = 'default',
+      variant = 'default',
       onToggle,
       ...rest
     },

--- a/packages/react/src/components/Popover/Popover.mdx
+++ b/packages/react/src/components/Popover/Popover.mdx
@@ -47,7 +47,7 @@ Bruk `inline={true}` (stiplet understrek) på `Popover.Trigger` for å indikere 
 ### Farger
 
 `Popover` kommer i alle farger, du kan endre den med `data-color`. 
-Du kan også sette `data-variant` direkte for å endre bakgrunnsfarge.
+Du kan også sette `variant` direkte for å endre bakgrunnsfarge.
 
 <Canvas of={PopoverStories.Variants} />
 

--- a/packages/react/src/components/Popover/Popover.stories.tsx
+++ b/packages/react/src/components/Popover/Popover.stories.tsx
@@ -121,28 +121,28 @@ const VariantsMap: {
   },
   neutralTinted: {
     'data-color': 'neutral',
-    'data-variant': 'tinted',
+    variant: 'tinted',
   },
   dangerDefault: {
     'data-color': 'danger',
   },
   dangerTinted: {
     'data-color': 'danger',
-    'data-variant': 'tinted',
+    variant: 'tinted',
   },
   infoDefault: {
     'data-color': 'info',
   },
   infoTinted: {
     'data-color': 'info',
-    'data-variant': 'tinted',
+    variant: 'tinted',
   },
   warningDefault: {
     'data-color': 'warning',
   },
   warningTinted: {
     'data-color': 'warning',
-    'data-variant': 'tinted',
+    variant: 'tinted',
   },
 };
 

--- a/packages/react/src/components/Popover/Popover.tsx
+++ b/packages/react/src/components/Popover/Popover.tsx
@@ -57,7 +57,7 @@ export type PopoverProps = MergeRight<
      *
      * @default 'default'
      */
-    'data-variant'?: 'default' | 'tinted';
+    variant?: 'default' | 'tinted';
     /**
      * Change the color scheme of the popover
      */
@@ -108,7 +108,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
       onClose,
       onOpen,
       open,
-      'data-variant': variant = 'default',
+      variant = 'default',
       placement = 'top',
       autoPlacement = true,
       asChild = false,

--- a/packages/react/src/components/ToggleGroup/ToggleGroupItem.tsx
+++ b/packages/react/src/components/ToggleGroup/ToggleGroupItem.tsx
@@ -11,7 +11,7 @@ export type ToggleGroupItemProps = {
    * Generates a random value if not set.
    **/
   value?: string;
-} & Omit<ButtonProps, 'loading' | 'value'>;
+} & Omit<ButtonProps, 'loading' | 'value' | 'variant'>;
 
 /**
  * A single item in a ToggleGroup.


### PR DESCRIPTION
The only `data-*` props in the React component API is now:
  - `data-color-scheme`
  - `data-color`
  - `data-size`

These are special, since they apply to regular HTML elements and also affect descendants.

The rest of our API now consistently does **not** use the `data-` prefix, even if a `data-` attribute is used internally for the implementation. This ensures a clear distinction between React props and global-affecting attributes in our API.