### PR TITLE
fix(Suggestion): include chips and onbeforematch

### DIFF
--- a/.changeset/short-wolves-move.md
+++ b/.changeset/short-wolves-move.md
@@ -3,9 +3,9 @@
 ---
 
 **Suggestion:**
-- Depreciate `value`, use `selected` instead
-- Depreciate `defaultValue`, use `defaultSelected` instead
-- Depreciate `onValueChange`, use `onSelectedChange` instead
-- Depreciate `Suggestion.Chips`, use `renderSelected` on `Suggestion` instead
+- Deprecated `value`, use `selected` instead
+- Deprecated `defaultValue`, use `defaultSelected` instead
+- Deprecated `onValueChange`, use `onSelectedChange` instead
+- Deprecated `Suggestion.Chips`, use `renderSelected` on `Suggestion` instead
 - Add `onBeforeMatch` to `Suggestion` for custom matching
 - Revert input `value` when to current `selected` when no match

--- a/.changeset/short-wolves-move.md
+++ b/.changeset/short-wolves-move.md
@@ -8,4 +8,4 @@
 - Deprecated `onValueChange`, use `onSelectedChange` instead
 - Deprecated `Suggestion.Chips`, use `renderSelected` on `Suggestion` instead
 - Add `onBeforeMatch` to `Suggestion` for custom matching
-- Revert input `value` when to current `selected` when no match
+- Revert input `value` to current `selected` when no match

--- a/.changeset/short-wolves-move.md
+++ b/.changeset/short-wolves-move.md
@@ -1,0 +1,11 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+**Suggestion:**
+- Depreciate `value`, use `selected` instead
+- Depreciate `defaultValue`, use `defaultSelected` instead
+- Depreciate `onValueChange`, use `onSelectedChange` instead
+- Depreciate `Suggestion.Chips`, use `renderSelected` on `Suggestion` instead
+- Add `onBeforeMatch` to `Suggestion` for custom matching
+- Revert input `value` when to current `selected` when no match

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -47,7 +47,7 @@
     "@navikt/aksel-icons": "^7.25.1",
     "@radix-ui/react-slot": "^1.2.3",
     "@tanstack/react-virtual": "^3.13.12",
-    "@u-elements/u-combobox": "^0.0.17",
+    "@u-elements/u-combobox": "^0.0.18",
     "@u-elements/u-datalist": "^1.0.10",
     "@u-elements/u-details": "^0.1.1",
     "clsx": "^2.1.1"

--- a/packages/react/src/components/suggestion/index.ts
+++ b/packages/react/src/components/suggestion/index.ts
@@ -46,7 +46,11 @@ export {
   SuggestionOption as EXPERIMENTAL_SuggestionOption,
   SuggestionClear as EXPERIMENTAL_SuggestionClear,
 };
-export type { SuggestionProps, SuggestionValues } from './suggestion'; // Export SuggestionValues for easier useState
+export type {
+  SuggestionProps,
+  SuggestionSelected, // Export SuggestionValues for easier useState
+  SuggestionSelected as SuggestionValues, // Kept for backwards compatibility
+} from './suggestion';
 export type { SuggestionChipsProps } from './suggestion-chips';
 export type { SuggestionClearProps } from './suggestion-clear';
 export type { SuggestionEmptyProps } from './suggestion-empty';

--- a/packages/react/src/components/suggestion/index.ts
+++ b/packages/react/src/components/suggestion/index.ts
@@ -21,6 +21,9 @@ import { SuggestionOption } from './suggestion-option';
  * </Suggestion>
  */
 const EXPERIMENTAL_Suggestion = Object.assign(SuggestionRoot, {
+  /**
+   * @deprecated Suggestion.Chips is deprecated, use `renderSelected` on `Suggestion` instead
+   */
   Chips: SuggestionChips,
   List: SuggestionList,
   Input: SuggestionInput,
@@ -39,6 +42,9 @@ EXPERIMENTAL_Suggestion.Clear.displayName = 'EXPERIMENTAL_Suggestion.Clear';
 
 export {
   EXPERIMENTAL_Suggestion,
+  /**
+   * @deprecated Suggestion.Chips is deprecated, use `renderSelected` on `Suggestion` instead
+   */
   SuggestionChips as EXPERIMENTAL_SuggestionChips,
   SuggestionList as EXPERIMENTAL_SuggestionList,
   SuggestionInput as EXPERIMENTAL_SuggestionInput,

--- a/packages/react/src/components/suggestion/index.ts
+++ b/packages/react/src/components/suggestion/index.ts
@@ -6,73 +6,71 @@ import { SuggestionInput } from './suggestion-input';
 import { SuggestionList } from './suggestion-list';
 import { SuggestionOption } from './suggestion-option';
 
-
-
 type SuggestionCompound = typeof SuggestionRoot & {
   /**
-  * @deprecated Suggestion.Chips is deprecated, use `renderSelected` on `Suggestion` instead
-  */
+   * @deprecated Suggestion.Chips is deprecated, use `renderSelected` on `Suggestion` instead
+   */
   Chips: typeof SuggestionChips;
   /**
-  * Component that provides a Suggestion list.
-  *
-  * Place as a descendant of `Suggestion`
-  *
-  * @example
-  * <Suggestion>
-  *   <Suggestion.Input />
-  *   <Suggestion.List />
-  * </Suggestion>
-  */
+   * Component that provides a Suggestion list.
+   *
+   * Place as a descendant of `Suggestion`
+   *
+   * @example
+   * <Suggestion>
+   *   <Suggestion.Input />
+   *   <Suggestion.List />
+   * </Suggestion>
+   */
   List: typeof SuggestionList;
   /**
-* Component that provides an input field for the Suggestion list.
-*
-* Place as a descendant of `Suggestion`
-*
-* @example
-* <Suggestion>
-*   <Suggestion.Input />
-*   <Suggestion.List />
-* </Suggestion>
-*/
+   * Component that provides an input field for the Suggestion list.
+   *
+   * Place as a descendant of `Suggestion`
+   *
+   * @example
+   * <Suggestion>
+   *   <Suggestion.Input />
+   *   <Suggestion.List />
+   * </Suggestion>
+   */
   Input: typeof SuggestionInput;
   /**
-* Component that provides an empty Suggestion list.
-*
-* Place as a descendant of `Suggestion.List`
-*
-* @example
-* <Suggestion.List>
-*   <Suggestion.Empty>Tomt</Suggestion.Empty>
-* </Suggestion.List>
-*/
+   * Component that provides an empty Suggestion list.
+   *
+   * Place as a descendant of `Suggestion.List`
+   *
+   * @example
+   * <Suggestion.List>
+   *   <Suggestion.Empty>Tomt</Suggestion.Empty>
+   * </Suggestion.List>
+   */
   Empty: typeof SuggestionEmpty;
   /**
-* A component for rendering individual options in the Suggestion list.
-*
-* @example
-* <Suggestion>
-*   <Suggestion.Input />
-*   <Suggestion.List>
-*     <Suggestion.Option value='Option 1'>Option 1</Suggestion.Option>
-*     <Suggestion.Option value='Option 2'>Option 2</Suggestion.Option>
-*   </Suggestion.List>
-* </Suggestion>
-*/
+   * A component for rendering individual options in the Suggestion list.
+   *
+   * @example
+   * <Suggestion>
+   *   <Suggestion.Input />
+   *   <Suggestion.List>
+   *     <Suggestion.Option value='Option 1'>Option 1</Suggestion.Option>
+   *     <Suggestion.Option value='Option 2'>Option 2</Suggestion.Option>
+   *   </Suggestion.List>
+   * </Suggestion>
+   */
   Option: typeof SuggestionOption;
   /**
-* Component that provides a clear button for the Suggestion input.
-*
-* Place as a descendant of `Suggestion`
-*
-* @example
-* <Suggestion>
-*   <Suggestion.Input />
-*   <Suggestion.Clear />
-*   <Suggestion.List />
-* </Suggestion>
-*/
+   * Component that provides a clear button for the Suggestion input.
+   *
+   * Place as a descendant of `Suggestion`
+   *
+   * @example
+   * <Suggestion>
+   *   <Suggestion.Input />
+   *   <Suggestion.Clear />
+   *   <Suggestion.List />
+   * </Suggestion>
+   */
   Clear: typeof SuggestionClear;
 };
 
@@ -90,14 +88,17 @@ type SuggestionCompound = typeof SuggestionRoot & {
  *   </Suggestion.List>
  * </Suggestion>
  */
-const EXPERIMENTAL_Suggestion: SuggestionCompound = Object.assign(SuggestionRoot, {
-  Chips: SuggestionChips,
-  List: SuggestionList,
-  Input: SuggestionInput,
-  Empty: SuggestionEmpty,
-  Option: SuggestionOption,
-  Clear: SuggestionClear,
-});
+const EXPERIMENTAL_Suggestion: SuggestionCompound = Object.assign(
+  SuggestionRoot,
+  {
+    Chips: SuggestionChips,
+    List: SuggestionList,
+    Input: SuggestionInput,
+    Empty: SuggestionEmpty,
+    Option: SuggestionOption,
+    Clear: SuggestionClear,
+  },
+);
 
 EXPERIMENTAL_Suggestion.displayName = 'EXPERIMENTAL_Suggestion';
 EXPERIMENTAL_Suggestion.Chips.displayName = 'EXPERIMENTAL_Suggestion.Chips';

--- a/packages/react/src/components/suggestion/index.ts
+++ b/packages/react/src/components/suggestion/index.ts
@@ -7,12 +7,72 @@ import { SuggestionList } from './suggestion-list';
 import { SuggestionOption } from './suggestion-option';
 
 
+
 type SuggestionCompound = typeof SuggestionRoot & {
+  /**
+  * @deprecated Suggestion.Chips is deprecated, use `renderSelected` on `Suggestion` instead
+  */
   Chips: typeof SuggestionChips;
+  /**
+  * Component that provides a Suggestion list.
+  *
+  * Place as a descendant of `Suggestion`
+  *
+  * @example
+  * <Suggestion>
+  *   <Suggestion.Input />
+  *   <Suggestion.List />
+  * </Suggestion>
+  */
   List: typeof SuggestionList;
+  /**
+* Component that provides an input field for the Suggestion list.
+*
+* Place as a descendant of `Suggestion`
+*
+* @example
+* <Suggestion>
+*   <Suggestion.Input />
+*   <Suggestion.List />
+* </Suggestion>
+*/
   Input: typeof SuggestionInput;
+  /**
+* Component that provides an empty Suggestion list.
+*
+* Place as a descendant of `Suggestion.List`
+*
+* @example
+* <Suggestion.List>
+*   <Suggestion.Empty>Tomt</Suggestion.Empty>
+* </Suggestion.List>
+*/
   Empty: typeof SuggestionEmpty;
+  /**
+* A component for rendering individual options in the Suggestion list.
+*
+* @example
+* <Suggestion>
+*   <Suggestion.Input />
+*   <Suggestion.List>
+*     <Suggestion.Option value='Option 1'>Option 1</Suggestion.Option>
+*     <Suggestion.Option value='Option 2'>Option 2</Suggestion.Option>
+*   </Suggestion.List>
+* </Suggestion>
+*/
   Option: typeof SuggestionOption;
+  /**
+* Component that provides a clear button for the Suggestion input.
+*
+* Place as a descendant of `Suggestion`
+*
+* @example
+* <Suggestion>
+*   <Suggestion.Input />
+*   <Suggestion.Clear />
+*   <Suggestion.List />
+* </Suggestion>
+*/
   Clear: typeof SuggestionClear;
 };
 
@@ -31,70 +91,11 @@ type SuggestionCompound = typeof SuggestionRoot & {
  * </Suggestion>
  */
 const EXPERIMENTAL_Suggestion: SuggestionCompound = Object.assign(SuggestionRoot, {
-  /**
-   * @deprecated Suggestion.Chips is deprecated, use `renderSelected` on `Suggestion` instead
-   */
   Chips: SuggestionChips,
-  /**
-  * Component that provides a Suggestion list.
-  *
-  * Place as a descendant of `Suggestion`
-  *
-  * @example
-  * <Suggestion>
-  *   <Suggestion.Input />
-  *   <Suggestion.List />
-  * </Suggestion>
-  */
   List: SuggestionList,
-  /**
-  * Component that provides an input field for the Suggestion list.
-  *
-  * Place as a descendant of `Suggestion`
-  *
-  * @example
-  * <Suggestion>
-  *   <Suggestion.Input />
-  *   <Suggestion.List />
-  * </Suggestion>
-  */
   Input: SuggestionInput,
-  /**
-  * Component that provides an empty Suggestion list.
-  *
-  * Place as a descendant of `Suggestion.List`
-  *
-  * @example
-  * <Suggestion.List>
-  *   <Suggestion.Empty>Tomt</Suggestion.Empty>
-  * </Suggestion.List>
-  */
   Empty: SuggestionEmpty,
-  /**
-  * A component for rendering individual options in the Suggestion list.
-  *
-  * @example
-  * <Suggestion>
-  *   <Suggestion.Input />
-  *   <Suggestion.List>
-  *     <Suggestion.Option value='Option 1'>Option 1</Suggestion.Option>
-  *     <Suggestion.Option value='Option 2'>Option 2</Suggestion.Option>
-  *   </Suggestion.List>
-  * </Suggestion>
-  */
   Option: SuggestionOption,
-  /**
-  * Component that provides a clear button for the Suggestion input.
-  *
-  * Place as a descendant of `Suggestion`
-  *
-  * @example
-  * <Suggestion>
-  *   <Suggestion.Input />
-  *   <Suggestion.Clear />
-  *   <Suggestion.List />
-  * </Suggestion>
-  */
   Clear: SuggestionClear,
 });
 

--- a/packages/react/src/components/suggestion/index.ts
+++ b/packages/react/src/components/suggestion/index.ts
@@ -88,17 +88,14 @@ type Suggestion = typeof SuggestionRoot & {
  *   </Suggestion.List>
  * </Suggestion>
  */
-const EXPERIMENTAL_Suggestion: Suggestion = Object.assign(
-  SuggestionRoot,
-  {
-    Chips: SuggestionChips,
-    List: SuggestionList,
-    Input: SuggestionInput,
-    Empty: SuggestionEmpty,
-    Option: SuggestionOption,
-    Clear: SuggestionClear,
-  },
-);
+const EXPERIMENTAL_Suggestion: Suggestion = Object.assign(SuggestionRoot, {
+  Chips: SuggestionChips,
+  List: SuggestionList,
+  Input: SuggestionInput,
+  Empty: SuggestionEmpty,
+  Option: SuggestionOption,
+  Clear: SuggestionClear,
+});
 
 EXPERIMENTAL_Suggestion.displayName = 'EXPERIMENTAL_Suggestion';
 EXPERIMENTAL_Suggestion.Chips.displayName = 'EXPERIMENTAL_Suggestion.Chips';

--- a/packages/react/src/components/suggestion/index.ts
+++ b/packages/react/src/components/suggestion/index.ts
@@ -6,7 +6,7 @@ import { SuggestionInput } from './suggestion-input';
 import { SuggestionList } from './suggestion-list';
 import { SuggestionOption } from './suggestion-option';
 
-type SuggestionCompound = typeof SuggestionRoot & {
+type Suggestion = typeof SuggestionRoot & {
   /**
    * @deprecated Suggestion.Chips is deprecated, use `renderSelected` on `Suggestion` instead
    */
@@ -88,7 +88,7 @@ type SuggestionCompound = typeof SuggestionRoot & {
  *   </Suggestion.List>
  * </Suggestion>
  */
-const EXPERIMENTAL_Suggestion: SuggestionCompound = Object.assign(
+const EXPERIMENTAL_Suggestion: Suggestion = Object.assign(
   SuggestionRoot,
   {
     Chips: SuggestionChips,

--- a/packages/react/src/components/suggestion/index.ts
+++ b/packages/react/src/components/suggestion/index.ts
@@ -1,10 +1,20 @@
-import { Suggestion as SuggestionRoot } from './suggestion';
+import { Suggestion } from './suggestion';
 import { SuggestionChips } from './suggestion-chips';
 import { SuggestionClear } from './suggestion-clear';
 import { SuggestionEmpty } from './suggestion-empty';
 import { SuggestionInput } from './suggestion-input';
 import { SuggestionList } from './suggestion-list';
 import { SuggestionOption } from './suggestion-option';
+
+
+type SuggestionComponent = typeof Suggestion & {
+  Chips: typeof SuggestionChips;
+  List: typeof SuggestionList;
+  Input: typeof SuggestionInput;
+  Empty: typeof SuggestionEmpty;
+  Option: typeof SuggestionOption;
+  Clear: typeof SuggestionClear;
+};
 
 /**
  * A component that provides a suggestion list for an input field.
@@ -20,7 +30,7 @@ import { SuggestionOption } from './suggestion-option';
  *   </Suggestion.List>
  * </Suggestion>
  */
-const EXPERIMENTAL_Suggestion = Object.assign(SuggestionRoot, {
+const EXPERIMENTAL_Suggestion: SuggestionComponent = Object.assign(Suggestion, {
   /**
    * @deprecated Suggestion.Chips is deprecated, use `renderSelected` on `Suggestion` instead
    */

--- a/packages/react/src/components/suggestion/index.ts
+++ b/packages/react/src/components/suggestion/index.ts
@@ -1,4 +1,4 @@
-import { Suggestion } from './suggestion';
+import { Suggestion as SuggestionRoot } from './suggestion';
 import { SuggestionChips } from './suggestion-chips';
 import { SuggestionClear } from './suggestion-clear';
 import { SuggestionEmpty } from './suggestion-empty';
@@ -7,7 +7,7 @@ import { SuggestionList } from './suggestion-list';
 import { SuggestionOption } from './suggestion-option';
 
 
-type SuggestionComponent = typeof Suggestion & {
+type SuggestionCompound = typeof SuggestionRoot & {
   Chips: typeof SuggestionChips;
   List: typeof SuggestionList;
   Input: typeof SuggestionInput;
@@ -30,15 +30,71 @@ type SuggestionComponent = typeof Suggestion & {
  *   </Suggestion.List>
  * </Suggestion>
  */
-const EXPERIMENTAL_Suggestion: SuggestionComponent = Object.assign(Suggestion, {
+const EXPERIMENTAL_Suggestion: SuggestionCompound = Object.assign(SuggestionRoot, {
   /**
    * @deprecated Suggestion.Chips is deprecated, use `renderSelected` on `Suggestion` instead
    */
   Chips: SuggestionChips,
+  /**
+  * Component that provides a Suggestion list.
+  *
+  * Place as a descendant of `Suggestion`
+  *
+  * @example
+  * <Suggestion>
+  *   <Suggestion.Input />
+  *   <Suggestion.List />
+  * </Suggestion>
+  */
   List: SuggestionList,
+  /**
+  * Component that provides an input field for the Suggestion list.
+  *
+  * Place as a descendant of `Suggestion`
+  *
+  * @example
+  * <Suggestion>
+  *   <Suggestion.Input />
+  *   <Suggestion.List />
+  * </Suggestion>
+  */
   Input: SuggestionInput,
+  /**
+  * Component that provides an empty Suggestion list.
+  *
+  * Place as a descendant of `Suggestion.List`
+  *
+  * @example
+  * <Suggestion.List>
+  *   <Suggestion.Empty>Tomt</Suggestion.Empty>
+  * </Suggestion.List>
+  */
   Empty: SuggestionEmpty,
+  /**
+  * A component for rendering individual options in the Suggestion list.
+  *
+  * @example
+  * <Suggestion>
+  *   <Suggestion.Input />
+  *   <Suggestion.List>
+  *     <Suggestion.Option value='Option 1'>Option 1</Suggestion.Option>
+  *     <Suggestion.Option value='Option 2'>Option 2</Suggestion.Option>
+  *   </Suggestion.List>
+  * </Suggestion>
+  */
   Option: SuggestionOption,
+  /**
+  * Component that provides a clear button for the Suggestion input.
+  *
+  * Place as a descendant of `Suggestion`
+  *
+  * @example
+  * <Suggestion>
+  *   <Suggestion.Input />
+  *   <Suggestion.Clear />
+  *   <Suggestion.List />
+  * </Suggestion>
+  */
   Clear: SuggestionClear,
 });
 
@@ -52,9 +108,6 @@ EXPERIMENTAL_Suggestion.Clear.displayName = 'EXPERIMENTAL_Suggestion.Clear';
 
 export {
   EXPERIMENTAL_Suggestion,
-  /**
-   * @deprecated Suggestion.Chips is deprecated, use `renderSelected` on `Suggestion` instead
-   */
   SuggestionChips as EXPERIMENTAL_SuggestionChips,
   SuggestionList as EXPERIMENTAL_SuggestionList,
   SuggestionInput as EXPERIMENTAL_SuggestionInput,

--- a/packages/react/src/components/suggestion/suggestion-chips.tsx
+++ b/packages/react/src/components/suggestion/suggestion-chips.tsx
@@ -6,7 +6,7 @@ export type SuggestionChipsProps = DefaultProps &
 
 export const SuggestionChips = () => {
   console.warn(
-    'Using <Suggestion.Chips> is deprecated - please remove from your code.',
+    'Suggestion: Using <Suggestion.Chips> is deprecated - please remove from your code.',
   );
   return null;
 };

--- a/packages/react/src/components/suggestion/suggestion-chips.tsx
+++ b/packages/react/src/components/suggestion/suggestion-chips.tsx
@@ -1,36 +1,14 @@
-import type { HTMLAttributes, ReactNode } from 'react';
-import { useContext } from 'react';
+import type { HTMLAttributes } from 'react';
 import type { DefaultProps } from '../../types';
-import type { MergeRight } from '../../utilities';
-import { Chip } from '../chip';
-import { SuggestionContext } from './suggestion';
 
-export type SuggestionChipsProps = MergeRight<
-  DefaultProps & HTMLAttributes<HTMLDivElement>,
-  {
-    /**
-     * Change the rendered content of the chip.
-     *
-     * @default ({ label }) => label
-     */
-    render?: (args: { label: string; value: string }) => ReactNode;
-  }
->;
+export type SuggestionChipsProps = DefaultProps &
+  HTMLAttributes<HTMLDivElement>;
 
-export const SuggestionChips = ({
-  render = ({ label }) => label,
-}: SuggestionChipsProps) => {
-  const { selectedItems = [] } = useContext(SuggestionContext);
-
-  return (
-    <>
-      {selectedItems.map((item) => (
-        <Chip.Removable key={item.value} value={item.value} asChild>
-          <data>{render(item)}</data>
-        </Chip.Removable>
-      ))}
-    </>
+export const SuggestionChips = () => {
+  console.warn(
+    'Using <Suggestion.Chips> is deprecated - please remove from your code.',
   );
+  return null;
 };
 
 SuggestionChips.displayName = 'SuggestionChips';

--- a/packages/react/src/components/suggestion/suggestion-chips.tsx
+++ b/packages/react/src/components/suggestion/suggestion-chips.tsx
@@ -4,6 +4,9 @@ import type { DefaultProps } from '../../types';
 export type SuggestionChipsProps = DefaultProps &
   HTMLAttributes<HTMLDivElement>;
 
+/**
+ * @deprecated Suggestion.Chips is deprecated, use `renderSelected` on `Suggestion` instead
+ */
 export const SuggestionChips = () => {
   console.warn(
     'Suggestion: Using <Suggestion.Chips> is deprecated - please remove from your code.',

--- a/packages/react/src/components/suggestion/suggestion-input.tsx
+++ b/packages/react/src/components/suggestion/suggestion-input.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useContext, useEffect, version } from 'react';
+import { forwardRef, useContext, useEffect } from 'react';
 import { Input, type InputProps } from '../input/input';
 import { SuggestionContext } from './suggestion';
 
@@ -35,7 +35,7 @@ export const SuggestionInput = forwardRef<
   HTMLInputElement,
   SuggestionInputProps
 >(function SuggestionList({ value, onInput, onChange, ...rest }, ref) {
-  const { listId, handleFilter } = useContext(SuggestionContext);
+  const { handleFilter } = useContext(SuggestionContext);
 
   useEffect(handleFilter, [value]); // Filter if controlled value
   if (onChange)
@@ -47,13 +47,6 @@ export const SuggestionInput = forwardRef<
       'SuggestionInput: Avoid using value, as Suggestion controls the Input. Use value on Suggest instead.',
     );
 
-  const popoverProps = Object.assign(
-    {
-      [version.startsWith('19') ? 'popoverTarget' : 'popovertarget']: listId,
-    },
-    rest,
-  );
-
   return (
     <Input
       placeholder='' // We need an empty placeholder for the clear button to be able to show/hide
@@ -62,7 +55,7 @@ export const SuggestionInput = forwardRef<
         onInput?.(event); // Should run first
         handleFilter?.(); // Filter if uncontrolled value
       }}
-      {...popoverProps}
+      {...rest}
     />
   );
 });

--- a/packages/react/src/components/suggestion/suggestion-list.tsx
+++ b/packages/react/src/components/suggestion/suggestion-list.tsx
@@ -1,5 +1,5 @@
 import type { HTMLAttributes } from 'react';
-import { forwardRef, useContext, useEffect, useRef } from 'react';
+import { forwardRef, useContext, useEffect } from 'react';
 import '@u-elements/u-datalist';
 import {
   autoUpdate,
@@ -8,7 +8,6 @@ import {
 } from '@floating-ui/dom';
 import type { DefaultProps } from '../../types';
 import type { MergeRight } from '../../utilities';
-import { useMergeRefs } from '../../utilities/hooks';
 import { SuggestionContext } from './suggestion';
 
 export type SuggestionListProps = MergeRight<
@@ -45,22 +44,14 @@ export const SuggestionList = forwardRef<
   { singular = '%d forslag', plural = '%d forslag', className, id, ...rest },
   ref,
 ) {
-  const { listId, setListId, handleFilter } = useContext(SuggestionContext);
-  const listRef = useRef<HTMLDataListElement>(null);
-  const mergedRefs = useMergeRefs([ref, listRef]);
+  const { handleFilter, uComboboxRef } = useContext(SuggestionContext);
 
   useEffect(handleFilter); // Must run on every render
 
-  useEffect(() => {
-    id && setListId(id);
-  }, [id]);
-
   // Position with floating-ui
   useEffect(() => {
-    const list = listRef.current;
-    const trigger = document.querySelector(
-      `[popovertarget="${list?.id}"]`,
-    ) as HTMLInputElement;
+    const trigger = uComboboxRef?.current?.control;
+    const list = uComboboxRef?.current?.list;
 
     if (list && trigger) {
       return autoUpdate(trigger, list, () => {
@@ -73,7 +64,7 @@ export const SuggestionList = forwardRef<
         });
       });
     }
-  }, [listId]);
+  }, []);
 
   return (
     <u-datalist
@@ -81,8 +72,7 @@ export const SuggestionList = forwardRef<
       data-sr-singular={singular}
       data-sr-plural={plural}
       class={className} // Using "class" since React does not translate className on custom elements
-      ref={mergedRefs}
-      id={listId}
+      ref={ref}
       popover='manual'
       {...rest}
     />
@@ -93,9 +83,7 @@ const triggerWidth = {
   name: 'TriggerWidth',
   fn(data: MiddlewareState) {
     const { elements, rects } = data;
-
     elements.floating.style.width = `${rects.reference.width}px`;
-
     return data;
   },
 };

--- a/packages/react/src/components/suggestion/suggestion-option.tsx
+++ b/packages/react/src/components/suggestion/suggestion-option.tsx
@@ -5,6 +5,18 @@ import type { DefaultProps } from '../../types';
 export type SuggestionOptionProps = OptionHTMLAttributes<HTMLOptionElement> &
   DefaultProps;
 
+/**
+ * A component for rendering individual options in the Suggestion list.
+ *
+ * @example
+ * <Suggestion>
+ *   <Suggestion.Input />
+ *   <Suggestion.List>
+ *     <Suggestion.Option value='Option 1'>Option 1</Suggestion.Option>
+ *     <Suggestion.Option value='Option 2'>Option 2</Suggestion.Option>
+ *   </Suggestion.List>
+ * </Suggestion>
+ */
 export const SuggestionOption = forwardRef<
   HTMLOptionElement,
   SuggestionOptionProps

--- a/packages/react/src/components/suggestion/suggestion.mdx
+++ b/packages/react/src/components/suggestion/suggestion.mdx
@@ -21,7 +21,6 @@ import { EXPERIMENTAL_Suggestion as Suggestion } from '@digdir/designsystemet-re
 
 
 <Suggestion>
-  <Suggestion.Chips /> {/* Må alltid være med da den lagrer valgte elementer */}
   <Suggestion.Input />
   <Suggestion.Clear />
   <Suggestion.List>

--- a/packages/react/src/components/suggestion/suggestion.mdx
+++ b/packages/react/src/components/suggestion/suggestion.mdx
@@ -39,7 +39,7 @@ import { EXPERIMENTAL_Suggestion as Suggestion } from '@digdir/designsystemet-re
 
 ### Flervalg
 
-Når du setter `multiple={true}` må du også ha `<Suggestion.Chips />` for å vise valgte elementer.
+Bruk `multiple` på `Suggestion`. Dersom du vil endre hvordan valgte alternativer vises, kan du bruke `renderSelected` .
 
 <Canvas of={SuggestionStories.Multiple} />
 

--- a/packages/react/src/components/suggestion/suggestion.stories.tsx
+++ b/packages/react/src/components/suggestion/suggestion.stories.tsx
@@ -14,7 +14,7 @@ import {
 import {
   EXPERIMENTAL_Suggestion as Suggestion,
   type SuggestionProps,
-  type SuggestionValues,
+  type SuggestionSelected,
 } from './';
 
 export default {
@@ -97,7 +97,7 @@ export const Preview: StoryFn<typeof Suggestion> = (args) => {
 };
 
 export const ControlledSingleArray: StoryFn<typeof Suggestion> = (args) => {
-  const [value, setValue] = useState<string[]>(['Oslo']);
+  const [selected, setSelected] = useState<string[]>(['Oslo']);
 
   return (
     <>
@@ -105,8 +105,10 @@ export const ControlledSingleArray: StoryFn<typeof Suggestion> = (args) => {
         <Label>Velg destinasjon</Label>
         <Suggestion
           {...args}
-          value={value}
-          onValueChange={(items) => setValue(items.map((item) => item.value))}
+          selected={selected}
+          onSelectedChange={(items) =>
+            setSelected(items.map((item) => item.value))
+          }
         >
           <Suggestion.Input />
           <Suggestion.Clear />
@@ -124,12 +126,12 @@ export const ControlledSingleArray: StoryFn<typeof Suggestion> = (args) => {
       <Divider style={{ marginTop: 'var(--ds-size-4)' }} />
 
       <Paragraph style={{ margin: 'var(--ds-size-2) 0' }}>
-        Valgte reisemål: {value.join(', ')}
+        Valgte reisemål: {selected.join(', ')}
       </Paragraph>
 
       <Button
         onClick={() => {
-          setValue(['Sogndal']);
+          setSelected(['Sogndal']);
         }}
       >
         Sett reisemål til Sogndal
@@ -162,7 +164,7 @@ ControlledSingleArray.play = async ({ canvasElement, step }) => {
 };
 
 export const ControlledSingle: StoryFn<typeof Suggestion> = (args) => {
-  const [value, setValue] = useState<string>('');
+  const [selected, setSelected] = useState<string>('');
 
   return (
     <>
@@ -170,8 +172,8 @@ export const ControlledSingle: StoryFn<typeof Suggestion> = (args) => {
         <Label>Velg destinasjon</Label>
         <Suggestion
           {...args}
-          value={value}
-          onValueChange={(items) => setValue(items.at(0)?.value ?? '')}
+          selected={selected}
+          onSelectedChange={(items) => setSelected(items.at(0)?.value ?? '')}
         >
           <Suggestion.Input />
           <Suggestion.Clear />
@@ -189,12 +191,12 @@ export const ControlledSingle: StoryFn<typeof Suggestion> = (args) => {
       <Divider style={{ marginTop: 'var(--ds-size-4)' }} />
 
       <Paragraph style={{ margin: 'var(--ds-size-2) 0' }}>
-        Valgte reisemål: {value}
+        Valgte reisemål: {selected}
       </Paragraph>
 
       <Button
         onClick={() => {
-          setValue('Sogndal');
+          setSelected('Sogndal');
         }}
       >
         Sett reisemål til Sogndal
@@ -227,7 +229,7 @@ ControlledSingle.play = async ({ canvasElement, step }) => {
 };
 
 export const ControlledMultiple: StoryFn<typeof Suggestion> = (args) => {
-  const [value, setValue] = useState<string[]>(['Oslo']);
+  const [selected, setSelected] = useState<string[]>(['Oslo']);
 
   return (
     <>
@@ -236,8 +238,10 @@ export const ControlledMultiple: StoryFn<typeof Suggestion> = (args) => {
         <Suggestion
           {...args}
           multiple
-          value={value}
-          onValueChange={(items) => setValue(items.map((item) => item.value))}
+          selected={selected}
+          onSelectedChange={(items) =>
+            setSelected(items.map((item) => item.value))
+          }
         >
           <Suggestion.Input />
           <Suggestion.Clear />
@@ -255,12 +259,12 @@ export const ControlledMultiple: StoryFn<typeof Suggestion> = (args) => {
       <Divider style={{ marginTop: 'var(--ds-size-4)' }} />
 
       <Paragraph style={{ margin: 'var(--ds-size-2) 0' }}>
-        Valgte reisemål: {value.join(', ')}
+        Valgte reisemål: {selected.join(', ')}
       </Paragraph>
 
       <Button
         onClick={() => {
-          setValue(['Sogndal', 'Stavanger']);
+          setSelected(['Sogndal', 'Stavanger']);
         }}
       >
         Sett reisemål til Sogndal, Stavanger
@@ -313,8 +317,8 @@ export const ControlledIndependentLabelValue: StoryFn<typeof Suggestion> = (
         <Label>Velg person</Label>
         <Suggestion
           {...args}
-          value={items.slice(0, 1)}
-          onValueChange={(items) => setItems(items)}
+          selected={items.slice(0, 1)}
+          onSelectedChange={(items) => setItems(items)}
           filter={false}
         >
           <Suggestion.Input />
@@ -390,20 +394,20 @@ CustomFilterAlt1.parameters = {
 };
 
 export const CustomFilterAlt2: StoryFn<typeof Suggestion> = (args) => {
-  const [value, setValue] = useState('');
+  const [selected, setSelected] = useState('');
 
   return (
     <Field>
       <Label>Skriv inn et tall mellom 1-6</Label>
       <Suggestion {...args} filter={false}>
         <Suggestion.Input
-          onInput={({ currentTarget }) => setValue(currentTarget.value)}
+          onInput={({ currentTarget }) => setSelected(currentTarget.value)}
         />
         <Suggestion.Clear />
         <Suggestion.List>
           <Suggestion.Empty>Tomt</Suggestion.Empty>
           {DATA_PLACES.filter(
-            (_, index) => !value || index === Number(value) - 1,
+            (_, index) => !selected || index === Number(selected) - 1,
           ).map((label) => (
             <Suggestion.Option key={label}>{label}</Suggestion.Option>
           ))}
@@ -441,16 +445,16 @@ export const CustomMatching: StoryFn<typeof Suggestion> = (args) => {
 };
 
 export const AlwaysShowAll: StoryFn<typeof Suggestion> = (args) => {
-  const [value, setValue] = useState<SuggestionValues>('Sogndal');
+  const [selected, setSelected] = useState<SuggestionSelected>('Sogndal');
 
   return (
     <Field>
       <Label>Viser alle options også når valgt</Label>
       <Suggestion
         {...args}
-        value={value}
+        selected={selected}
         filter={false}
-        onValueChange={(values) => setValue(values)}
+        onSelectedChange={(values) => setSelected(values)}
       >
         <Suggestion.Input />
         <Suggestion.Clear />
@@ -528,7 +532,7 @@ export const DefaultValue: StoryFn<typeof Suggestion> = (args) => {
   return (
     <Field>
       <Label>Velg en destinasjon</Label>
-      <Suggestion {...args} defaultValue={['Sogndal']}>
+      <Suggestion {...args} defaultSelected={['Sogndal']}>
         <Suggestion.Input />
         <Suggestion.Clear />
         <Suggestion.List>

--- a/packages/react/src/components/suggestion/suggestion.stories.tsx
+++ b/packages/react/src/components/suggestion/suggestion.stories.tsx
@@ -13,6 +13,7 @@ import {
 } from '../';
 import {
   EXPERIMENTAL_Suggestion as Suggestion,
+  type SuggestionProps,
   type SuggestionValues,
 } from './';
 
@@ -79,7 +80,6 @@ export const Preview: StoryFn<typeof Suggestion> = (args) => {
     <Field>
       <Label>Velg en destinasjon</Label>
       <Suggestion {...args}>
-        <Suggestion.Chips />
         <Suggestion.Input />
         <Suggestion.Clear />
         <Suggestion.List id='123'>
@@ -108,7 +108,6 @@ export const ControlledSingleArray: StoryFn<typeof Suggestion> = (args) => {
           value={value}
           onValueChange={(items) => setValue(items.map((item) => item.value))}
         >
-          <Suggestion.Chips />
           <Suggestion.Input />
           <Suggestion.Clear />
           <Suggestion.List>
@@ -174,7 +173,6 @@ export const ControlledSingle: StoryFn<typeof Suggestion> = (args) => {
           value={value}
           onValueChange={(items) => setValue(items.at(0)?.value ?? '')}
         >
-          <Suggestion.Chips />
           <Suggestion.Input />
           <Suggestion.Clear />
           <Suggestion.List>
@@ -241,7 +239,6 @@ export const ControlledMultiple: StoryFn<typeof Suggestion> = (args) => {
           value={value}
           onValueChange={(items) => setValue(items.map((item) => item.value))}
         >
-          <Suggestion.Chips />
           <Suggestion.Input />
           <Suggestion.Clear />
           <Suggestion.List>
@@ -320,7 +317,6 @@ export const ControlledIndependentLabelValue: StoryFn<typeof Suggestion> = (
           onValueChange={(items) => setItems(items)}
           filter={false}
         >
-          <Suggestion.Chips />
           <Suggestion.Input />
           <Suggestion.Clear />
           <Suggestion.List>
@@ -370,7 +366,6 @@ export const CustomFilterAlt1: StoryFn<typeof Suggestion> = (args) => {
           !input.value || index === Number(input.value) - 1
         }
       >
-        <Suggestion.Chips />
         <Suggestion.Input />
         <Suggestion.Clear />
         <Suggestion.List>
@@ -401,7 +396,6 @@ export const CustomFilterAlt2: StoryFn<typeof Suggestion> = (args) => {
     <Field>
       <Label>Skriv inn et tall mellom 1-6</Label>
       <Suggestion {...args} filter={false}>
-        <Suggestion.Chips />
         <Suggestion.Input
           onInput={({ currentTarget }) => setValue(currentTarget.value)}
         />
@@ -411,6 +405,33 @@ export const CustomFilterAlt2: StoryFn<typeof Suggestion> = (args) => {
           {DATA_PLACES.filter(
             (_, index) => !value || index === Number(value) - 1,
           ).map((label) => (
+            <Suggestion.Option key={label}>{label}</Suggestion.Option>
+          ))}
+        </Suggestion.List>
+      </Suggestion>
+    </Field>
+  );
+};
+
+export const CustomMatching: StoryFn<typeof Suggestion> = (args) => {
+  const handleBeforeMatch: SuggestionProps['onBeforeMatch'] = (event) => {
+    event.preventDefault(); // Prevent default matching
+    const { list, control } = event.currentTarget;
+    const value = control?.value.toLowerCase() || '';
+
+    for (const option of list?.options || [])
+      option.selected = option.value.toLowerCase().startsWith(value); // Setting selected indicates a match
+  };
+
+  return (
+    <Field>
+      <Label>Matcher fra første bokstav</Label>
+      <Suggestion {...args} onBeforeMatch={handleBeforeMatch}>
+        <Suggestion.Input />
+        <Suggestion.Clear />
+        <Suggestion.List>
+          <Suggestion.Empty>Tomt</Suggestion.Empty>
+          {DATA_PLACES.map((label) => (
             <Suggestion.Option key={label}>{label}</Suggestion.Option>
           ))}
         </Suggestion.List>
@@ -431,7 +452,6 @@ export const AlwaysShowAll: StoryFn<typeof Suggestion> = (args) => {
         filter={false}
         onValueChange={(values) => setValue(values)}
       >
-        <Suggestion.Chips />
         <Suggestion.Input />
         <Suggestion.Clear />
         <Suggestion.List>
@@ -473,7 +493,6 @@ export const FetchExternal: StoryFn<typeof Suggestion> = (args) => {
     <Field lang='en'>
       <Label>Search for countries (in english)</Label>
       <Suggestion {...args} filter={false}>
-        <Suggestion.Chips />
         <Suggestion.Input onInput={handleInput} />
         <Suggestion.Clear />
         <Suggestion.List singular='%d country' plural='%d countries'>
@@ -510,7 +529,6 @@ export const DefaultValue: StoryFn<typeof Suggestion> = (args) => {
     <Field>
       <Label>Velg en destinasjon</Label>
       <Suggestion {...args} defaultValue={['Sogndal']}>
-        <Suggestion.Chips />
         <Suggestion.Input />
         <Suggestion.Clear />
         <Suggestion.List>
@@ -529,7 +547,6 @@ export const Multiple: StoryFn<typeof Suggestion> = (args) => {
     <Field>
       <Label>Velg en destinasjon</Label>
       <Suggestion {...args}>
-        <Suggestion.Chips />
         <Suggestion.Input />
         <Suggestion.Clear />
         <Suggestion.List>
@@ -555,7 +572,6 @@ export const InDetails: StoryFn<typeof Suggestion> = (args) => {
         <Field>
           <Label>Velg en destinasjon</Label>
           <Suggestion {...args} autoFocus>
-            <Suggestion.Chips />
             <Suggestion.Input />
             <Suggestion.Clear />
             <Suggestion.List>

--- a/packages/react/src/components/suggestion/suggestion.tsx
+++ b/packages/react/src/components/suggestion/suggestion.tsx
@@ -121,9 +121,9 @@ export type SuggestionProps = {
    */
   name?: string;
   /**
-   * Allows the user to select multiple items
+   * Change how the selected options are rendered inside the `Chip`.
    *
-   * @default false
+   * @default ({ label }) => label
    */
   renderSelected?: (args: { label: string; value: string }) => ReactNode;
 } & HTMLAttributes<UHTMLComboboxElement>;

--- a/packages/react/src/components/suggestion/suggestion.tsx
+++ b/packages/react/src/components/suggestion/suggestion.tsx
@@ -90,7 +90,7 @@ export type SuggestionProps = {
    *
    * If `label` and `value` is the same, you can use `string[]`.
    *
-   * If `label` and `value` is different, use `{ value: string; label: string}[]`.
+   * If `label` and `value` is different, you must use `{ value: string; label: string}[]`.
    *
    * Using this makes the component controlled and it must be used in combination with {@link SuggestionProps.onSelectedChange|onSelectedChange}.
    */

--- a/packages/react/src/components/suggestion/suggestion.tsx
+++ b/packages/react/src/components/suggestion/suggestion.tsx
@@ -85,13 +85,12 @@ export type SuggestionProps = {
    * @default false
    */
   multiple?: boolean;
-
   /**
    * The selected items of the Suggestion.
    *
    * If `label` and `value` is the same, you can use `string[]`.
    *
-   * If `label` and `value` is different, use `Array<{ value: string; label: string}>`.
+   * If `label` and `value` is different, use `{ value: string; label: string}[]`.
    *
    * Using this makes the component controlled and it must be used in combination with {@link SuggestionProps.onSelectedChange|onSelectedChange}.
    */

--- a/packages/react/src/components/suggestion/suggestion.tsx
+++ b/packages/react/src/components/suggestion/suggestion.tsx
@@ -85,9 +85,15 @@ export type SuggestionProps = {
    * @default false
    */
   multiple?: boolean;
+
   /**
    * The selected items of the Suggestion.
-   * Using this makes the component controlled and it must be used in combination with onSelectedChange.
+   *
+   * If `label` and `value` is the same, you can use `string[]`.
+   *
+   * If `label` and `value` is different, use `Array<{ value: string; label: string}>`.
+   *
+   * Using this makes the component controlled and it must be used in combination with {@link SuggestionProps.onSelectedChange|onSelectedChange}.
    */
   selected?: SuggestionSelected;
   /**

--- a/packages/react/src/components/suggestion/suggestion.tsx
+++ b/packages/react/src/components/suggestion/suggestion.tsx
@@ -64,11 +64,9 @@ export const SuggestionContext = createContext<SuggestionContextType>({
 
 export type SuggestionProps = {
   /**
-   * Filter options, either true, false or a custom callback () => boolean
+   * Filter options; boolean or a custom callback.
    *
-   * If true, the <datalist> will handle filtering.
-   * If false, the <datalist> will not handle filtering.
-   * If a custom callback, the callback will be used to filter the <option> elements.
+   * See {@link Filter} for the callback signature.
    *
    * @default true
    */
@@ -92,11 +90,11 @@ export type SuggestionProps = {
    *
    * If `label` and `value` is different, you must use `{ value: string; label: string}[]`.
    *
-   * Using this makes the component controlled and it must be used in combination with {@link SuggestionProps.onSelectedChange|onSelectedChange}.
+   * Using this makes the component controlled and it must be used in combination with {@linkcode SuggestionProps.onSelectedChange|onSelectedChange}.
    */
   selected?: SuggestionSelected;
   /**
-   * @deprecated Use `selected` instead
+   * @deprecated Use {@linkcode SuggestionProps.selected|selected} instead
    */
   value?: SuggestionSelected; // Kept for backwards compatibility
   /**
@@ -104,7 +102,7 @@ export type SuggestionProps = {
    */
   defaultSelected?: SuggestionSelected;
   /**
-   * @deprecated Use `defaultSelected` instead
+   * @deprecated Use `{@linkcode SuggestionProps.defaultSelected|defaultSelected} instead
    */
   defaultValue?: SuggestionSelected; // Kept for backwards compatibility
   /**
@@ -112,7 +110,7 @@ export type SuggestionProps = {
    */
   onSelectedChange?: (value: Item[]) => void;
   /**
-   * @deprecated Use `onSelectedChange` instead
+   * @deprecated Use {@linkcode SuggestionProps.onSelectedChange|onSelectedChange} instead
    */
   onValueChange?: (value: Item[]) => void; // Kept for backwards compatibility
   /**

--- a/packages/react/src/components/suggestion/suggestion.tsx
+++ b/packages/react/src/components/suggestion/suggestion.tsx
@@ -89,18 +89,27 @@ export type SuggestionProps = {
    * The selected items of the Suggestion.
    * Using this makes the component controlled and it must be used in combination with onSelectedChange.
    */
-  value?: SuggestionSelected; // Kept for backwards compatibility
   selected?: SuggestionSelected;
+  /**
+   * @deprecated Use `selected` instead
+   */
+  value?: SuggestionSelected; // Kept for backwards compatibility
   /**
    * Default selected items when uncontrolled
    */
-  defaultValue?: SuggestionSelected; // Kept for backwards compatibility
   defaultSelected?: SuggestionSelected;
+  /**
+   * @deprecated Use `defaultSelected` instead
+   */
+  defaultValue?: SuggestionSelected; // Kept for backwards compatibility
   /**
    * Callback when selected items changes
    */
-  onValueChange?: (value: Item[]) => void; // Kept for backwards compatibility
   onSelectedChange?: (value: Item[]) => void;
+  /**
+   * @deprecated Use `onSelectedChange` instead
+   */
+  onValueChange?: (value: Item[]) => void; // Kept for backwards compatibility
   /**
    * Callback when matching input value against options
    */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -506,8 +506,8 @@ importers:
         specifier: ^3.13.12
         version: 3.13.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@u-elements/u-combobox':
-        specifier: ^0.0.17
-        version: 0.0.17
+        specifier: ^0.0.18
+        version: 0.0.18
       '@u-elements/u-datalist':
         specifier: ^1.0.10
         version: 1.0.10
@@ -2146,8 +2146,8 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@u-elements/u-combobox@0.0.17':
-    resolution: {integrity: sha512-WjbaiZm8cQLYsgPaqbRPI59DhdvvKA1xa5p8jhNZ3R5683NqziBKnZN2V0RnAxJQBus3s3qXAYoxcjDSWc/18g==}
+  '@u-elements/u-combobox@0.0.18':
+    resolution: {integrity: sha512-0WttCjvLVTmJkEoTx7jkOu2thV3titNrQmo12jeBU/c+uviSAOfh5jMAwUj8ms2sZfvFkRy+d73VxjOHo0Iskw==}
 
   '@u-elements/u-datalist@1.0.10':
     resolution: {integrity: sha512-ctPlx8SL4njfsA0/JINVlVbfBW31HCswj8hDt/SsPUiF89n/fLmTLG49DxOW7RZNcXrWW+AudJy5zsuPCmCGRA==}
@@ -7262,7 +7262,7 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@u-elements/u-combobox@0.0.17': {}
+  '@u-elements/u-combobox@0.0.18': {}
 
   '@u-elements/u-datalist@1.0.10': {}
 


### PR DESCRIPTION
## Summary

- Deprecated `Suggestion.Chips` as this always needs to render
- `renderSelected` added to `Suggestion`
- `onBeforeMatch` added to `Suggestion`
- `u-combobox` updated, so value is reverted instead of cleared when there is no match
- `value`/`defaultValue`/`onValueChange` deprecated and replaced by `selected`/`defaultSelected`/`onSelectedChange`
- Part of #3851

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
