### PR TITLE
docs(Alert): small follow-up for live region refinement

### DIFF
--- a/apps/storybook/story-utils/transformSource.ts
+++ b/apps/storybook/story-utils/transformSource.ts
@@ -14,8 +14,10 @@ const formatCache = new Map<string, string>();
  * Not enabled by default to avoid unnecessary performance hit.
  */
 export const formatReactSource = (src: string, ctx: StoryContext) => {
-  // Ignore value of ctx.globals.codePreview, always output as React code
-  return asyncFormatWorkaround('typescript', src, ctx);
+  if (ctx.globals.codePreview === 'react') {
+    return asyncFormatWorkaround('typescript', src, ctx);
+  }
+  return transformSource(src, ctx);
 };
 
 export const transformSource = (src: string, ctx: StoryContext) => {

--- a/packages/react/src/components/Alert/Alert.stories.tsx
+++ b/packages/react/src/components/Alert/Alert.stories.tsx
@@ -164,7 +164,11 @@ export const WrongLiveRegionReact: StoryFn<typeof Alert> = () => {
   return (
     <>
       {showAlert && (
-        <Alert data-color='warning' role='alert'>
+        <Alert
+          data-color='warning'
+          // Feil bruk: role="alert" ligger på selve varselet
+          role='alert'
+        >
           <Heading
             level={2}
             data-size='xs'
@@ -214,6 +218,7 @@ export const CorrectLiveRegionReact: StoryFn<typeof Alert> = () => {
   const [showAlert, setShowAlert] = useState(false);
   return (
     <>
+      {/* Korrekt bruk: role="alert" ligger på elementet der varselet dukker opp */}
       <div role='alert'>
         {showAlert && (
           <Alert data-color='warning'>


### PR DESCRIPTION
Follow up from #3572

- Make `formatReactSource` not disable the html output from the default transform function, which makes it usable also in future situations when the auto-generated html is good enough (without using `ReactOrHtmlCanvas`)

- Add some comments to live region examples in React, same as was done in the html examples, to make the difference between the two examples more obvious