### PR TITLE
chore(www): disable copy files to root

### DIFF
--- a/apps/www/scripts/copy-content.js
+++ b/apps/www/scripts/copy-content.js
@@ -59,7 +59,7 @@ try {
   }
 
   copyDirectory(contentPath, distPath);
-  copyDirectory(contentPath, './');
+  // copyDirectory(contentPath, './');
   console.log(`Successfully copied content from ${contentPath} to ${distPath}`);
 } catch (error) {
   console.error(`Error copying content directory:`, error);
@@ -71,7 +71,7 @@ try {
   }
 
   copyDirectory(contentPath, clientPath);
-  copyDirectory(contentPath, './');
+  // copyDirectory(contentPath, './');
   console.log(
     `Successfully copied content from ${contentPath} to ${clientPath}`,
   );


### PR DESCRIPTION
Disables a bunch of files being copied to root causing over 100 untracked files when working locally.