### PR TITLE
fix(themebuilder): can format code for windows cmd

### DIFF
--- a/apps/themebuilder/app/_components/token-modal/token-modal.tsx
+++ b/apps/themebuilder/app/_components/token-modal/token-modal.tsx
@@ -6,6 +6,7 @@ import {
   Input,
   Link,
   Paragraph,
+  Switch,
 } from '@digdir/designsystemet-react';
 import {
   type CreateTokensOptions,
@@ -41,6 +42,9 @@ export const TokenModal = () => {
 
   const [themeName, setThemeName] = useState('theme');
   const [themeCSS, setThemeCSS] = useState('');
+  const [formatWin, setFormatWin] = useState(
+    navigator.userAgent.includes('Windows'),
+  );
 
   const setCliColors = (colorTheme: ColorTheme[]) => {
     if (!colorTheme.length) return '';
@@ -57,6 +61,7 @@ export const TokenModal = () => {
 
   const packageWithTag = `@digdir/designsystemet${isProduction ? '@latest' : '@next'}`;
   const buildSnippet = `npx ${packageWithTag} tokens build`;
+  const seperator = formatWin ? ' ^\n' : ' \\\n';
 
   const cliSnippet = [
     `npx ${packageWithTag} tokens create`,
@@ -67,7 +72,7 @@ export const TokenModal = () => {
     `--theme "${themeName}"`,
   ]
     .filter(Boolean)
-    .join(' \\\n');
+    .join(seperator);
 
   const theme: CreateTokensOptions = {
     name: themeName,
@@ -198,6 +203,14 @@ export const TokenModal = () => {
               </div>
               <div className={classes.snippet}>
                 <CodeBlock language='bash'>{cliSnippet}</CodeBlock>
+                <Switch
+                  style={{ marginBlockEnd: 'var(--ds-size-4)' }}
+                  label={t('themeModal.format')}
+                  checked={formatWin}
+                  onChange={(e) => {
+                    setFormatWin(e.currentTarget.checked);
+                  }}
+                />
               </div>
               <div
                 className={classes.step}

--- a/apps/themebuilder/app/locales/en.ts
+++ b/apps/themebuilder/app/locales/en.ts
@@ -118,6 +118,7 @@ export default {
       'to update a theme directly in Figma. Read more about these options on',
     'own-theme': 'your own theme (opens in new tab)',
     page: 'page.',
+    format: 'Formatted for Windows',
     'step-two': 'Run the code snippet to generate CSS variables for code.',
     'help-heading': 'Something not working?',
     'help-description': 'Send us a message on',

--- a/apps/themebuilder/app/locales/no.ts
+++ b/apps/themebuilder/app/locales/no.ts
@@ -116,6 +116,7 @@ export default {
       'for å oppdatere et tema direkte i Figma. Les mer om disse alternativene på',
     'own-theme': 'eget tema (åpnes i ny fane)',
     page: 'siden.',
+    format: 'Formatert for Windows',
     'step-two': 'Kjør kodesnutten for å generere CSS variabler til kode.',
     'help-heading': 'Noe som ikke fungerer?',
     'help-description': 'Send oss en melding på',


### PR DESCRIPTION
resolves #3449 

I added a switch to toggle windows formatting. The placement of the switch is up for debate. 

<img width="1005" alt="bilde" src="https://github.com/user-attachments/assets/0ace4d70-ef87-4825-b6f5-52226f0e0fb1" />
