### PR TITLE
feat(Tooltip): add `autoPlacement` prop

### DIFF
--- a/.changeset/slow-bugs-relate.md
+++ b/.changeset/slow-bugs-relate.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+**Tooltip**: Add `autoPlacement` prop. By default `true`, set to `false` to disable autoplacement

--- a/.changeset/slow-bugs-relate.md
+++ b/.changeset/slow-bugs-relate.md
@@ -2,4 +2,4 @@
 "@digdir/designsystemet-react": patch
 ---
 
-**Tooltip**: Add `autoPlacement` prop. By default `true`, set to `false` to disable autoplacement
+**Tooltip**: Add `autoPlacement` prop. By default `true`, set to `false` to disable auto placement

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -75,7 +75,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       children,
       content,
       placement = 'top',
-      autoPlacement,
+      autoPlacement = true,
       open,
       className,
       ...rest

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -43,6 +43,11 @@ export type TooltipProps = MergeRight<
      */
     placement?: 'top' | 'right' | 'bottom' | 'left';
     /**
+     * Whether to enable auto placement.
+     * @default true
+     */
+    autoPlacement?: boolean;
+    /**
      * Whether the tooltip is open or not.
      * This overrides the internal state of the tooltip.
      */
@@ -65,7 +70,16 @@ export type TooltipProps = MergeRight<
  */
 export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
   function Tooltip(
-    { id, children, content, placement = 'top', open, className, ...rest },
+    {
+      id,
+      children,
+      content,
+      placement = 'top',
+      autoPlacement,
+      open,
+      className,
+      ...rest
+    },
     ref,
   ) {
     const randomTooltipId = useId();
@@ -107,9 +121,9 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
                 );
                 return parseFloat(styles.height);
               }),
-              flip({
-                fallbackAxisSideDirection: 'start',
-              }),
+              ...(autoPlacement
+                ? [flip({ fallbackAxisSideDirection: 'start' }), shift()]
+                : []),
               shift(),
               arrowPseudoElement,
             ],


### PR DESCRIPTION
Adds `autoPlacement` to Tooltip to better align with `Popover`, which is also a floating element that has this prop.