### PR TITLE
fix: update plugin to latest theme colors

### DIFF
--- a/plugins/figma/package.json
+++ b/plugins/figma/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@plugin/figma",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "watch:ui": "npm run build:ui -- --watch --mode=development",

--- a/plugins/figma/package.json
+++ b/plugins/figma/package.json
@@ -4,8 +4,6 @@
   "version": "0.4.0",
   "type": "module",
   "scripts": {
-    "dev": "run-s watch",
-    "watch": "run-p 'watch:*'",
     "watch:ui": "npm run build:ui -- --watch --mode=development",
     "watch:plugin": "npm run build:plugin -- --watch --mode=development",
     "build": "npm run build:plugin && npm run build:ui",

--- a/plugins/figma/package.json
+++ b/plugins/figma/package.json
@@ -16,7 +16,6 @@
     "types:node": "tsc -P tsconfig.node.json"
   },
   "dependencies": {
-    "@adobe/leonardo-contrast-colors": "^1.0.0",
     "@digdir/designsystemet": "workspace:^",
     "@digdir/designsystemet-css": "workspace:^",
     "@digdir/designsystemet-react": "workspace:^",

--- a/plugins/figma/package.json
+++ b/plugins/figma/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@plugin/figma",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "watch:ui": "npm run build:ui -- --watch --mode=development",

--- a/plugins/figma/src/common/dummyTheme.ts
+++ b/plugins/figma/src/common/dummyTheme.ts
@@ -1,25 +1,25 @@
-import type { ColorTheme } from './store';
+import type { ColorInfo, ColorTheme } from './store';
 
 export const getDummyTheme = () => {
   return JSON.parse(JSON.stringify(dummyTheme)) as ColorTheme;
 };
 
-const generateColorSet = () => {
-  const colors: { [key: number]: string } = {};
+const generateColorSet = (): ColorInfo => {
+  const colors = {} as ColorInfo;
   for (let i = 1; i <= 16; i++) {
-    colors[i] = '#000000';
+    colors[i as unknown as keyof ColorInfo] = '#000000';
   }
 
   return colors;
 };
 
-const dummyTheme = {
-  primary: {
+const dummyTheme: ColorTheme = {
+  brand1: {
     light: generateColorSet(),
     dark: generateColorSet(),
     contrast: generateColorSet(),
   },
-  accent: {
+  brand2: {
     light: generateColorSet(),
     dark: generateColorSet(),
     contrast: generateColorSet(),
@@ -29,12 +29,12 @@ const dummyTheme = {
     dark: generateColorSet(),
     contrast: generateColorSet(),
   },
-  extra1: {
+  brand3: {
     light: generateColorSet(),
     dark: generateColorSet(),
     contrast: generateColorSet(),
   },
-  extra2: {
+  accent: {
     light: generateColorSet(),
     dark: generateColorSet(),
     contrast: generateColorSet(),

--- a/plugins/figma/src/common/store.ts
+++ b/plugins/figma/src/common/store.ts
@@ -1,8 +1,6 @@
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
 
-import type { FigmaModeName } from './types';
-
 export type ColorInfo = {
   [key in ColorIndex]: string;
 };
@@ -37,22 +35,15 @@ export type StoreTheme = {
 export type ColorTheme = {
   accent: ThemeInfo;
   neutral: ThemeInfo;
-  primary: ThemeInfo;
-  extra1: ThemeInfo;
-  extra2: ThemeInfo;
+  brand1: ThemeInfo;
+  brand2: ThemeInfo;
+  brand3: ThemeInfo;
 };
 
 export type ThemeInfo = {
   light: ColorInfo;
   dark: ColorInfo;
   contrast?: ColorInfo;
-};
-
-export type StoreThemeModes = {
-  name: string;
-  id: string;
-  prefix: FigmaModeName;
-  colors: { brand1Base: string; brand2Base: string; brand3Base: string };
 };
 
 type ColorStore = {

--- a/plugins/figma/src/common/types.ts
+++ b/plugins/figma/src/common/types.ts
@@ -1,16 +1,3 @@
-export type JsonInput = {
-  theme: {
-    accent: object;
-    neutral: object;
-    brand1: object;
-    brand2: object;
-    brand3: object;
-  };
-};
-
-export type FigmaModeName = 'theme' | 'theme2' | 'theme3' | 'theme4';
-export type ThemeColors = 'accent' | 'neutral' | 'brand1' | 'brand2' | 'brand3';
-
 export enum Messages {
   GetThemes = 'getThemes',
   GetThemesAndRedirect = 'getThemesAndRedirect',

--- a/plugins/figma/src/plugin/figma/updateVariables.ts
+++ b/plugins/figma/src/plugin/figma/updateVariables.ts
@@ -1,7 +1,6 @@
 import { hexToRgb, rgbToHex } from '@digdir/designsystemet/color';
 
 import type { ColorIndex, ColorTheme, StoreThemes } from '../../common/store';
-import type { FigmaModeName, ThemeColors } from '../../common/types';
 
 const updateColors = (
   themes: StoreThemes,
@@ -12,8 +11,8 @@ const updateColors = (
   themeCollection: VariableCollection,
   variables: Variable[],
 ) => {
-  const themeName = variable.name.split('/')[0] as FigmaModeName;
-  const themeType = variable.name.split('/')[1] as ThemeColors;
+  const themeName = variable.name.split('/')[0];
+  const themeType = variable.name.split('/')[1];
   const themeIndex = variable.name.split('/')[2] as ColorIndex;
   if (
     variable.variableCollectionId === modeCollection.id &&

--- a/plugins/figma/src/plugin/plugin.ts
+++ b/plugins/figma/src/plugin/plugin.ts
@@ -5,7 +5,7 @@ import { getVariables } from './figma/getVariables';
 import { getThemes } from './figma/themes';
 import { updateVariables } from './figma/updateVariables';
 
-figma.showUI(__html__, { width: 710, height: 650, themeColors: true });
+figma.showUI(__html__, { width: 710, height: 710, themeColors: true });
 
 figma.ui.onmessage = (msg: {
   type: Messages;

--- a/plugins/figma/src/plugin/plugin.ts
+++ b/plugins/figma/src/plugin/plugin.ts
@@ -5,7 +5,7 @@ import { getVariables } from './figma/getVariables';
 import { getThemes } from './figma/themes';
 import { updateVariables } from './figma/updateVariables';
 
-figma.showUI(__html__, { width: 710, height: 550, themeColors: true });
+figma.showUI(__html__, { width: 710, height: 650, themeColors: true });
 
 figma.ui.onmessage = (msg: {
   type: Messages;

--- a/plugins/figma/src/ui/pages/Theme/Theme.tsx
+++ b/plugins/figma/src/ui/pages/Theme/Theme.tsx
@@ -167,7 +167,7 @@ function Theme() {
           <Link href='https://theme.designsystemet.no/' target='_blank'>
             Temabyggeren
           </Link>{' '}
-          for å lage deg et tema og lim inn kodensnutten fra steg 1 i feltet
+          for å lage deg et tema, lim inn kodensnutten fra steg 1 i feltet
           under.
         </Paragraph>
         <Alert>

--- a/plugins/figma/src/ui/pages/Theme/Theme.tsx
+++ b/plugins/figma/src/ui/pages/Theme/Theme.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   Breadcrumbs,
   Button,
   Label,
@@ -46,42 +47,36 @@ function Theme() {
   });
 
   const handleClick = () => {
-    // split input into lines
     const lines = command.split('\\\n');
-
-    // helper regex for extracting color info
     const colorRegex = /"([^:]+):(#\w{6})"/g;
 
-    const result: {
-      mainColors: { name: string; hex: CssColor }[];
-      neutralColor: CssColor | null;
-      supportColors: { name: string; hex: CssColor }[];
-    } = {
-      mainColors: [],
-      neutralColor: null,
-      supportColors: [],
-    };
+    let colors: { name: string; hex: CssColor }[] = [];
 
     for (const line of lines) {
-      if (line.includes(`--${colorCliOptions.main}`)) {
+      if (
+        line.includes(`--${colorCliOptions.main}`) ||
+        line.includes(`--${colorCliOptions.support}`)
+      ) {
         const matches = [...line.matchAll(colorRegex)];
-        result.mainColors = matches.map((match) => ({
-          name: match[1],
-          hex: match[2] as CssColor,
-        }));
-      } else if (line.includes(`--${colorCliOptions.neutral}`)) {
+        if (matches.length > 0) {
+          colors = colors.concat(
+            matches.map((match) => ({
+              name: match[1],
+              hex: match[2] as CssColor,
+            })),
+          );
+        }
+      }
+      if (line.includes(`--${colorCliOptions.neutral}`)) {
         const match = line.match(/#\w{6}/);
-        if (match) result.neutralColor = match[0] as CssColor;
-      } else if (line.includes(`--${colorCliOptions.support}`)) {
-        const matches = [...line.matchAll(colorRegex)];
-        result.supportColors = matches.map((match) => ({
-          name: match[1],
-          hex: match[2] as CssColor,
-        }));
+        if (match)
+          colors = colors.concat([
+            { name: 'neutral', hex: match[0] as CssColor },
+          ]);
       }
     }
 
-    if (!result.mainColors.length || !result.neutralColor) {
+    if (!colors.length) {
       console.log('No match');
       setCodeSnippetError(
         'Koden du limte inn er ikke gyldig. Prøv å lim inn på nytt.',
@@ -91,22 +86,13 @@ function Theme() {
 
     /* For now we check that we have  accent, brand1, brand2, brand3 */
 
-    const accent = result.mainColors.find(
-      (color) => color.name === 'accent',
-    )?.hex;
-    const brand1 = result.supportColors.find(
-      (color) => color.name === 'brand1',
-    )?.hex;
-    const brand2 = result.supportColors.find(
-      (color) => color.name === 'brand2',
-    )?.hex;
-    const brand3 = result.supportColors.find(
-      (color) => color.name === 'brand3',
-    )?.hex;
+    const accent = colors.find((color) => color.name === 'accent')?.hex;
+    const brand1 = colors.find((color) => color.name === 'brand1')?.hex;
+    const brand2 = colors.find((color) => color.name === 'brand2')?.hex;
+    const brand3 = colors.find((color) => color.name === 'brand3')?.hex;
+    const neutral = colors.find((color) => color.name === 'neutral')?.hex;
 
-    const neutral = result.neutralColor;
-
-    if (!accent || !brand1 || !brand2 || !brand3) {
+    if (!accent || !brand1 || !brand2 || !brand3 || !neutral) {
       setCodeSnippetError(
         'I denne versjonen av pluginen må du ha fargene  accent, brand1, brand2, brand3, i koden du limer inn. Prøv å lim inn på nytt.',
       );
@@ -163,15 +149,21 @@ function Theme() {
         </div>
       </div>
       <div className={classes.wrapper}>
+        <Paragraph>
+          Dette verktøyet lar deg oppdatere fargene i teamet ditt for enkel
+          testing.
+        </Paragraph>
         <Paragraph variant='long'>
           Gå til{' '}
           <Link href='https://theme.designsystemet.no/' target='_blank'>
             Temabyggeren
           </Link>{' '}
-          for å lage deg et tema og lim inn koden i feltet under. Det er kun
-          fargene som blir oppdatert for øyeblikket. Vi jobber med å utvide
-          pluginen med mer funksjonalitet senere.
+          for å lage deg et tema og lim inn kodensnutten fra steg 1 i feltet
+          under.
         </Paragraph>
+        <Alert>
+          Fargene må ha navnene; accent, neutral, brand1, brand2 og brand3.
+        </Alert>
         <Label htmlFor='my-textarea'>Kodesnutt fra temabyggeren</Label>
         <Textarea
           value={command}

--- a/plugins/figma/src/ui/pages/Theme/Theme.tsx
+++ b/plugins/figma/src/ui/pages/Theme/Theme.tsx
@@ -103,7 +103,7 @@ function Theme() {
         .filter(Boolean)
         .join(', ');
       setCodeSnippetError(
-        `I denne versjonen av pluginen må du ha bestemte fargenavn. Det mangler: ${missingColors}, i kodensnutten du limer inn.`,
+        `I denne versjonen av pluginen må du ha bestemte fargenavn. Det mangler: ${missingColors}, i kodensnutten.`,
       );
       return;
     }

--- a/plugins/figma/src/ui/pages/Theme/Theme.tsx
+++ b/plugins/figma/src/ui/pages/Theme/Theme.tsx
@@ -93,8 +93,17 @@ function Theme() {
     const neutral = colors.find((color) => color.name === 'neutral')?.hex;
 
     if (!accent || !brand1 || !brand2 || !brand3 || !neutral) {
+      const missingColors = [
+        !accent && 'accent',
+        !brand1 && 'brand1',
+        !brand2 && 'brand2',
+        !brand3 && 'brand3',
+        !neutral && 'neutral',
+      ]
+        .filter(Boolean)
+        .join(', ');
       setCodeSnippetError(
-        'I denne versjonen av pluginen må du ha fargene  accent, brand1, brand2, brand3, i koden du limer inn. Prøv å lim inn på nytt.',
+        `I denne versjonen av pluginen må du ha bestemte fargenavn. Det mangler: ${missingColors}, i kodensnutten du limer inn.`,
       );
       return;
     }

--- a/plugins/figma/src/ui/pages/Theme/Theme.tsx
+++ b/plugins/figma/src/ui/pages/Theme/Theme.tsx
@@ -89,31 +89,32 @@ function Theme() {
       return;
     }
 
-    /* For now we check that we have primary, accent, extra1, extra2 */
-    const primary = result.mainColors.find(
-      (color) => color.name === 'primary',
-    )?.hex;
+    /* For now we check that we have  accent, brand1, brand2, brand3 */
+
     const accent = result.mainColors.find(
       (color) => color.name === 'accent',
     )?.hex;
-    const extra1 = result.supportColors.find(
-      (color) => color.name === 'extra1',
+    const brand1 = result.supportColors.find(
+      (color) => color.name === 'brand1',
     )?.hex;
-    const extra2 = result.supportColors.find(
-      (color) => color.name === 'extra2',
+    const brand2 = result.supportColors.find(
+      (color) => color.name === 'brand2',
+    )?.hex;
+    const brand3 = result.mainColors.find(
+      (color) => color.name === 'brand3',
     )?.hex;
 
     const neutral = result.neutralColor;
 
-    if (!primary || !accent || !extra1 || !extra2) {
+    if (!brand3 || !accent || !brand1 || !brand2) {
       setCodeSnippetError(
-        'I denne versjonen av pluginen må du ha fargene primary, accent, extra1 og extra2',
+        'I denne versjonen av pluginen må du ha fargene  accent, brand1, brand2, brand3, i koden du limer inn. Prøv å lim inn på nytt.',
       );
       return;
     }
 
     console.log(
-      `Primary: ${primary}, Accent: ${accent}, Neutral: ${neutral}, Extra1: ${extra1}, Extra2: ${extra2}`,
+      `Primary: ${brand3}, Accent: ${accent}, Neutral: ${neutral}, Brand1: ${brand1}, Brand2: ${brand2}, Brand3: ${brand3}`,
     );
 
     const newArray = Array.from(themes);
@@ -122,10 +123,10 @@ function Theme() {
       colors: {
         ...newArray[themeIndex].colors,
         accent: themeToFigmaFormat(generateColorSchemes(accent)),
-        primary: themeToFigmaFormat(generateColorSchemes(primary)),
         neutral: themeToFigmaFormat(generateColorSchemes(neutral)),
-        extra1: themeToFigmaFormat(generateColorSchemes(extra1)),
-        extra2: themeToFigmaFormat(generateColorSchemes(extra2)),
+        brand1: themeToFigmaFormat(generateColorSchemes(brand1)),
+        brand2: themeToFigmaFormat(generateColorSchemes(brand2)),
+        brand3: themeToFigmaFormat(generateColorSchemes(brand3)),
       },
     };
 

--- a/plugins/figma/src/ui/pages/Theme/Theme.tsx
+++ b/plugins/figma/src/ui/pages/Theme/Theme.tsx
@@ -79,7 +79,7 @@ function Theme() {
     if (!colors.length) {
       console.log('No match');
       setCodeSnippetError(
-        'Koden du limte inn er ikke gyldig. Prøv å lim inn på nytt.',
+        'Kodesnutten du limte inn er ikke gyldig. Prøv på nytt.',
       );
       return;
     }

--- a/plugins/figma/src/ui/pages/Theme/Theme.tsx
+++ b/plugins/figma/src/ui/pages/Theme/Theme.tsx
@@ -100,13 +100,13 @@ function Theme() {
     const brand2 = result.supportColors.find(
       (color) => color.name === 'brand2',
     )?.hex;
-    const brand3 = result.mainColors.find(
+    const brand3 = result.supportColors.find(
       (color) => color.name === 'brand3',
     )?.hex;
 
     const neutral = result.neutralColor;
 
-    if (!brand3 || !accent || !brand1 || !brand2) {
+    if (!accent || !brand1 || !brand2 || !brand3) {
       setCodeSnippetError(
         'I denne versjonen av pluginen må du ha fargene  accent, brand1, brand2, brand3, i koden du limer inn. Prøv å lim inn på nytt.',
       );
@@ -114,7 +114,7 @@ function Theme() {
     }
 
     console.log(
-      `Primary: ${brand3}, Accent: ${accent}, Neutral: ${neutral}, Brand1: ${brand1}, Brand2: ${brand2}, Brand3: ${brand3}`,
+      `Accent: ${accent}, Neutral: ${neutral}, Brand1: ${brand1}, Brand2: ${brand2}, Brand3: ${brand3}`,
     );
 
     const newArray = Array.from(themes);

--- a/plugins/figma/src/ui/pages/Theme/Theme.tsx
+++ b/plugins/figma/src/ui/pages/Theme/Theme.tsx
@@ -103,7 +103,7 @@ function Theme() {
         .filter(Boolean)
         .join(', ');
       setCodeSnippetError(
-        `I denne versjonen av pluginen må du ha bestemte fargenavn. Det mangler: ${missingColors}, i kodensnutten.`,
+        `I denne versjonen av pluginen må du ha bestemte fargenavn. Det mangler: ${missingColors}, i kodesnutten.`,
       );
       return;
     }

--- a/plugins/figma/src/ui/pages/Themes/Themes.tsx
+++ b/plugins/figma/src/ui/pages/Themes/Themes.tsx
@@ -31,8 +31,8 @@ function Themes() {
               url={`/themes/${theme.themeModeId}`}
               colors={{
                 colorDot1: theme.colors.accent.light?.[12] ?? '',
-                colorDot2: theme.colors.extra1.light?.[12] ?? '',
-                colorDot3: theme.colors.extra2.light?.[12] ?? '',
+                colorDot2: theme.colors.brand1.light?.[12] ?? '',
+                colorDot3: theme.colors.brand2.light?.[12] ?? '',
               }}
             />
           );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -745,9 +745,6 @@ importers:
 
   plugins/figma:
     dependencies:
-      '@adobe/leonardo-contrast-colors':
-        specifier: ^1.0.0
-        version: 1.0.0
       '@digdir/designsystemet':
         specifier: workspace:^
         version: link:../../packages/cli
@@ -820,9 +817,6 @@ packages:
 
   '@adobe/css-tools@4.4.2':
     resolution: {integrity: sha512-baYZExFpsdkBNuvGKTKWCwKH57HRZLVtycZS05WTQNVOiXVSeAki3nU35zlRbToeMW8aHlJfyS+1C4BOv27q0A==}
-
-  '@adobe/leonardo-contrast-colors@1.0.0':
-    resolution: {integrity: sha512-a4mD0JZ1zNu2wIem/vWJqdaiuQZgxwOph/gpHA75mlXcs6iiIQx9G+W0jtssRFgdYYAi/ceQYOlYwiSQj1AUCw==}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -2874,9 +2868,6 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
-  chroma-js@2.6.0:
-    resolution: {integrity: sha512-BLHvCB9s8Z1EV4ethr6xnkl/P2YRFOGqfgvuMG/MyCbZPrTA+NeiByY6XvgF0zP4/2deU2CXnWyMa3zu1LqQ3A==}
-
   chroma-js@3.1.2:
     resolution: {integrity: sha512-IJnETTalXbsLx1eKEgx19d5L6SRM7cH4vINw/99p/M11HCuXGRWL+6YmCm7FWFGIo6dtWuQoQi1dc5yQ7ESIHg==}
 
@@ -2895,12 +2886,6 @@ packages:
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
-
-  ciebase@0.1.1:
-    resolution: {integrity: sha512-KEnf/WVT5E+Gn+LsfMHGJFATltSOeW0qm7dpzQYL/Qe5PEpyTM+UI5bMoBo16FE81zMpu+U6032USTP6Cz1XNA==}
-
-  ciecam02@0.4.6:
-    resolution: {integrity: sha512-nh/Kl8s5lgtyEl7lA381JFinLhgUwDhJaAVgbVx2BaiiJIzJLumQvuFXwdS76tSch7jDjWejP+MtKYCCEk/brg==}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
@@ -3678,9 +3663,6 @@ packages:
     resolution: {integrity: sha512-HVJyzUrLIL1c0QmviVh5E8VGyUS7xCFPS6yydaVd1UegW+ibV/CohqTH9MkOLDp5o+rb82DMo77PTuc9F/8GKw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  hsluv@0.1.0:
-    resolution: {integrity: sha512-ERcanKLAszD2XN3Vh5r5Szkrv9q0oSTudmP0rkiKAGM/3NMc9FLmMZBB7TSqTaXJfSDBOreYTfjezCOYbRKqlw==}
-
   hsluv@1.0.1:
     resolution: {integrity: sha512-zCaFTiDqBLQjCCFBu0qg7z9ASYPd+Bxx2GDCVZJsnehjK80S+jByqhuFz0pCd2Aw3FSKr18AWbRlwnKR0YdizQ==}
 
@@ -4440,9 +4422,6 @@ packages:
   morgan@1.10.0:
     resolution: {integrity: sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==}
     engines: {node: '>= 0.8.0'}
-
-  mout@0.11.1:
-    resolution: {integrity: sha512-pK9VNiLE3QgGBrC/3ICAscwOLU7oTNeK2l32uqNAioBYtB2tQAfSsGDNChUlk7CP23126mc5lUt6+na9FlN8JA==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -6284,14 +6263,6 @@ snapshots:
   '@adobe/css-tools@4.3.3': {}
 
   '@adobe/css-tools@4.4.2': {}
-
-  '@adobe/leonardo-contrast-colors@1.0.0':
-    dependencies:
-      apca-w3: 0.1.9
-      chroma-js: 2.6.0
-      ciebase: 0.1.1
-      ciecam02: 0.4.6
-      hsluv: 0.1.0
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -8509,22 +8480,11 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
-  chroma-js@2.6.0: {}
-
   chroma-js@3.1.2: {}
 
   chromatic@11.29.0: {}
 
   ci-info@3.9.0: {}
-
-  ciebase@0.1.1:
-    dependencies:
-      mout: 0.11.1
-
-  ciecam02@0.4.6:
-    dependencies:
-      ciebase: 0.1.1
-      mout: 0.11.1
 
   client-only@0.0.1: {}
 
@@ -9402,8 +9362,6 @@ snapshots:
   hosted-git-info@6.1.3:
     dependencies:
       lru-cache: 7.18.3
-
-  hsluv@0.1.0: {}
 
   hsluv@1.0.1: {}
 
@@ -10406,8 +10364,6 @@ snapshots:
       on-headers: 1.0.2
     transitivePeerDependencies:
       - supports-color
-
-  mout@0.11.1: {}
 
   mri@1.2.0: {}
 


### PR DESCRIPTION
Hotfix to update to new default theme color names and feedback.

- Changed hardcoded color names to match new default theme. Will update this to actually pick colors from default theme in a separate PR.
- Updated error message to show which required colors are missing in pasted snippet.
- Updated wording and info box about required colors.

<img width="719" alt="image" src="https://github.com/user-attachments/assets/8e74d8ce-8e15-4bf9-ab0c-ab7c9c7b8da2" />

<img width="721" alt="image" src="https://github.com/user-attachments/assets/9d4812e4-2bdb-4b75-99ab-81cc4a724aad" />

