### PR TITLE
style(Breadcrumbs): make arrow in link inherit color

### DIFF
--- a/.changeset/seven-hornets-cheat.md
+++ b/.changeset/seven-hornets-cheat.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**Breadcrumbs**: Fix arrow to inherit color

--- a/.changeset/seven-hornets-cheat.md
+++ b/.changeset/seven-hornets-cheat.md
@@ -2,4 +2,4 @@
 "@digdir/designsystemet-css": patch
 ---
 
-**Breadcrumbs**: Fix arrow to inherit color
+**Breadcrumbs**: Fix arrow to inherit color when in a link

--- a/packages/css/src/breadcrumbs.css
+++ b/packages/css/src/breadcrumbs.css
@@ -38,12 +38,9 @@
     }
   }
 
-  & > :not(ol, ul)::before {
-    background: currentColor;
-  }
-
   /* When link is direct child of Breadcrumbs, make it back button */
   & > :not(ol, ul)::before {
+    background: currentColor;
     margin: 0;
     rotate: 180deg;
   }

--- a/packages/css/src/breadcrumbs.css
+++ b/packages/css/src/breadcrumbs.css
@@ -38,6 +38,10 @@
     }
   }
 
+  & > :not(ol, ul)::before {
+    background: currentColor;
+  }
+
   /* When link is direct child of Breadcrumbs, make it back button */
   & > :not(ol, ul)::before {
     margin: 0;


### PR DESCRIPTION
fixes this:
<img width="112" alt="image" src="https://github.com/user-attachments/assets/45916d77-5111-4f72-ac58-90f62d12e801" />

it is now this:
<img width="114" alt="image" src="https://github.com/user-attachments/assets/bbbe4305-a500-4c15-a814-64a43bc952c2" />

but keeps the arrows the same color as link when listed out:
<img width="376" alt="image" src="https://github.com/user-attachments/assets/3e582490-5753-4a40-b4f7-11cb142115da" />
