### PR TITLE
fix(theme): add missing default file export

### DIFF
--- a/.changeset/petite-cobras-buy.md
+++ b/.changeset/petite-cobras-buy.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-theme": patch
+---
+
+Fix missing export for default theme file

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -20,7 +20,8 @@
   "files": [
     "brand/**",
     "*.css",
-    "configs/**"
+    "configs/**",
+    "src/themes/**"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Fixes missing default export when importing using just package name.

```js
import '@digdir/designsystemet-theme'
```

Test using https://unpkg.com/@digdir/designsystemet-theme@test