### PR TITLE
chore: update color description and labels in themebuilder

### DIFF
--- a/apps/theme/components/Sidebar/ColorPage/ColorPage.tsx
+++ b/apps/theme/components/Sidebar/ColorPage/ColorPage.tsx
@@ -55,7 +55,7 @@ export const ColorPage = () => {
         <>
           <div className={classes.group}>
             <div className={classes.groupHeader}>
-              <Heading data-size='2xs'>Hovedfarger</Heading>
+              <Heading data-size='2xs'>Main</Heading>
               {colors.main.length < 40 && (
                 <Button
                   variant='tertiary'
@@ -103,7 +103,7 @@ export const ColorPage = () => {
           {/* SUPPORT COLORS */}
           <div className={classes.group}>
             <div className={classes.groupHeader}>
-              <Heading data-size='2xs'>Støttefarger</Heading>
+              <Heading data-size='2xs'>Support</Heading>
               {colors.support.length < 40 && (
                 <Button
                   variant='tertiary'

--- a/apps/theme/components/Sidebar/ColorPane/ColorPane.tsx
+++ b/apps/theme/components/Sidebar/ColorPane/ColorPane.tsx
@@ -118,7 +118,7 @@ export const ColorPane = ({
         <Textfield
           placeholder='Skriv navnet her...'
           label='Navn'
-          description='Kun bokstaver, tall og bindestrek'
+          description='Bruk kun bokstavene a-z, tall og bindestrek'
           className={classes.name}
           data-size='sm'
           value={name}


### PR DESCRIPTION
* Renamed the color labels to "main" and "support" in the sidebar to better match what the colors are named in figma and code.
* Updated the description of the color input to "Bruk kun bokstavene a-z, tall og bindestrek" to better communicate with the user that they cant use "æøå". This was a suggestion from Brreg.