### PR TITLE
docs: use rendered html for code examples and update when args change

### DIFF
--- a/apps/storybook/story-utils/extractRenderedHtml.ts
+++ b/apps/storybook/story-utils/extractRenderedHtml.ts
@@ -1,0 +1,8 @@
+export function extractRenderedHtml(canvasElement: HTMLElement) {
+  const decorators = canvasElement.querySelectorAll(
+    '[data-storybook-decorator]',
+  );
+  const innerDecorator = Array.from(decorators).at(decorators.length - 1);
+  const html = innerDecorator?.innerHTML || canvasElement.innerHTML;
+  return html;
+}

--- a/apps/storybook/story-utils/transformSource.ts
+++ b/apps/storybook/story-utils/transformSource.ts
@@ -1,13 +1,15 @@
+import { DocsContext } from '@storybook/addon-docs';
 import type { StoryContext } from '@storybook/react';
 import type { Plugin } from 'prettier';
 import * as EstreePlugin from 'prettier/plugins/estree';
 import * as HtmlPlugin from 'prettier/plugins/html';
 import * as TypescriptPlugin from 'prettier/plugins/typescript';
 import { format as prettierFormat } from 'prettier/standalone';
-import { type FunctionComponent, type ReactNode, createElement } from 'react';
-import * as ReactDOMServer from 'react-dom/server';
+import { useContext } from 'react';
+import { extractRenderedHtml } from './extractRenderedHtml';
 
 const formatCache = new Map<string, string>();
+const htmlCache = new Map<string, string>();
 
 /**
  * Use this as parameters.docs.source.transform as needed to better format React code.
@@ -22,20 +24,18 @@ export const formatReactSource = (src: string, ctx: StoryContext) => {
 
 export const transformSource = (src: string, ctx: StoryContext) => {
   if (ctx.globals.codePreview === 'html') {
-    let component: ReactNode;
-
-    //a storyFn expects 1 argument, a storyObj expects 2
-    if (ctx.originalStoryFn.length === 1) {
-      component = createElement(ctx.originalStoryFn as FunctionComponent);
-    } else {
-      component = createElement(
-        ctx.component as FunctionComponent,
-        ctx.initialArgs,
-      );
+    const docsContext = useContext(DocsContext);
+    const storyElement =
+      document.getElementById(`story--${ctx.id}-inner`) ??
+      document.getElementById(`story--${ctx.id}--primary-inner`);
+    if (storyElement && !htmlCache.get(ctx.id)) {
+      htmlCache.set(ctx.id, extractRenderedHtml(storyElement));
+      // Once the element has been rendered (storyElement !== null),
+      // force Storybook to re-render the story, so that the rendered html can be used in the code preview
+      docsContext.channel.emit('forceReRender');
     }
 
-    const unformatted = ReactDOMServer.renderToStaticMarkup(component);
-
+    const unformatted = htmlCache.get(ctx.id) ?? '...rendering html...';
     return asyncFormatWorkaround('html', unformatted, ctx);
   }
   return src;


### PR DESCRIPTION
This works more consistently than `ReactDOMServer.renderToStaticMarkup`, for instance when a React context is used. An example of `renderToStaticMarkup` not being sufficient is [this ErrorSummary story](https://next.storybook.designsystemet.no/?path=/docs/komponenter-errorsummary--docs&globals=codePreview:html#bruk-med-tekstfelt).

As a bonus, this PR also ensures the html preview is updated whenever story args change by users interacting with the props table.

Storybook's low-level channel API, which is used here, is accessed through `DocsContext` which is exported publically. The event names themselves are not exported or documented except in the source code, but are available through `channel.eventNames()`.

Hopefully this code can be simplified in the future if Storybook introduces async support for source `transform` functions.