### PR TITLE
fix(Suggestion): controlled state for single-suggestion didn't render correctly

### DIFF
--- a/.changeset/sweet-shoes-juggle.md
+++ b/.changeset/sweet-shoes-juggle.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+**Suggestion**: Visual value didn't correctly update in single mode when controlled value was updated externally

--- a/packages/react/src/components/Suggestion/Suggestion.tsx
+++ b/packages/react/src/components/Suggestion/Suggestion.tsx
@@ -127,7 +127,7 @@ const defaultFilter: Filter = ({ label, input }) =>
   label.toLowerCase().includes(input.value.trim().toLowerCase());
 
 // https://github.com/u-elements/u-elements/blob/fe076b724272c2fef00d41838b091b1563661829/packages/utils.ts#L222
-// DELETE THIS when bug in u-combobox is fixed
+// TODO: DELETE THIS when bug in u-combobox is fixed. See https://github.com/u-elements/u-elements/issues/25
 const setValue = (input: HTMLInputElement, data: string, type = '') => {
   const event = { bubbles: true, composed: true, data, inputType: type };
   const proto = HTMLInputElement.prototype;


### PR DESCRIPTION
## Summary

- Adds tests for rendering of controlled state in Suggestion component (stories ControlledSingle and ControlledMultiple).
- Fixes that the test fails for ControlledSingle, because of a bug / ommision upstream in u-combobox: https://github.com/u-elements/u-elements/issues/25

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
