### PR TITLE
chore(tooltip): stays open when mouse is inside

### DIFF
--- a/.changeset/nasty-owls-pay.md
+++ b/.changeset/nasty-owls-pay.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+**Tooltip**: Will now stay open when mouse is moved to the `Tooltip`

--- a/packages/css/src/tooltip.css
+++ b/packages/css/src/tooltip.css
@@ -54,12 +54,39 @@
     content: '';
     background: transparent;
     box-sizing: border-box;
-    height: calc(var(--dsc-tooltip-arrow-size));
+    height: var(--dsc-tooltip-arrow-size);
     width: 100%;
     position: absolute;
     left: var(--dsc-tooltip-arrow-x, 50%);
     top: var(--dsc-tooltip-arrow-y, 100%);
-    translate: -50% 0;
+  }
+
+  &[data-placement='top'] {
+    &::after {
+      translate: -50% 0%;
+    }
+  }
+
+  &[data-placement='bottom'] {
+    &::after {
+      translate: -50% -100%;
+    }
+  }
+
+  &[data-placement='right'] {
+    &::after {
+      height: 100%;
+      width: var(--dsc-tooltip-arrow-size);
+      translate: -100% -50%;
+    }
+  }
+
+  &[data-placement='left'] {
+    &::after {
+      height: 100%;
+      width: var(--dsc-tooltip-arrow-size);
+      translate: 0 -50%;
+    }
   }
 
   @media (forced-colors: active) {

--- a/packages/css/src/tooltip.css
+++ b/packages/css/src/tooltip.css
@@ -54,39 +54,12 @@
     content: '';
     background: transparent;
     box-sizing: border-box;
-    height: var(--dsc-tooltip-arrow-size);
-    width: 100%;
+    height: var(--_dsc-tooltip-safearea-height, 0px);
+    width: var(--_dsc-tooltip-safearea-width, 0px);
+    translate: var(--_dsc-tooltip-safearea-translate);
     position: absolute;
     left: var(--dsc-tooltip-arrow-x, 50%);
     top: var(--dsc-tooltip-arrow-y, 100%);
-  }
-
-  &[data-placement='top'] {
-    &::after {
-      translate: -50% 0%;
-    }
-  }
-
-  &[data-placement='bottom'] {
-    &::after {
-      translate: -50% -100%;
-    }
-  }
-
-  &[data-placement='right'] {
-    &::after {
-      height: 100%;
-      width: var(--dsc-tooltip-arrow-size);
-      translate: -100% -50%;
-    }
-  }
-
-  &[data-placement='left'] {
-    &::after {
-      height: 100%;
-      width: var(--dsc-tooltip-arrow-size);
-      translate: 0 -50%;
-    }
   }
 
   @media (forced-colors: active) {

--- a/packages/css/src/tooltip.css
+++ b/packages/css/src/tooltip.css
@@ -49,6 +49,7 @@
     rotate: 45deg;
   }
 
+  /* Transparent box to make tooltip stay open when mouse is over it */
   &::after {
     content: '';
     background: transparent;

--- a/packages/css/src/tooltip.css
+++ b/packages/css/src/tooltip.css
@@ -49,6 +49,18 @@
     rotate: 45deg;
   }
 
+  &::after {
+    content: '';
+    background: transparent;
+    box-sizing: border-box;
+    height: calc(var(--dsc-tooltip-arrow-size));
+    width: 100%;
+    position: absolute;
+    left: var(--dsc-tooltip-arrow-x, 50%);
+    top: var(--dsc-tooltip-arrow-y, 100%);
+    translate: -50% 0;
+  }
+
   @media (forced-colors: active) {
     background: CanvasText;
   }

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -188,6 +188,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
           className={cl('ds-tooltip', className)}
           id={id ?? randomTooltipId}
           popover='manual'
+          data-placement={placement}
           {...rest}
         >
           {content}

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -126,6 +126,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
                 : []),
               shift(),
               arrowPseudoElement,
+              safeAreaElement,
             ],
           }).then(({ x, y }) => {
             tooltip.style.translate = `${x}px ${y}px`;
@@ -227,7 +228,47 @@ const arrowPseudoElement = {
 
     elements.floating.style.setProperty('--dsc-tooltip-arrow-x', arrowX);
     elements.floating.style.setProperty('--dsc-tooltip-arrow-y', arrowY);
-    elements.floating.setAttribute('data-placement', placement);
+    return data;
+  },
+};
+
+const safeAreaElement = {
+  name: 'SafeAreaElement',
+  fn(data: MiddlewareState) {
+    const { elements, placement } = data;
+
+    let width = '100%';
+    let height = 'var(--dsc-tooltip-arrow-size)';
+    let translate = '0px';
+
+    switch (placement) {
+      case 'top':
+        translate = `-50% 0%`;
+        break;
+      case 'right':
+        height = '100%';
+        width = 'var(--dsc-tooltip-arrow-size)';
+        translate = '-100% -50%';
+        break;
+      case 'bottom':
+        translate = '-50% -100%';
+        break;
+      case 'left':
+        height = '100%';
+        width = 'var(--dsc-tooltip-arrow-size)';
+        translate = '0 -50%';
+        break;
+    }
+
+    elements.floating.style.setProperty(
+      '--_dsc-tooltip-safearea-height',
+      height,
+    );
+    elements.floating.style.setProperty('--_dsc-tooltip-safearea-width', width);
+    elements.floating.style.setProperty(
+      '--_dsc-tooltip-safearea-translate',
+      translate,
+    );
     return data;
   },
 };

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -227,6 +227,7 @@ const arrowPseudoElement = {
 
     elements.floating.style.setProperty('--dsc-tooltip-arrow-x', arrowX);
     elements.floating.style.setProperty('--dsc-tooltip-arrow-y', arrowY);
+    elements.floating.setAttribute('data-placement', placement);
     return data;
   },
 };

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -181,6 +181,8 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
           {children}
         </ChildContainer>
         <span
+          onMouseEnter={setOpen}
+          onMouseLeave={setClose}
           ref={mergedRefs}
           role='tooltip'
           className={cl('ds-tooltip', className)}

--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -189,7 +189,6 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
           className={cl('ds-tooltip', className)}
           id={id ?? randomTooltipId}
           popover='manual'
-          data-placement={placement}
           {...rest}
         >
           {content}


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

resolves #2941

This is fixed by just adding a transparent (in the picture red) `::after` element, and then adding the same mouse listeners to the tooltip.
![image](https://github.com/user-attachments/assets/4d196bad-8554-485d-8f7f-3b57e201444b)


## Checks

- [ ] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
