### PR TITLE
ci(check-changeset): ignore mdx-files

### DIFF
--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -11,6 +11,7 @@ on:
       - "!packages/**/*.stories.tsx"
       - "!packages/**/*.chromatic.tsx"
       - "!packages/**/*.test.tsx"
+      - "!packages/**/*.mdx"
 jobs:
   checks:
     name: Check if changeset is present


### PR DESCRIPTION
## Current behavior
Changeset-check fails if only mdx-files are changed

## New behavior
Dont fail the changeset-check if only mdx-files are changed