### PR TITLE
style(dropdown): move closer to trigger

### DIFF
--- a/.changeset/old-monkeys-grab.md
+++ b/.changeset/old-monkeys-grab.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**Dropdown**: Move dropdown closer to trigger

--- a/packages/css/src/dropdown.css
+++ b/packages/css/src/dropdown.css
@@ -6,6 +6,7 @@
   --dsc-dropdown-border-width: var(--ds-border-width-default);
   --dsc-dropdown-border-style: solid;
   --dsc-dropdown-border-color: var(--ds-color-neutral-border-subtle);
+  --dsc-popover-arrow-size: var(--ds-size-2);
 
   background: var(--dsc-dropdown-background);
   border-radius: var(--ds-border-radius-md);


### PR DESCRIPTION
we changed the arrow size of `Popover`. This moved the dropdown further away from its trigger:
<img width="309" alt="image" src="https://github.com/user-attachments/assets/5c574630-70b9-4039-9f90-faf694339b0e" />

changed to this:
<img width="303" alt="image" src="https://github.com/user-attachments/assets/bd8f33e5-ffbc-4abf-8056-4005e598f706" />
