### PR TITLE
chore(apps): updates to disabled sb a11y tests

### DIFF
--- a/apps/storybook/stories/showcase.stories.tsx
+++ b/apps/storybook/stories/showcase.stories.tsx
@@ -17,10 +17,9 @@ export default {
       },
     },
     a11y: {
-      // TODO: these rules should be enabled after figuring out why they occur.
+      // TODO: this rule should be enabled after https://github.com/dequelabs/axe-core/issues/4672 have propagated to @storybook/addon-a11y.
       config: {
         rules: [
-          /* https://github.com/dequelabs/axe-core/issues/4672 */
           {
             id: 'aria-allowed-role',
             enabled: false,

--- a/apps/storybook/stories/showcase.stories.tsx
+++ b/apps/storybook/stories/showcase.stories.tsx
@@ -18,14 +18,9 @@ export default {
     },
     a11y: {
       // TODO: these rules should be enabled after figuring out why they occur.
-      // for some reason it says `aria-expanded` is not allowed
       config: {
         rules: [
-          {
-            id: 'aria-allowed-attr',
-            enabled: false,
-          },
-          /* It does not like role="combobox" either */
+          /* https://github.com/dequelabs/axe-core/issues/4672 */
           {
             id: 'aria-allowed-role',
             enabled: false,

--- a/packages/react/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/react/src/components/Dialog/Dialog.stories.tsx
@@ -299,10 +299,9 @@ export const DialogWithSuggestion: StoryFn<typeof Dialog> = () => {
 
 DialogWithSuggestion.parameters = {
   a11y: {
-    // TODO: these rules should be enabled after figuring out why they occur.
+    // TODO: this rule should be enabled after https://github.com/dequelabs/axe-core/issues/4672 have propagated to @storybook/addon-a11y.
     config: {
       rules: [
-        /* https://github.com/dequelabs/axe-core/issues/4672 */
         {
           id: 'aria-allowed-role',
           enabled: false,

--- a/packages/react/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/react/src/components/Dialog/Dialog.stories.tsx
@@ -300,14 +300,9 @@ export const DialogWithSuggestion: StoryFn<typeof Dialog> = () => {
 DialogWithSuggestion.parameters = {
   a11y: {
     // TODO: these rules should be enabled after figuring out why they occur.
-    // for some reason it says `aria-expanded` is not allowed
     config: {
       rules: [
-        {
-          id: 'aria-allowed-attr',
-          enabled: false,
-        },
-        /* It does not like role="combobox" either */
+        /* https://github.com/dequelabs/axe-core/issues/4672 */
         {
           id: 'aria-allowed-role',
           enabled: false,

--- a/packages/react/src/components/MultiSuggestion/MultiSuggestion.stories.tsx
+++ b/packages/react/src/components/MultiSuggestion/MultiSuggestion.stories.tsx
@@ -18,10 +18,9 @@ export default {
   ],
   parameters: {
     a11y: {
-      // TODO: these rules should be enabled after figuring out why they occur.
+      // TODO: this rule should be enabled after https://github.com/dequelabs/axe-core/issues/4672 have propagated to @storybook/addon-a11y.
       config: {
         rules: [
-          /* https://github.com/dequelabs/axe-core/issues/4672 */
           {
             id: 'aria-allowed-role',
             enabled: false,

--- a/packages/react/src/components/MultiSuggestion/MultiSuggestion.stories.tsx
+++ b/packages/react/src/components/MultiSuggestion/MultiSuggestion.stories.tsx
@@ -19,14 +19,9 @@ export default {
   parameters: {
     a11y: {
       // TODO: these rules should be enabled after figuring out why they occur.
-      // for some reason it says `aria-expanded` is not allowed
       config: {
         rules: [
-          {
-            id: 'aria-allowed-attr',
-            enabled: false,
-          },
-          /* It does not like role="combobox" either */
+          /* https://github.com/dequelabs/axe-core/issues/4672 */
           {
             id: 'aria-allowed-role',
             enabled: false,

--- a/packages/react/src/components/Suggestion/Suggestion.stories.tsx
+++ b/packages/react/src/components/Suggestion/Suggestion.stories.tsx
@@ -22,14 +22,9 @@ export default {
     },
     a11y: {
       // TODO: these rules should be enabled after figuring out why they occur.
-      // for some reason it says `aria-expanded` is not allowed
       config: {
         rules: [
-          {
-            id: 'aria-allowed-attr',
-            enabled: false,
-          },
-          /* It does not like role="combobox" either */
+          /* https://github.com/dequelabs/axe-core/issues/4672 */
           {
             id: 'aria-allowed-role',
             enabled: false,

--- a/packages/react/src/components/Suggestion/Suggestion.stories.tsx
+++ b/packages/react/src/components/Suggestion/Suggestion.stories.tsx
@@ -21,10 +21,9 @@ export default {
       disableSnapshot: false,
     },
     a11y: {
-      // TODO: these rules should be enabled after figuring out why they occur.
+      // TODO: this rule should be enabled after https://github.com/dequelabs/axe-core/issues/4672 have propagated to @storybook/addon-a11y.
       config: {
         rules: [
-          /* https://github.com/dequelabs/axe-core/issues/4672 */
           {
             id: 'aria-allowed-role',
             enabled: false,


### PR DESCRIPTION
resolves #3245 

I do not get any violations if I re-enable `aria-allowed-attr` rule, so I have removed this.

The "combobox role not allowed on input" problem in `Suggestion`/`Multisuggestion` seems to possibly stem from [this](https://github.com/dequelabs/axe-core/issues/4672) reported issue in axe-core. 

> The logic axe-core uses vs the logic the spec uses for determining when text/tel/url/email/search should be treated as comboboxes is also slightly different; the spec says that the presence of a list attribute is enough that it should be treated as combobox-like, but axe-core demands that it not just have a list attribute but that the list attribute be a valid idrefs-style reference to a datalist element (html-elms.js is inconsistent with implicit-html-roles.js and just looks for any list attribute)

Specifically this check in[ implicit-html-roles.js](https://github.com/dequelabs/axe-core/blob/64d409dc5862e9fdebcec87a0a269ab3f3e71ad2/lib/commons/standards/implicit-html-roles.js#L150) 
`suggestionsSourceElement = listElement && listElement.nodeName.toLowerCase() === 'datalist';` 
In our code this returns `u-datalist`. 

Then in [get-element-unallowed-roles.js](https://github.com/dequelabs/axe-core/blob/64d409dc5862e9fdebcec87a0a269ab3f3e71ad2/lib/commons/aria/get-element-unallowed-roles.js#L72) there is now a mismatch between explicit and implicit role returning false for `roleIsAllowed`

If I change the element to `datalist` in `SuggestionList.tsx `I no longer get the violation in storybook.

Conclusion: it should fix itself in a future update of `@storybook/addon-a11y` after the axe-core issue linked above has been resolved and published