### PR TITLE
fix(badge): allow custom positioning

### DIFF
--- a/.changeset/lucky-pandas-see.md
+++ b/.changeset/lucky-pandas-see.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": minor
+---
+
+**Badge**: Allow adjusting the position of the badge using css variables `--dsc-badge-{top,bottom,left,right}`

--- a/packages/css/src/badge.css
+++ b/packages/css/src/badge.css
@@ -3,6 +3,10 @@
   --dsc-badge-color: var(--ds-color-base-contrast-default);
   --dsc-badge-padding: 0 calc(var(--ds-size-1) + calc(var(--ds-size-1) / 2));
   --dsc-badge-size: calc(var(--ds-size-3) + calc(var(--ds-size-1) / 2));
+  --dsc-badge-top: inherit;
+  --dsc-badge-bottom: inherit;
+  --dsc-badge-left: inherit;
+  --dsc-badge-right: inherit;
   @composes ds-print-preserve from './base.css';
 
   &::before {

--- a/packages/css/src/badge.css
+++ b/packages/css/src/badge.css
@@ -88,26 +88,26 @@
   }
 
   &[data-placement='top-right'][data-overlap='circle'] .ds-badge::before {
-    top: 14%;
-    right: 14%;
+    top: var(--dsc-badge-top, 14%);
+    right: var(--dsc-badge-right, 14%);
     translate: 50% -50%;
   }
 
   &[data-placement='top-left'][data-overlap='circle'] .ds-badge::before {
-    top: 14%;
-    left: 14%;
+    top: var(--dsc-badge-top, 14%);
+    left: var(--dsc-badge-left, 14%);
     translate: -50% -50%;
   }
 
   &[data-placement='bottom-right'][data-overlap='circle'] .ds-badge::before {
-    bottom: 14%;
-    right: 14%;
+    bottom: var(--dsc-badge-bottom, 14%);
+    right: var(--dsc-badge-right, 14%);
     translate: 50% 50%;
   }
 
   &[data-placement='bottom-left'][data-overlap='circle'] .ds-badge::before {
-    bottom: 14%;
-    left: 14%;
+    bottom: var(--dsc-badge-bottom, 14%);
+    left: var(--dsc-badge-left, 14%);
     translate: -50% 50%;
   }
 }

--- a/packages/css/src/badge.css
+++ b/packages/css/src/badge.css
@@ -48,6 +48,10 @@
 
   & .ds-badge::before {
     position: absolute;
+    top: var(--dsc-badge-top);
+    bottom: var(--dsc-badge-bottom);
+    left: var(--dsc-badge-left);
+    right: var(--dsc-badge-right);
   }
 
   & :where(img, svg) {
@@ -56,26 +60,26 @@
   }
 
   &[data-placement='top-right'] .ds-badge::before {
-    top: 0;
-    right: 0;
+    top: var(--dsc-badge-top, 0);
+    right: var(--dsc-badge-right, 0);
     translate: 50% -50%;
   }
 
   &[data-placement='top-left'] .ds-badge::before {
-    top: 0;
-    left: 0;
+    top: var(--dsc-badge-top, 0);
+    left: var(--dsc-badge-left, 0);
     translate: -50% -50%;
   }
 
   &[data-placement='bottom-right'] .ds-badge::before {
-    bottom: 0;
-    right: 0;
+    bottom: var(--dsc-badge-bottom, 0);
+    right: var(--dsc-badge-right, 0);
     translate: 50% 50%;
   }
 
   &[data-placement='bottom-left'] .ds-badge::before {
-    bottom: 0;
-    left: 0;
+    bottom: var(--dsc-badge-bottom, 0);
+    left: var(--dsc-badge-left, 0);
     translate: -50% 50%;
   }
 

--- a/packages/react/src/components/badge/badge.stories.tsx
+++ b/packages/react/src/components/badge/badge.stories.tsx
@@ -8,6 +8,7 @@ import {
   VideoIcon,
 } from '@navikt/aksel-icons';
 import type { Meta, StoryFn } from '@storybook/react-vite';
+import type { CSSProperties } from 'react';
 import { Badge, Button, Tabs } from '../';
 
 type Story = StoryFn<typeof Badge>;
@@ -107,10 +108,12 @@ export const CustomPlacement: Story = () => (
   <>
     <Badge.Position
       placement='top-right'
-      style={{
-        top: '16%',
-        right: '10%',
-      }}
+      style={
+        {
+          '--dsc-badge-top': '16%',
+          '--dsc-badge-right': '10%',
+        } as CSSProperties
+      }
     >
       <Badge data-color='accent'></Badge>
       <EnvelopeClosedFillIcon title='Meldinger' />


### PR DESCRIPTION
## Summary

Adds support (through css variables) and fixes example story for custom positioning of Badge. The example didn't actually move the badge, but now it does.

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
