### PR TITLE
fix(Suggestion): empty string as initial value led to crash when changing value

### DIFF
--- a/.changeset/mean-mails-bake.md
+++ b/.changeset/mean-mails-bake.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+**Suggestion**: fix crash when changing the value if the initial value was an empty string

--- a/packages/react/src/components/Suggestion/Suggestion.stories.tsx
+++ b/packages/react/src/components/Suggestion/Suggestion.stories.tsx
@@ -81,7 +81,7 @@ export const Preview: StoryFn<typeof Suggestion> = (args) => {
   );
 };
 
-export const ControlledSingle: StoryFn<typeof Suggestion> = (args) => {
+export const ControlledSingleArray: StoryFn<typeof Suggestion> = (args) => {
   const [value, setValue] = useState<string[]>(['Oslo']);
 
   return (
@@ -123,7 +123,7 @@ export const ControlledSingle: StoryFn<typeof Suggestion> = (args) => {
     </>
   );
 };
-ControlledSingle.play = async ({ canvasElement, step }) => {
+ControlledSingleArray.play = async ({ canvasElement, step }) => {
   const input = await waitFor(() =>
     within(canvasElement).getByRole('combobox'),
   );
@@ -138,6 +138,72 @@ ControlledSingle.play = async ({ canvasElement, step }) => {
   await step('Initial state is rendered correctly', async () => {
     await expect(resultText).toHaveTextContent('Oslo');
     await waitFor(() => expect(input).toHaveValue('Oslo'));
+  });
+
+  await step('Controlled state change renders correctly', async () => {
+    await userEvent.click(button);
+    await expect(resultText).toHaveTextContent('Sogndal');
+    await waitFor(() => expect(input).toHaveValue('Sogndal'));
+  });
+};
+
+export const ControlledSingle: StoryFn<typeof Suggestion> = (args) => {
+  const [value, setValue] = useState<string>('');
+
+  return (
+    <>
+      <Field>
+        <Label>Velg destinasjon</Label>
+        <Suggestion
+          {...args}
+          value={value}
+          onValueChange={(items) => setValue(items.at(0)?.value ?? '')}
+        >
+          <Suggestion.Chips />
+          <Suggestion.Input />
+          <Suggestion.Clear />
+          <Suggestion.List>
+            <Suggestion.Empty>Tomt</Suggestion.Empty>
+            {DATA_PLACES.map((place) => (
+              <Suggestion.Option key={place} label={place} value={place}>
+                {place}
+                <div>Kommune</div>
+              </Suggestion.Option>
+            ))}
+          </Suggestion.List>
+        </Suggestion>
+      </Field>
+      <Divider style={{ marginTop: 'var(--ds-size-4)' }} />
+
+      <Paragraph style={{ margin: 'var(--ds-size-2) 0' }}>
+        Valgte reisemål: {value}
+      </Paragraph>
+
+      <Button
+        onClick={() => {
+          setValue('Sogndal');
+        }}
+      >
+        Sett reisemål til Sogndal
+      </Button>
+    </>
+  );
+};
+ControlledSingle.play = async ({ canvasElement, step }) => {
+  const input = await waitFor(() =>
+    within(canvasElement).getByRole('combobox'),
+  );
+  const resultText = within(canvasElement).getByText('Valgte reisemål:', {
+    exact: false,
+  });
+  const button = within(canvasElement).getByText('Sett reisemål', {
+    exact: false,
+    selector: 'button',
+  });
+
+  await step('Initial state is empty', async () => {
+    await expect(resultText).toHaveTextContent(/^Valgte reisemål:$/);
+    await waitFor(() => expect(input).toHaveValue(''));
   });
 
   await step('Controlled state change renders correctly', async () => {

--- a/packages/react/src/components/Suggestion/Suggestion.tsx
+++ b/packages/react/src/components/Suggestion/Suggestion.tsx
@@ -109,7 +109,7 @@ const sanitizeItems = (values: SuggestionValues = []): Item[] =>
               value: value.value || '',
             },
       )
-  ).filter((x) => !(x.label === '' && x.value === ''));
+  ).filter((x) => !!x.label);
 
 const nextItems = (
   data: HTMLDataElement,

--- a/packages/react/src/components/Suggestion/Suggestion.tsx
+++ b/packages/react/src/components/Suggestion/Suggestion.tsx
@@ -99,7 +99,7 @@ export type SuggestionProps = {
 
 const text = (el: Element): string => el.textContent?.trim() || '';
 const sanitizeItems = (values: SuggestionValues = []): Item[] =>
-  typeof values === 'string'
+  (typeof values === 'string'
     ? [{ label: values, value: values }]
     : values.map((value) =>
         typeof value === 'string'
@@ -108,7 +108,8 @@ const sanitizeItems = (values: SuggestionValues = []): Item[] =>
               label: value.label || value.value || '',
               value: value.value || '',
             },
-      );
+      )
+  ).filter((x) => !(x.label === '' && x.value === ''));
 
 const nextItems = (
   data: HTMLDataElement,


### PR DESCRIPTION
## Summary

Fixes a crash in Suggestion which occurs only when changing the value if the initial value was an empty string
```
DOMException: Node.removeChild: The node to be removed is not a child of this node

The above error occurred in the <data> component.
```

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
