### PR TITLE
feat(cli): add metadata file for `tokens create`

### DIFF
--- a/.changeset/metal-beers-stand.md
+++ b/.changeset/metal-beers-stand.md
@@ -1,5 +1,5 @@
 ---
-"@digdir/designsystemet": minor
+"@digdir/designsystemet": patch
 ---
 
 Add file (`$designsystemet.json`) with metadata for `tokens create`

--- a/.changeset/metal-beers-stand.md
+++ b/.changeset/metal-beers-stand.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet": minor
+---
+
+Add file (`$designsystemet.json`) with metadata for `tokens create`

--- a/packages/cli/src/tokens/create/generators/$designsystemet.ts
+++ b/packages/cli/src/tokens/create/generators/$designsystemet.ts
@@ -1,6 +1,6 @@
 import pkg from '../../../../package.json' with { type: 'json' };
 
-export function generate$DesignSystemet() {
+export function generate$Designsystemet() {
   return {
     name: pkg.name,
     version: pkg.version,

--- a/packages/cli/src/tokens/create/generators/$designsystemet.ts
+++ b/packages/cli/src/tokens/create/generators/$designsystemet.ts
@@ -1,0 +1,8 @@
+import pkg from '../../../../package.json' with { type: 'json' };
+
+export function generate$DesignSystemet() {
+  return {
+    name: pkg.name,
+    version: pkg.version,
+  };
+}

--- a/packages/cli/src/tokens/create/write.ts
+++ b/packages/cli/src/tokens/create/write.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import * as R from 'ramda';
 import { mkdir, readFile, writeFile } from '../../utils.js';
 import type { Theme, TokenSets } from '../types.js';
+import { generate$DesignSystemet } from './generators/$designsystemet.js';
 import { generate$Metadata } from './generators/$metadata.js';
 import { generate$Themes } from './generators/$themes.js';
 
@@ -27,6 +28,7 @@ export const writeTokens = async (options: WriteTokensOptions) => {
   const targetDir = path.resolve(process.cwd(), String(outDir));
   const $themesPath = path.join(targetDir, '$themes.json');
   const $metadataPath = path.join(targetDir, '$metadata.json');
+  const $designsystemetPath = path.join(targetDir, '$designsystemet.json');
   let themeObjects: ThemeObject[] = [];
 
   await mkdir(targetDir, dry);
@@ -54,9 +56,11 @@ export const writeTokens = async (options: WriteTokensOptions) => {
   // Create metadata and themes json for Token Studio and build script
   const $themes = await generate$Themes(['dark', 'light'], themes, colors);
   const $metadata = generate$Metadata(['dark', 'light'], themes, colors);
+  const $designsystemet = generate$DesignSystemet();
 
   await writeFile($themesPath, stringify($themes), dry);
   await writeFile($metadataPath, stringify($metadata), dry);
+  await writeFile($designsystemetPath, stringify($designsystemet), dry);
 
   for (const [set, tokens] of tokenSets) {
     // Remove last part of the path to get the directory

--- a/packages/cli/src/tokens/create/write.ts
+++ b/packages/cli/src/tokens/create/write.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import * as R from 'ramda';
 import { mkdir, readFile, writeFile } from '../../utils.js';
 import type { Theme, TokenSets } from '../types.js';
-import { generate$DesignSystemet } from './generators/$designsystemet.js';
+import { generate$Designsystemet } from './generators/$designsystemet.js';
 import { generate$Metadata } from './generators/$metadata.js';
 import { generate$Themes } from './generators/$themes.js';
 
@@ -56,7 +56,7 @@ export const writeTokens = async (options: WriteTokensOptions) => {
   // Create metadata and themes json for Token Studio and build script
   const $themes = await generate$Themes(['dark', 'light'], themes, colors);
   const $metadata = generate$Metadata(['dark', 'light'], themes, colors);
-  const $designsystemet = generate$DesignSystemet();
+  const $designsystemet = generate$Designsystemet();
 
   await writeFile($themesPath, stringify($themes), dry);
   await writeFile($metadataPath, stringify($metadata), dry);


### PR DESCRIPTION
resolves #3496

Adds a file which includes name and version from `package.json` used to create tokens.
<img width="264" alt="image" src="https://github.com/user-attachments/assets/1d9a7f62-e65d-4dba-a340-8859342e114a" />

```
{
  "name": "@digdir/designsystemet",
  "version": "1.0.3"
}
```
