### PR TITLE
fix(cli): rename config so token-studio ignores it

### DIFF
--- a/.changeset/lucky-ghosts-make.md
+++ b/.changeset/lucky-ghosts-make.md
@@ -1,5 +1,4 @@
 ---
-"@digdir/designsystemet-theme": patch
 "@digdir/designsystemet": minor
 ---
 

--- a/.changeset/lucky-ghosts-make.md
+++ b/.changeset/lucky-ghosts-make.md
@@ -1,0 +1,6 @@
+---
+"@digdir/designsystemet-theme": patch
+"@digdir/designsystemet": patch
+---
+
+Renamed $designsystemet.json to $designsystemet.jsonc so token-studio ignores the file

--- a/.changeset/lucky-ghosts-make.md
+++ b/.changeset/lucky-ghosts-make.md
@@ -1,6 +1,6 @@
 ---
 "@digdir/designsystemet-theme": patch
-"@digdir/designsystemet": patch
+"@digdir/designsystemet": minor
 ---
 
 Renamed $designsystemet.json to $designsystemet.jsonc so token-studio ignores the file

--- a/design-tokens/$designsystemet.jsonc
+++ b/design-tokens/$designsystemet.jsonc
@@ -1,4 +1,4 @@
 {
   "name": "@digdir/designsystemet",
-  "version": "1.1.5"
+  "version": "1.2.0"
 }

--- a/internal/design-tokens/$designsystemet.jsonc
+++ b/internal/design-tokens/$designsystemet.jsonc
@@ -1,0 +1,4 @@
+{
+  "name": "@digdir/designsystemet",
+  "version": "1.2.0"
+}

--- a/packages/cli/src/scripts/update-design-tokens.ts
+++ b/packages/cli/src/scripts/update-design-tokens.ts
@@ -28,7 +28,7 @@ async function updateDesignTokens() {
   await cp(path.join(INTERNAL, 'semantic'), path.join(TARGET, 'semantic'));
 
   await cp(path.join(INTERNAL, 'themes'), path.join(TARGET, 'themes'));
-  await cp(path.join(INTERNAL, '$designsystemet.json'), path.join(TARGET, '$designsystemet.json'));
+  await cp(path.join(INTERNAL, '$designsystemet.jsonc'), path.join(TARGET, '$designsystemet.jsonc'));
 
   console.log('✅ Finished copying design tokens');
 }

--- a/packages/cli/src/tokens/build.ts
+++ b/packages/cli/src/tokens/build.ts
@@ -32,7 +32,7 @@ export const buildTokens = async (options: Omit<BuildOptions, 'type' | 'processe
   let $designsystemet: DesignsystemetObject | undefined;
 
   try {
-    const $designsystemetContent = await readFile(`${tokensDir}/$designsystemet.json`);
+    const $designsystemetContent = await readFile(`${tokensDir}/$designsystemet.jsonc`);
     $designsystemet = JSON.parse($designsystemetContent) as DesignsystemetObject;
   } catch (_error) {}
 

--- a/packages/cli/src/tokens/create/write.ts
+++ b/packages/cli/src/tokens/create/write.ts
@@ -28,7 +28,7 @@ export const writeTokens = async (options: WriteTokensOptions) => {
   const targetDir = path.resolve(process.cwd(), String(outDir));
   const $themesPath = path.join(targetDir, '$themes.json');
   const $metadataPath = path.join(targetDir, '$metadata.json');
-  const $designsystemetPath = path.join(targetDir, '$designsystemet.json');
+  const $designsystemetPath = path.join(targetDir, '$designsystemet.jsonc');
   let themeObjects: ThemeObject[] = [];
 
   await mkdir(targetDir, dry);

--- a/packages/theme/brand/altinn.css
+++ b/packages/theme/brand/altinn.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
-build: v1.1.5
-design-tokens: v1.1.5
+build: v1.2.0
+design-tokens: v1.2.0
 */
 
 @layer ds.theme.color-scheme.light {

--- a/packages/theme/brand/colors.d.ts
+++ b/packages/theme/brand/colors.d.ts
@@ -1,5 +1,5 @@
 /* This file is deprecated and will be removed in a future release. Use types.d.ts instead */
-/* build: v1.1.5 */
+/* build: v1.2.0 */
 import type {} from '@digdir/designsystemet/types';
 
 // Augment types based on theme

--- a/packages/theme/brand/digdir.css
+++ b/packages/theme/brand/digdir.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
-build: v1.1.5
-design-tokens: v1.1.5
+build: v1.2.0
+design-tokens: v1.2.0
 */
 
 @layer ds.theme.color-scheme.light {

--- a/packages/theme/brand/portal.css
+++ b/packages/theme/brand/portal.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
-build: v1.1.5
-design-tokens: v1.1.5
+build: v1.2.0
+design-tokens: v1.2.0
 */
 
 @layer ds.theme.color-scheme.light {

--- a/packages/theme/brand/types.d.ts
+++ b/packages/theme/brand/types.d.ts
@@ -1,4 +1,4 @@
-/* build: v1.1.5 */
+/* build: v1.2.0 */
 import type {} from '@digdir/designsystemet/types';
 
 // Augment types based on theme

--- a/packages/theme/brand/uutilsynet.css
+++ b/packages/theme/brand/uutilsynet.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
-build: v1.1.5
-design-tokens: v1.1.5
+build: v1.2.0
+design-tokens: v1.2.0
 */
 
 @layer ds.theme.color-scheme.light {

--- a/packages/theme/src/themes/colors.d.ts
+++ b/packages/theme/src/themes/colors.d.ts
@@ -1,5 +1,5 @@
 /* This file is deprecated and will be removed in a future release. Use types.d.ts instead */
-/* build: v1.1.5 */
+/* build: v1.2.0 */
 import type {} from '@digdir/designsystemet/types';
 
 // Augment types based on theme

--- a/packages/theme/src/themes/designsystemet.css
+++ b/packages/theme/src/themes/designsystemet.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
-build: v1.1.5
-design-tokens: v1.1.5
+build: v1.2.0
+design-tokens: v1.2.0
 */
 
 @layer ds.theme.color-scheme.light {

--- a/packages/theme/src/themes/types.d.ts
+++ b/packages/theme/src/themes/types.d.ts
@@ -1,4 +1,4 @@
-/* build: v1.1.5 */
+/* build: v1.2.0 */
 import type {} from '@digdir/designsystemet/types';
 
 // Augment types based on theme


### PR DESCRIPTION
resolves #3790

I propose we just rename the config file to $designsystemet.jsonc. It does not make a difference to us and token-studio will ignore it then. 