### PR TITLE
style(Tabs): focus border above active line

### DIFF
--- a/.changeset/happy-hornets-lie.md
+++ b/.changeset/happy-hornets-lie.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**Tabs**: Focus now fully encompasses `Tab`

--- a/packages/css/src/tabs.css
+++ b/packages/css/src/tabs.css
@@ -70,6 +70,7 @@
           background: var(--dsc-tabs-tab-color--selected);
         }
 
+        /* Place active line under focus */
         &:focus-visible::after {
           z-index: -1;
         }

--- a/packages/css/src/tabs.css
+++ b/packages/css/src/tabs.css
@@ -70,6 +70,10 @@
           background: var(--dsc-tabs-tab-color--selected);
         }
 
+        &:focus-visible::after {
+          z-index: -1;
+        }
+
         @media (forced-colors: active) {
           color: CanvasText;
           border-bottom: 2px solid CanvasText;


### PR DESCRIPTION
fixes this, where the active line is above the focus border:
<img width="299" alt="image" src="https://github.com/user-attachments/assets/b7fa4b76-c062-4209-98ec-44e14f2543b1" />

it is now this:
<img width="295" alt="image" src="https://github.com/user-attachments/assets/12dd367c-1041-43a4-ab18-a8da91feb048" />
