### PR TITLE
fix(skeleton): deprecate unused `characters` prop

### DIFF
--- a/.changeset/tangy-cows-jump.md
+++ b/.changeset/tangy-cows-jump.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+**Skeleton**: Deprecate `characters` prop, which never had any effect.

--- a/packages/react/src/components/skeleton/skeleton.tsx
+++ b/packages/react/src/components/skeleton/skeleton.tsx
@@ -23,11 +23,9 @@ export type SkeletonProps = {
    * @default false
    */
   asChild?: boolean;
-} & HTMLAttributes<HTMLSpanElement> &
-  (
-    | { variant: 'text'; characters?: number }
-    | { variant?: 'rectangle' | 'circle'; characters?: never }
-  );
+  /** @deprecated This prop has no effect. Use `width` or supply text as children instead */
+  characters?: number;
+} & HTMLAttributes<HTMLSpanElement>;
 
 /**
  * Skeleton is used to represent a draft of page while the content loads.


### PR DESCRIPTION
## Summary

Deprecate `characters` prop in Skeleton, which has never been used in code that has been merged to main. Maybe it was used during development of Skeleton at some point?

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
