### PR TITLE
feat(Details): Allow multiple children

### DIFF
--- a/apps/_components/src/Showcase/Showcase.tsx
+++ b/apps/_components/src/Showcase/Showcase.tsx
@@ -31,13 +31,13 @@ import { type HTMLAttributes, useState } from 'react';
 import classes from './Showcase.module.css';
 
 const DATA_PLACES = [
+  'Lillestrøm',
   'Sogndal',
   'Oslo',
   'Brønnøysund',
   'Stavanger',
   'Trondheim',
   'Bergen',
-  'Lillestrøm',
 ];
 
 type ShowcaseProps = HTMLAttributes<HTMLDivElement>;

--- a/packages/css/src/details.css
+++ b/packages/css/src/details.css
@@ -86,11 +86,6 @@
     margin-top: 0; /* Prevent gap when places as child of .ds-card */
   }
 
-  & > :not(summary, u-summary) {
-    border-radius: inherit;
-    padding: var(--ds-size-5, 1rem);
-  }
-
   &[open] > :is(summary, u-summary) {
     background: var(--dsc-details-summary-background--open);
 
@@ -111,6 +106,8 @@
   }
 
   &::part(details-content) {
+    border-radius: inherit;
+    padding: var(--ds-size-5, 1rem);
     block-size: 0;
     overflow-y: clip;
     transition: content-visibility 400ms allow-discrete, height 400ms;

--- a/packages/react/src/components/Details/Details.stories.tsx
+++ b/packages/react/src/components/Details/Details.stories.tsx
@@ -1,8 +1,13 @@
-import { ChevronDownUpIcon, ChevronUpDownIcon } from '@navikt/aksel-icons';
+import {
+  ChevronDownUpIcon,
+  ChevronUpDownIcon,
+  PersonIcon,
+  PhoneIcon,
+} from '@navikt/aksel-icons';
 import type { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';
 
-import { Button, Card, Details, Link, Paragraph } from '../';
+import { Button, Card, Details, Link, List, Paragraph } from '../';
 
 export default {
   title: 'Komponenter/Details',
@@ -83,6 +88,25 @@ export const InCardWithColor: StoryFn<typeof Details> = () => (
       </Details>
     </Card>
   </>
+);
+
+export const MultipleChildren: StoryFn<typeof Details> = () => (
+  <Details>
+    <Details.Summary>Vi har følgende informasjon om deg</Details.Summary>
+    <p>
+      For å kunne tilby bedre tjenester til våre innbyggere henter vi ut
+      følgende informasjon fra Folkeregisteret, matrikkelen og kontakt- og
+      reservasjonsregisteret:{' '}
+    </p>
+    <List.Unordered>
+      <List.Item>
+        <PersonIcon aria-label='' fontSize='1.5em' /> Navn <p>Ken Langaas</p>
+      </List.Item>
+      <List.Item>
+        <PhoneIcon fontSize='1.5em' /> Telefon <p>999 99 999</p>
+      </List.Item>
+    </List.Unordered>
+  </Details>
 );
 
 export const Controlled: StoryFn<typeof Details> = () => {


### PR DESCRIPTION
If the u-details element has multiple children the styling gets applied to each.
This happened when using the u-details element directly with current styling.

Better support for the web component version. 