### PR TITLE
fix(Field): make sure there will be no duplicate IDs

### DIFF
--- a/packages/react/src/components/Field/fieldObserver.test.tsx
+++ b/packages/react/src/components/Field/fieldObserver.test.tsx
@@ -97,4 +97,41 @@ describe('fieldObserver', () => {
       `${input.id}:description`,
     );
   });
+  it('assigns unique IDs to multiple elements with the same data-field type', () => {
+    const { container } = render(
+      <div>
+        <Label>Name</Label>
+        <Input />
+        <div data-field='validation'>First validation message</div>
+        <div data-field='validation'>Second validation message</div>
+        <div data-field='description'>Description text</div>
+        <div data-field='description'>Additional description</div>
+      </div>,
+    );
+    fieldObserver(container);
+
+    const input = screen.getByLabelText('Name');
+    const firstValidation = screen.getByText('First validation message');
+    const secondValidation = screen.getByText('Second validation message');
+    const firstDescription = screen.getByText('Description text');
+    const secondDescription = screen.getByText('Additional description');
+
+    // First of each type gets the simple format
+    expect(firstValidation).toHaveAttribute('id', `${input.id}:validation`);
+    expect(firstDescription).toHaveAttribute('id', `${input.id}:description`);
+
+    // Subsequent ones get numbered
+    expect(secondValidation).toHaveAttribute('id', `${input.id}:validation:2`);
+    expect(secondDescription).toHaveAttribute(
+      'id',
+      `${input.id}:description:2`,
+    );
+
+    // All should be in aria-describedby
+    const ariaDescribedby = input.getAttribute('aria-describedby');
+    expect(ariaDescribedby).toContain(firstValidation.id);
+    expect(ariaDescribedby).toContain(secondValidation.id);
+    expect(ariaDescribedby).toContain(firstDescription.id);
+    expect(ariaDescribedby).toContain(secondDescription.id);
+  });
 });

--- a/packages/react/src/components/Field/fieldObserver.ts
+++ b/packages/react/src/components/Field/fieldObserver.ts
@@ -2,6 +2,7 @@ export function fieldObserver(fieldElement: HTMLElement | null) {
   if (!fieldElement) return;
 
   const elements = new Map<Element, string | null>();
+  const typeCounter = new Map<string, number>(); // Track count for each data-field type
   const uuid = `:${Date.now().toString(36)}${Math.random().toString(36).slice(2, 5)}`;
   let input: Element | null = null;
   let describedby = '';
@@ -44,9 +45,21 @@ export function fieldObserver(fieldElement: HTMLElement | null) {
     const describedbyIds = [describedby]; // Keep original aria-describedby
     const inputId = input?.id || uuid;
 
+    // Reset type counters since we reprocess all elements
+    typeCounter.clear();
+
     for (const [el, value] of elements) {
       const descriptionType = el.getAttribute('data-field');
-      const id = descriptionType ? `${inputId}:${descriptionType}` : inputId;
+      let id: string;
+
+      if (descriptionType) {
+        // Increment type counter for this type
+        const count = (typeCounter.get(descriptionType) || 0) + 1;
+        typeCounter.set(descriptionType, count);
+        id = `${inputId}:${descriptionType}:${count}`;
+      } else {
+        id = inputId;
+      }
 
       if (!value) setAttr(el, isLabel(el) ? 'for' : 'id', id); // Ensure we have a value
       if (descriptionType === 'validation')


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

If you for example have two `data-field="description"`, these would get the same ID.
This PR adds a counter for each type, and then adds `:n` to the end of all IDs

## Checks

- [ ] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)
