### PR TITLE
fix: mattilsynet css fixes

### DIFF
--- a/.changeset/many-jobs-teach.md
+++ b/.changeset/many-jobs-teach.md
@@ -1,0 +1,9 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**Details:** content using `overflow: hidden` to prevent margin clipping
+**Tabs:** adjusted to allow non-tab-button-elements inside `tablist`
+**Table:**
+- sorting icon never shrinks, even when using `Button` component (which is `display: flex`) as parent
+- with `data-border` adjusts `border-radius` according to `border-width`

--- a/.changeset/many-jobs-teach.md
+++ b/.changeset/many-jobs-teach.md
@@ -2,8 +2,6 @@
 "@digdir/designsystemet-css": patch
 ---
 
-**Details:** content using `overflow: hidden` to prevent margin clipping
-**Tabs:** adjusted to allow non-tab-button-elements inside `tablist`
 **Table:**
 - sorting icon never shrinks, even when using `Button` component (which is `display: flex`) as parent
 - with `data-border` adjusts `border-radius` according to `border-width`

--- a/.changeset/poor-ways-boil.md
+++ b/.changeset/poor-ways-boil.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**Tabs:** adjusted to allow non-tab-button-elements inside `tablist`

--- a/.changeset/wise-emus-deny.md
+++ b/.changeset/wise-emus-deny.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**Details:** content using `overflow: hidden` to prevent margin clipping

--- a/packages/css/src/details.css
+++ b/packages/css/src/details.css
@@ -118,7 +118,7 @@
 
   &::part(details-content) {
     block-size: 0;
-    overflow-y: clip;
+    overflow-y: hidden; /* Using hidden instead of clip to contain margins */
     transition:
       content-visibility 400ms allow-discrete,
       height 400ms;

--- a/packages/css/src/table.css
+++ b/packages/css/src/table.css
@@ -16,6 +16,7 @@
   --dsc-table-header-background: transparent;
   --dsc-table-padding: var(--ds-size-2) var(--ds-size-3);
   --dsc-table-sort-size: var(--ds-size-6);
+  --_dsc-table-border-radius--inner: calc(var(--dsc-table-border-radius) - var(--dsc-table-border-width)); /* Shrink border radius to match border-width */
 
   border-collapse: separate; /* Using separate mode to enable border-radius */
   border-spacing: 0;
@@ -100,6 +101,7 @@
         content: '';
         display: inline-block;
         height: var(--dsc-table-sort-size);
+        flex-shrink: 0; /* Prevent shrinking if Button component with display: flex */
         mask:
           center / contain no-repeat
           url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12.53 4.47a.75.75 0 0 0-1.06 0l-3.5 3.5a.75.75 0 0 0 1.06 1.06L12 6.06l2.97 2.97a.75.75 0 1 0 1.06-1.06zm-3.5 10.5a.75.75 0 0 0-1.06 1.06l3.5 3.5a.75.75 0 0 0 1.06 0l3.5-3.5a.75.75 0 1 0-1.06-1.06L12 17.94z'/%3E%3C/svg%3E");
@@ -144,11 +146,11 @@
       > tr:first-child
       > :is(th, td) {
       &:first-child {
-        border-top-left-radius: var(--dsc-table-border-radius);
+        border-top-left-radius: var(--_dsc-table-border-radius--inner);
       }
 
       &:last-child {
-        border-top-right-radius: var(--dsc-table-border-radius);
+        border-top-right-radius: var(--_dsc-table-border-radius--inner);
       }
     }
 
@@ -161,11 +163,11 @@
       > tr:last-child
       > :is(th, td) {
       &:first-child {
-        border-bottom-left-radius: var(--dsc-table-border-radius);
+        border-bottom-left-radius: var(--_dsc-table-border-radius--inner);
       }
 
       &:last-child {
-        border-bottom-right-radius: var(--dsc-table-border-radius);
+        border-bottom-right-radius: var(--_dsc-table-border-radius--inner);
       }
     }
   }

--- a/packages/css/src/tabs.css
+++ b/packages/css/src/tabs.css
@@ -28,8 +28,8 @@
       display: flex;
     }
 
-    & button,
-    & u-tab {
+    & > [role='tab'] /* Using role= instead og <button> to allow non-tab-buttons in same parent */,
+    & > u-tab {
       align-items: center;
       background: none;
       border: 0;


### PR DESCRIPTION
## Summary

- `Table` sorting icon never shrinks, even when using `Button` component (which is `display: flex`) as parent
- `Table` with `data-border` adjusts `border-radius` according to `border-width`
- `Details` content using `overflow: hidden` to prevent margin clipping
- `Tabs` adjusted to allow non-tab-button-elements inside `tablist`

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
