### PR TITLE
fix(Switch): correct jsdoc on `label` prop

### DIFF
--- a/.changeset/short-teams-design.md
+++ b/.changeset/short-teams-design.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+**Switch**: correct jsdoc on `label` prop

--- a/packages/react/src/components/switch/switch.tsx
+++ b/packages/react/src/components/switch/switch.tsx
@@ -14,7 +14,7 @@ export type SwitchProps = MergeRight<
      */
     'aria-label'?: string;
     /**
-     * Radio label
+     * Switch label
      */
     label?: ReactNode;
     /**


### PR DESCRIPTION
## Summary

`label` prop on `Switch` incorrectly has the jsdoc description "Radio label". Changed to "Switch label".
## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
