### PR TITLE
feat(css): add empty typings for easier import in typescript

### DIFF
--- a/.changeset/full-bats-smash.md
+++ b/.changeset/full-bats-smash.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+Add empty typings for easier import in typescript 

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -9,10 +9,14 @@
   },
   "license": "MIT",
   "exports": {
-    ".": "./dist/src/index.css",
+    ".": {
+      "types": "./types.d.ts",
+      "default": "./dist/src/index.css"
+    },
     "./*": "./dist/src/*"
   },
   "files": [
+    "./types.d.ts",
     "dist"
   ],
   "publishConfig": {

--- a/packages/css/types.d.ts
+++ b/packages/css/types.d.ts
@@ -1,0 +1,1 @@
+declare module '@digdir/designsystemet-css' {}


### PR DESCRIPTION
resolves #3366

Conform imports on our packages. 

`css` package was the only one without types making it flag as type error, when importing when `theme` package works fine.

Added types so it matches behaviour of our other packages when importing in typescript. 

`import '@digdir/designsystemet-css';`