### PR TITLE
fix(Detail): one padding when multiple children

### DIFF
--- a/.changeset/silver-adults-pay.md
+++ b/.changeset/silver-adults-pay.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**Details**: Single outer padding when multiple children

--- a/packages/css/src/details.css
+++ b/packages/css/src/details.css
@@ -90,9 +90,14 @@
 
   & > :not(summary, u-summary) {
     border-radius: inherit;
-    padding: var(--ds-size-5, 1rem);
+    padding-inline: var(--ds-size-5, 1rem);
+    &:nth-child(2) {
+      padding-block-start: var(--ds-size-5, 1rem);
+    }
+    &:last-child {
+      padding-block-end: var(--ds-size-5, 1rem);
+    }
   }
-
   &[open] > :is(summary, u-summary) {
     background: var(--dsc-details-summary-background--open);
 


### PR DESCRIPTION
I offer an alternative to #3609 that should effectively do the same but without breaking the animation. 
