### PR TITLE
fix(Details): enhance direct content support

### DIFF
--- a/.changeset/lemon-cows-remember.md
+++ b/.changeset/lemon-cows-remember.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**Details:** Using `margin` instead `margin` to style children of `Details` to allow direct children such as `Button`

--- a/packages/css/src/details.css
+++ b/packages/css/src/details.css
@@ -88,16 +88,6 @@
     }
   }
 
-  & > :not(summary, u-summary) {
-    border-radius: inherit;
-    padding-inline: var(--ds-size-5, 1rem);
-    &:nth-child(2) {
-      padding-block-start: var(--ds-size-5, 1rem);
-    }
-    &:last-child {
-      padding-block-end: var(--ds-size-5, 1rem);
-    }
-  }
   &[open] > :is(summary, u-summary) {
     background: var(--dsc-details-summary-background--open);
 
@@ -126,5 +116,17 @@
 
   &[open]::part(details-content) {
     height: auto;
+  }
+}
+
+/* Wrap in :where to allow all other komponents to overwrite (i.e placing a <Button> inside <Details>) */
+:where(.ds-details > :not(summary, u-summary)) {
+  border-radius: inherit;
+  margin-inline: var(--ds-size-5, 1rem);
+  &:nth-child(2) {
+    margin-block-start: var(--ds-size-5, 1rem);
+  }
+  &:last-child {
+    margin-block-end: var(--ds-size-5, 1rem);
   }
 }

--- a/packages/css/src/details.css
+++ b/packages/css/src/details.css
@@ -119,7 +119,7 @@
   }
 }
 
-/* Wrap in :where to allow all other komponents to overwrite (i.e placing a <Button> inside <Details>) */
+/* Wrap in :where to allow all other components to overwrite (i.e placing a <Button> inside <Details>) */
 :where(.ds-details > :not(summary, u-summary)) {
   border-radius: inherit;
   margin-inline: var(--ds-size-5, 1rem);

--- a/packages/react/src/components/details/details.stories.tsx
+++ b/packages/react/src/components/details/details.stories.tsx
@@ -144,3 +144,12 @@ export const Controlled: StoryFn<typeof Details> = () => {
     </>
   );
 };
+
+export const WithDirectContent: StoryFn<typeof Details> = () => (
+  <Card>
+    <Details>
+      <Details.Summary>Vedlegg</Details.Summary>
+      <Button>Knapp</Button>
+    </Details>
+  </Card>
+);


### PR DESCRIPTION
## Summary

Details element is [supposed to support direct children](https://github.com/digdir/designsystemet/pull/3796), but due to CSS selector specificity, elements with `padding` or `border-radius` (such as buttons) broke. This branch fixes the issue.

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
