### PR TITLE
fix: codeblock -  tiny fontsize in storybook

### DIFF
--- a/internal/components/src/code-block/code-block.module.css
+++ b/internal/components/src/code-block/code-block.module.css
@@ -5,13 +5,15 @@
   padding: var(--ds-size-5);
   border-top-left-radius: var(--ds-border-radius-md);
   height: fit-content;
-  font-size: min(0.8em, 14px);
   background-color: var(--ds-color-neutral-background-tinted);
   font-family: monospace;
   margin-bottom: 0;
 
   & [class~='plain-text'] {
     color: var(--ds-color-neutral-text-default);
+  }
+  code {
+    font-size: min(0.8em, 14px);
   }
 }
 


### PR DESCRIPTION
storybook has 0.8em font-size set directly on `code` so with codeblock having 0.8em on the parent it became tiny
