### PR TITLE
docs: remove size-table in list

### DIFF
--- a/packages/react/src/components/list/list.mdx
+++ b/packages/react/src/components/list/list.mdx
@@ -45,12 +45,6 @@ Liste kan brukes sammen med en `Heading` for å gi brukeren en rask oversikt ove
 Størrelse på overskrifter over lister er avhengig av bruksområde, og er derfor noe du må sette selv.
 I løpende tekst anbefaler vi disse størrelsene:
 
-| Størrelse på `List` | Størrelse på `Heading` |
-| :----------------- | :---------------------- |
-| sm                 | 2xs                     |
-| md                 | xs                      |
-| lg                 | sm                      |
-
 <Canvas of={ListStories.ListeMedOverskrift} />
 
 ### Lister i lister


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

Since the sizes are shown in the code example we dont need the table.

## Checks

- [ ] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)
