### PR TITLE
fix(storybook): "interaction step" button dark mode

### DIFF
--- a/apps/storybook/.storybook/manager-head.html
+++ b/apps/storybook/.storybook/manager-head.html
@@ -348,6 +348,9 @@
     &:hover {
       background: var(--ds-color-neutral-base-hover) !important;
     }
+    &[aria-label~='step'] {
+      background-color: white !important;
+    }
   }
 
   & input,


### PR DESCRIPTION
hotfix the storybook interactions step button not being readable in either dark or light mode
Since we can not control the syntax-highligted text colors inside, the background should always be white
