### PR TITLE
chore: document popover polyfll

### DIFF
--- a/.changeset/odd-kings-lead.md
+++ b/.changeset/odd-kings-lead.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+`Tooltip`: add support for [Popover-Polyfill](https://github.com/oddbird/popover-polyfill)

--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ If you want this, add the following to your `tsconfig.json`:
 }
 ```
 
+##### Polyfill
+
+Designsystemet uses [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover). Since this api is still classified as [Baseline: Newly available](https://developer.mozilla.org/en-US/docs/Glossary/Baseline/Compatibility), consider adding the polyfill for this feature.
+* [Popover-Polyfill](https://github.com/oddbird/popover-polyfill)
+
 ### 2. Font
 
 You are free to use any font-family.

--- a/packages/css/src/tooltip.css
+++ b/packages/css/src/tooltip.css
@@ -30,6 +30,11 @@
     opacity: 1;
     visibility: visible;
   }
+  /*for polyfill*/
+  .\:popover-open {
+    opacity: 1;
+    visibility: visible;
+  }
 
   &::before {
     content: '';

--- a/packages/get-started.mdx
+++ b/packages/get-started.mdx
@@ -54,7 +54,12 @@ body {
 
 Dersom du velger å installere fonten på en annen måte, husk å inkludere fontvektene `400`, `500` og `600`.
 
-## 3. Bruk en React-komponent
+## 3. Polyfill
+
+Designsystemet bruker [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover) i enkelte komponenter. Dette apiet er klassifisert som [Baseline: Newly available](https://developer.mozilla.org/en-US/docs/Glossary/Baseline/Compatibility) fra april 2024, da Firefox som siste nettleser la det til. I noen tilfeller kan en oppleve at brukere av ulike grunner er låst til eldre nettleserversjoner, og da kan det være aktuelt å legge til en polyfill for å sikre at `popover` fungerer for alle.
+* [Popover-Polyfill](https://github.com/oddbird/popover-polyfill)
+
+## 4. Bruk en React-komponent
 
 ```jsx
 import '@digdir/designsystemet-theme';

--- a/packages/react/src/components/Popover/Popover.mdx
+++ b/packages/react/src/components/Popover/Popover.mdx
@@ -90,6 +90,12 @@ Når du bruker `popover` uten `Popover.TriggerContext`, kobler du selv sammen ut
 Da brukes `popovertarget` i små bokstaver, slik at alle versjoner av React korrekt gjengir attributtet.
 Når du bruker `@digdir/designsystemet-react` utvider vi `@types/react-dom` til å akseptere dette.
 
+## Polyfill
+
+`Popover` bruker [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover). Dette apiet er klassifisert som [Baseline: Newly available](https://developer.mozilla.org/en-US/docs/Glossary/Baseline/Compatibility) fra april 2024, da Firefox som siste nettleser la det til. I noen tilfeller kan en oppleve at brukere av ulike grunner er låst til eldre nettleserversjoner, og da kan det være aktuelt å legge til en polyfill for å sikre at `Popover` fungerer for alle.
+* [Popover-Polyfill](https://github.com/oddbird/popover-polyfill)
+
+
 ## CSS Variabler
 
 <CssVariables css={css} />

--- a/packages/react/src/components/Tooltip/Tooltip.mdx
+++ b/packages/react/src/components/Tooltip/Tooltip.mdx
@@ -87,3 +87,8 @@ På berøringsskjermer er `tooltip` mindre egnet, fordi de vanligvis aktiveres v
 
 - I Safari fungerer ikke fade-in animasjon.
 - Brukeren kan ikke flytte musepeker inn i `tooltip`
+
+### Polyfill
+
+`Tooltip` bruker [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/popover). Dette apiet er klassifisert som [Baseline: Newly available](https://developer.mozilla.org/en-US/docs/Glossary/Baseline/Compatibility) fra april 2024, da Firefox som siste nettleser la det til. I noen tilfeller kan en oppleve at brukere av ulike grunner er låst til eldre nettleserversjoner, og da kan det være aktuelt å legge til en polyfill for å sikre at `Tooltip` fungerer for alle.
+* [Popover-Polyfill](https://github.com/oddbird/popover-polyfill)


### PR DESCRIPTION
resolves #3444 

also adds support for the polyfill in `tooltip` by adding a selector for the `.\:popover-open` replacement class this uses.