### PR TITLE
fix(cli): zod schema error when creating tokens from config file

### DIFF
--- a/.changeset/clean-seals-shake.md
+++ b/.changeset/clean-seals-shake.md
@@ -2,4 +2,4 @@
 "@digdir/designsystemet": patch
 ---
 
-fix(cli): zod schema error when creating tokens from config file
+Fix zod schema error when creating tokens from config file

--- a/.changeset/clean-seals-shake.md
+++ b/.changeset/clean-seals-shake.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet": patch
+---
+
+fix(cli): zod schema error when creating tokens from config file

--- a/packages/cli/bin/config.ts
+++ b/packages/cli/bin/config.ts
@@ -40,11 +40,7 @@ export async function parseCreateConfig(
 ): Promise<CreateConfigSchema> {
   const { cmd, theme = 'theme', configPath } = options;
 
-  const configParsed: CreateConfigSchema = parseConfig<CreateConfigSchema>(
-    configFileCreateSchema,
-    configFile,
-    configPath,
-  );
+  const configParsed: CreateConfigSchema = parseConfig<CreateConfigSchema>(configFile, configPath);
 
   /*
    * Check that we're not creating multiple themes with different color names.
@@ -112,7 +108,7 @@ export async function parseBuildConfig(
   configFile: string,
   { configPath }: { configPath: string },
 ): Promise<BuildConfigSchema> {
-  const configParsed: BuildConfigSchema = parseConfig<BuildConfigSchema>(commonConfig, configFile, configPath);
+  const configParsed: BuildConfigSchema = parseConfig<BuildConfigSchema>(configFile, configPath);
 
   return validateConfig<BuildConfigSchema>(commonConfig, configParsed, configPath);
 }

--- a/packages/cli/bin/config.ts
+++ b/packages/cli/bin/config.ts
@@ -6,7 +6,7 @@ import {
   type ConfigSchema,
   type ConfigSchemaBuild,
   type ConfigSchemaCreate,
-  configFileBuildSchema,
+  commonConfig,
   configFileCreateSchema,
   parseConfig,
   validateConfig,
@@ -109,7 +109,7 @@ export async function parseBuildConfig(
   configFile: string,
   { configPath }: { configPath: string },
 ): Promise<ConfigSchemaBuild> {
-  const configParsed: ConfigSchemaBuild = parseConfig<ConfigSchemaBuild>(configFileBuildSchema, configFile, configPath);
+  const configParsed: ConfigSchemaBuild = parseConfig<ConfigSchemaBuild>(commonConfig, configFile, configPath);
 
-  return validateConfig<ConfigSchemaBuild>(configFileBuildSchema, configParsed, configPath);
+  return validateConfig<ConfigSchemaBuild>(commonConfig, configParsed, configPath);
 }

--- a/packages/cli/bin/config.ts
+++ b/packages/cli/bin/config.ts
@@ -3,6 +3,7 @@ import type { Command, OptionValues } from '@commander-js/extra-typings';
 import chalk from 'chalk';
 import * as R from 'ramda';
 import {
+  type ConfigSchema,
   type ConfigSchemaBuild,
   type ConfigSchemaCreate,
   configFileBuildSchema,
@@ -37,14 +38,10 @@ export async function readConfigFile(configPath: string, allowFileNotFound = tru
 export async function parseCreateConfig(
   configFile: string,
   options: { theme: string; cmd: Command<unknown[], OptionValues>; configPath: string },
-): Promise<ConfigSchemaCreate> {
+): Promise<ConfigSchema> {
   const { cmd, theme = 'theme', configPath } = options;
 
-  const configParsed: ConfigSchemaCreate = parseConfig<ConfigSchemaCreate>(
-    configFileCreateSchema,
-    configFile,
-    configPath,
-  );
+  const configParsed: ConfigSchema = parseConfig<ConfigSchema>(configFileCreateSchema, configFile, configPath);
 
   /*
    * Check that we're not creating multiple themes with different color names.

--- a/packages/cli/bin/config.ts
+++ b/packages/cli/bin/config.ts
@@ -3,9 +3,8 @@ import type { Command, OptionValues } from '@commander-js/extra-typings';
 import chalk from 'chalk';
 import * as R from 'ramda';
 import {
-  type ConfigSchema,
-  type ConfigSchemaBuild,
-  type ConfigSchemaCreate,
+  type BuildConfigSchema,
+  type CreateConfigSchema,
   commonConfig,
   configFileCreateSchema,
   parseConfig,
@@ -38,10 +37,14 @@ export async function readConfigFile(configPath: string, allowFileNotFound = tru
 export async function parseCreateConfig(
   configFile: string,
   options: { theme: string; cmd: Command<unknown[], OptionValues>; configPath: string },
-): Promise<ConfigSchema> {
+): Promise<CreateConfigSchema> {
   const { cmd, theme = 'theme', configPath } = options;
 
-  const configParsed: ConfigSchema = parseConfig<ConfigSchema>(configFileCreateSchema, configFile, configPath);
+  const configParsed: CreateConfigSchema = parseConfig<CreateConfigSchema>(
+    configFileCreateSchema,
+    configFile,
+    configPath,
+  );
 
   /*
    * Check that we're not creating multiple themes with different color names.
@@ -102,14 +105,14 @@ export async function parseCreateConfig(
         },
   });
 
-  return validateConfig<ConfigSchemaCreate>(configFileCreateSchema, unvalidatedConfig, configPath);
+  return validateConfig<CreateConfigSchema>(configFileCreateSchema, unvalidatedConfig, configPath);
 }
 
 export async function parseBuildConfig(
   configFile: string,
   { configPath }: { configPath: string },
-): Promise<ConfigSchemaBuild> {
-  const configParsed: ConfigSchemaBuild = parseConfig<ConfigSchemaBuild>(commonConfig, configFile, configPath);
+): Promise<BuildConfigSchema> {
+  const configParsed: BuildConfigSchema = parseConfig<BuildConfigSchema>(commonConfig, configFile, configPath);
 
-  return validateConfig<ConfigSchemaBuild>(commonConfig, configParsed, configPath);
+  return validateConfig<BuildConfigSchema>(commonConfig, configParsed, configPath);
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -126,7 +126,7 @@ const themeSchema = z
   })
   .meta({ description: 'An object defining a theme. The property name holding the object becomes the theme name.' });
 
-export const configFileBuildSchema = z.object({
+export const commonConfig = z.object({
   clean: z.boolean().meta({ description: 'Delete the output directory before building or creating tokens' }).optional(),
 });
 
@@ -143,8 +143,8 @@ export const configFileCreateSchema = z
 /**
  * This defines the structure of the final configuration file
  */
-export const combinedConfigSchema = configFileCreateSchema.extend(configFileBuildSchema.shape);
+export const combinedConfigSchema = commonConfig.extend(configFileCreateSchema.shape);
 export type ConfigSchema = z.infer<typeof combinedConfigSchema>;
-export type ConfigSchemaBuild = z.infer<typeof configFileBuildSchema>;
+export type ConfigSchemaBuild = z.infer<typeof commonConfig>;
 export type ConfigSchemaCreate = z.infer<typeof configFileCreateSchema>;
 export type ConfigSchemaTheme = z.infer<typeof themeSchema>;

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -57,20 +57,20 @@ export function validateConfig<T>(
   }
 }
 
-export function parseConfig<T>(schema: z.ZodType<T>, configFile: string, configPath: string): T {
+export function parseConfig<T>(configFile: string, configPath: string): T {
   if (!configFile) {
     return {} as T;
   }
 
   try {
-    const parsedConfig = JSON.parse(configFile);
-    return schema.parse(parsedConfig) as T;
+    return JSON.parse(configFile) as T;
   } catch (err) {
     console.error(chalk.redBright(`Failed parsing config file at ${chalk.red(configPath)}`));
     // const validationError = makeFriendlyError(err);
 
     // console.error(validationError.toString());
     console.error(chalk.red(err instanceof Error ? err.message : 'Unknown error occurred while parsing config file'));
+    console.error(err instanceof Error ? err.stack : 'No stack trace available');
     process.exit(1);
   }
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -133,10 +133,6 @@ export const configFileBuildSchema = z.object({
 export const configFileCreateSchema = z
   .object({
     outDir: z.string().meta({ description: 'Path to the output directory for the created design tokens' }),
-    clean: z
-      .boolean()
-      .meta({ description: 'Delete the output directory before building or creating tokens' })
-      .optional(),
     themes: z.record(z.string(), themeSchema).meta({
       description:
         'An object with one or more themes. Each property defines a theme, and the property name is used as the theme name.',

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -130,7 +130,7 @@ export const commonConfig = z.object({
   clean: z.boolean().meta({ description: 'Delete the output directory before building or creating tokens' }).optional(),
 });
 
-export const configFileCreateSchema = z
+const _configFileCreateSchema = z
   .object({
     outDir: z.string().meta({ description: 'Path to the output directory for the created design tokens' }),
     themes: z.record(z.string(), themeSchema).meta({
@@ -143,8 +143,8 @@ export const configFileCreateSchema = z
 /**
  * This defines the structure of the final configuration file
  */
-export const combinedConfigSchema = commonConfig.extend(configFileCreateSchema.shape);
-export type ConfigSchema = z.infer<typeof combinedConfigSchema>;
-export type ConfigSchemaBuild = z.infer<typeof commonConfig>;
-export type ConfigSchemaCreate = z.infer<typeof configFileCreateSchema>;
+export const configFileCreateSchema = _configFileCreateSchema.extend(commonConfig.shape);
+export type CommonConfigSchema = z.infer<typeof commonConfig>;
+export type BuildConfigSchema = z.infer<typeof commonConfig>;
+export type CreateConfigSchema = z.infer<typeof configFileCreateSchema>;
 export type ConfigSchemaTheme = z.infer<typeof themeSchema>;

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -67,8 +67,10 @@ export function parseConfig<T>(schema: z.ZodType<T>, configFile: string, configP
     return schema.parse(parsedConfig) as T;
   } catch (err) {
     console.error(chalk.redBright(`Failed parsing config file at ${chalk.red(configPath)}`));
-    const validationError = makeFriendlyError(err);
-    console.error(validationError.toString());
+    // const validationError = makeFriendlyError(err);
+
+    // console.error(validationError.toString());
+    console.error(chalk.red(err instanceof Error ? err.message : 'Unknown error occurred while parsing config file'));
     process.exit(1);
   }
 }

--- a/packages/cli/src/scripts/createJsonSchema.ts
+++ b/packages/cli/src/scripts/createJsonSchema.ts
@@ -1,13 +1,13 @@
 import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { z } from 'zod/v4';
-import { combinedConfigSchema } from '../config.js';
+import { configFileCreateSchema } from '../config.js';
 
 const schema = z
   .object({
     $schema: z.string().optional(),
   })
-  .extend(combinedConfigSchema.shape);
+  .extend(configFileCreateSchema.shape);
 
 writeFile(
   resolve(import.meta.dirname, '../../dist/config.schema.json'),


### PR DESCRIPTION
Fix error message downstream when running `tokens create --config` and defaulting to default values.

<img width="1252" alt="image" src="https://github.com/user-attachments/assets/6daa2471-d0a2-44b5-abe9-3c09c5991a46" />


- Removed double `zod.parse` in validate and parse config functions. Only in validate function now as it validates schema during parse.
- Updated `zod-validation-error` to v4
- Added better fallback for when `zod-validation-error` fails to parse friendly error message
- Changed some type names related to config for better readability. 


<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

<!-- Explain in short what this PR does -->

## Checks

- [ x ] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ x ] I have added a changeset (run `pnpm changeset` if relevant)
