### PR TITLE
chore: remove tinted value from blog-cards in storefront

### DIFF
--- a/apps/storefront/app/bloggen/_components/Card/BlogCard.tsx
+++ b/apps/storefront/app/bloggen/_components/Card/BlogCard.tsx
@@ -42,7 +42,6 @@ export const BlogCard = ({
       data-featured={featured}
       className={cl(classes.card, className)}
       data-color='neutral'
-      variant='tinted'
       {...props}
     >
       <CardBlock>


### PR DESCRIPTION
The blog-cards should be white in light mode, to look good against the grey background.