### PR TITLE
docs(Alert): small text change for clarity and consistency

### DIFF
--- a/packages/react/src/components/Alert/Alert.mdx
+++ b/packages/react/src/components/Alert/Alert.mdx
@@ -79,10 +79,10 @@ Pass på at `Alert` har samme utseende og formspråk i alle tjenester og produkt
 - informere om tilkoblingsproblemer eller API-feil som sannsynligvis løser seg ved å laste inn siden på nytt
 
 **Passer ikke til å**
-- validere enkelte skjemaelement, bruk heller komponentens egen feilmelding
+- validere individuelle skjemaelementer, bruk heller komponentens egen feilmelding
 - oppsummere flere feilmeldinger i et skjema, bruk heller [`ErrorSummary`](/docs/komponenter-errorsummary--docs)
-- vise feil som hindrer all videre bruk av tjenesten (bruk heller en feilside)
-- vise statisk informasjon som skal vises hele tiden (bruk heller [`Card`](/docs/komponenter-card--docs))
+- vise feil som hindrer all videre bruk av tjenesten, bruk heller en feilside
+- vise statisk informasjon som skal vises hele tiden, bruk heller [`Card`](/docs/komponenter-card--docs)
 
 
 ## Tekst i komponenten


### PR DESCRIPTION
- “enkelte skjemaelement” kan enkelt misforståast som “i noen tilfeller”
- på bokmål har vi vel elles brukt “elementer/elementene”  sjølv om “element/elementa” er lov
- halvparten av lista hadde ", bruk heller ..." og halvparten har "(bruk heller …)"