### PR TITLE
fix: move readonly logic to field/fieldset making label/legend components optional

### DIFF
--- a/.changeset/fresh-dogs-join.md
+++ b/.changeset/fresh-dogs-join.md
@@ -2,4 +2,4 @@
 "@digdir/designsystemet-css": patch
 ---
 
-**Label:** Move readonly styling from label/legend to field/fieldset for more robust setup
+**Label:** Move readonly styling from label to base for more robust setup. Now styles any label & legend element inside field & fieldset.

--- a/.changeset/fresh-dogs-join.md
+++ b/.changeset/fresh-dogs-join.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**Label:** Move readonly styling from label/legend to field/fieldset for more robust setup

--- a/.changeset/tasty-cats-rescue.md
+++ b/.changeset/tasty-cats-rescue.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+Added new class `ds-readonly-icon` for displaying a the readonly icon (padlock) before an element.

--- a/packages/css/src/base.css
+++ b/packages/css/src/base.css
@@ -15,6 +15,8 @@
 :root {
   --ds-font-size-minus-1: max(.9em, .875rem); /* Default to 90% of font-size, but minimum 14px */
   --ds-font-size-plus-1: 1.1em; /* Default to 110% */
+  --ds-readonly-icon-size: 1.2em;
+  --ds-readonly-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' viewBox='0 0 24 24'%3E%3Cpath fill-rule='evenodd' d='M12 2.25A4.75 4.75 0 0 0 7.25 7v2.25H7A1.75 1.75 0 0 0 5.25 11v9c0 .41.34.75.75.75h12a.75.75 0 0 0 .75-.75v-9A1.75 1.75 0 0 0 17 9.25h-.25V7A4.75 4.75 0 0 0 12 2.25m3.25 7V7a3.25 3.25 0 0 0-6.5 0v2.25zM12 13a1.5 1.5 0 0 0-.75 2.8V17a.75.75 0 0 0 1.5 0v-1.2A1.5 1.5 0 0 0 12 13'/%3E%3C/svg%3E");
 
   /* font-size adjustments if supporting round() */
   @supports (width: round(down, .1em, 1px)) {
@@ -35,6 +37,22 @@ body,
 [data-color-scheme] {
   color: var(--ds-color-neutral-text-default);
   background: var(--ds-color-neutral-background-default);
+}
+
+.ds-readonly-icon::before {
+  background: currentcolor;
+  content: '';
+  display: inline-block;
+  height: calc(1em * var(--ds-line-height-md)); /* Fallback for browsers not supporting lh unit */
+  height: 1lh;
+  margin-inline-end: .25ch; /* Fake a space character */
+  mask: center / contain no-repeat var(--ds-readonly-icon-url);
+  vertical-align: bottom;
+  width: var(--ds-readonly-icon-size);
+
+  @media (forced-colors: active) {
+    background: CanvasText;
+  }
 }
 
 /**

--- a/packages/css/src/field.css
+++ b/packages/css/src/field.css
@@ -26,7 +26,7 @@
   }
 
   &:has([aria-readonly='true'], [readonly]) label {
-    --_dsc-label--readonly: ; /* Activate lock icon for label when readonly */
+    @composes ds-readonly-icon from './base.css'; /* Activate lock icon for label when readonly */
   }
 
   /**
@@ -49,8 +49,10 @@
     }
 
     & label {
-      --_dsc-label--readonly: initial; /* Never show lock icon on toggle inputs */
       font-weight: var(--ds-font-weight-regular);
+    }
+    & label::before {
+      content: none; /* Hide readonly icon on toggle inputs */
     }
 
     & input {

--- a/packages/css/src/fieldset.css
+++ b/packages/css/src/fieldset.css
@@ -6,7 +6,7 @@
 
   /* Add lock icon to legend when only containing readonly inputs */
   &:has(input[readonly]):not(:has(input:not([readonly]))) > legend {
-    --_dsc-label--readonly: ; /* Using technique https://css-tricks.com/the-css-custom-property-toggle-trick/ */
+    @composes ds-readonly-icon from './base.css'; /* Activate lock icon for legend when all inputs are readonly */
   }
 
   /* Stack everything that is not directly after legend */

--- a/packages/css/src/label.css
+++ b/packages/css/src/label.css
@@ -2,27 +2,8 @@
   --dsc-label-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' viewBox='0 0 24 24'%3E%3Cpath fill-rule='evenodd' d='M12 2.25A4.75 4.75 0 0 0 7.25 7v2.25H7A1.75 1.75 0 0 0 5.25 11v9c0 .41.34.75.75.75h12a.75.75 0 0 0 .75-.75v-9A1.75 1.75 0 0 0 17 9.25h-.25V7A4.75 4.75 0 0 0 12 2.25m3.25 7V7a3.25 3.25 0 0 0-6.5 0v2.25zM12 13a1.5 1.5 0 0 0-.75 2.8V17a.75.75 0 0 0 1.5 0v-1.2A1.5 1.5 0 0 0 12 13'/%3E%3C/svg%3E");
   --dsc-label-icon-size: 1.2em;
   --dsc-label-icon-spacing: var(--ds-size-1);
-  --_dsc-label--readonly: initial; /* Using technique https://css-tricks.com/the-css-custom-property-toggle-trick/ */
 
   font-weight: var(--ds-font-weight-medium);
-  padding-inline-start: var(--_dsc-label--readonly) calc(var(--dsc-label-icon-size) + var(--dsc-label-icon-spacing));
-  position: relative;
-
-  &::before {
-    background: currentcolor;
-    content: var(--_dsc-label--readonly) '';
-    display: inline-block;
-    height: var(--dsc-label-icon-size);
-    margin-inline: calc((var(--dsc-label-icon-size) + var(--dsc-label-icon-spacing)) * -1); /* Using margin instead of top/left to avoid position: relative and to support dir="rtl" */
-    mask: center / contain no-repeat var(--dsc-label-icon-url);
-    position: absolute;
-    width: var(--dsc-label-icon-size);
-    translate: 0 calc((1lh - var(--dsc-label-icon-size)) / 2); /* Center icon to line height */
-
-    @media (forced-colors: active) {
-      background: CanvasText;
-    }
-  }
 
   &[data-weight='semibold'] {
     font-weight: var(--ds-font-weight-semibold);

--- a/packages/css/src/label.css
+++ b/packages/css/src/label.css
@@ -1,8 +1,4 @@
 .ds-label {
-  --dsc-label-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' viewBox='0 0 24 24'%3E%3Cpath fill-rule='evenodd' d='M12 2.25A4.75 4.75 0 0 0 7.25 7v2.25H7A1.75 1.75 0 0 0 5.25 11v9c0 .41.34.75.75.75h12a.75.75 0 0 0 .75-.75v-9A1.75 1.75 0 0 0 17 9.25h-.25V7A4.75 4.75 0 0 0 12 2.25m3.25 7V7a3.25 3.25 0 0 0-6.5 0v2.25zM12 13a1.5 1.5 0 0 0-.75 2.8V17a.75.75 0 0 0 1.5 0v-1.2A1.5 1.5 0 0 0 12 13'/%3E%3C/svg%3E");
-  --dsc-label-icon-size: 1.2em;
-  --dsc-label-icon-spacing: var(--ds-size-1);
-
   font-weight: var(--ds-font-weight-medium);
 
   &[data-weight='semibold'] {

--- a/packages/react/src/components/Suggestion/Suggestion.tsx
+++ b/packages/react/src/components/Suggestion/Suggestion.tsx
@@ -93,7 +93,6 @@ export const Suggestion = forwardRef<HTMLDivElement, SuggestionProps>(
 
         // Let <datalist> handle filtering if filter is true
         if (filter === true || !list) return;
-        console.log(list);
 
         // Handle custom filter
         if (filter !== false) {


### PR DESCRIPTION
Long time no see!
- We want to use as pure HTML as possible in Mattilsynet
- Currently, logic adding/hiding lock icon for read only field/fieldset is scattered across field+fieldset+label (which is also used `as="legend"`)
- By moving this into a base utility we can compose into field/fieldset, the logic is a little bit more readable - we remove a css custom property trick, and the label component no longer "communicates" with other files
- This also makes label/legend component optional - for us in Mattilsynet, we can jsut use pure HTML without any additional classnames <3