### PR TITLE
fix(www, themebuilder): header a11y fixes

### DIFF
--- a/apps/themebuilder/app/_components/sidebar/sidebar.module.css
+++ b/apps/themebuilder/app/_components/sidebar/sidebar.module.css
@@ -85,7 +85,6 @@
   border-radius: 50%;
   border: 1px solid var(--ds-color-neutral-border-subtle);
   display: none;
-  z-index: 5;
   background-color: var(--ds-color-neutral-background-default);
   cursor: pointer;
   place-items: center;

--- a/apps/themebuilder/app/app.css
+++ b/apps/themebuilder/app/app.css
@@ -180,3 +180,10 @@ body {
 .content {
   min-height: 100svh;
 }
+
+@layer overrides {
+  .ds-skip-link:focus {
+    position: relative;
+    z-index: 1;
+  }
+}

--- a/apps/www/app/app.css
+++ b/apps/www/app/app.css
@@ -227,3 +227,9 @@ body {
     }
   }
 }
+@layer overrides {
+  .ds-skip-link:focus {
+    position: relative;
+    z-index: 1;
+  }
+}

--- a/internal/components/src/header/header.module.css
+++ b/internal/components/src/header/header.module.css
@@ -63,9 +63,8 @@
       &[data-mobile='true'] {
         & .desktopMenu {
           display: none;
+        }
       }
-      }
-
     }
   }
 }

--- a/internal/components/src/header/header.module.css
+++ b/internal/components/src/header/header.module.css
@@ -25,10 +25,6 @@
       display: flex;
       gap: var(--ds-size-2);
 
-      &[data-mobile='true'] {
-        flex-direction: row-reverse;
-      }
-
       & button {
         height: fit-content;
       }
@@ -64,6 +60,12 @@
           }
         }
       }
+      &[data-mobile='true'] {
+        & .desktopMenu {
+          display: none;
+      }
+      }
+
     }
   }
 }

--- a/internal/components/src/header/header.tsx
+++ b/internal/components/src/header/header.tsx
@@ -12,7 +12,13 @@ import {
   XMarkIcon,
 } from '@navikt/aksel-icons';
 import cl from 'clsx/lite';
-import { type MouseEvent, type FocusEvent, useEffect, useRef, useState } from 'react';
+import {
+  type FocusEvent,
+  type MouseEvent,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useLocation } from 'react-router';
 import { DsEmbledLogo, DsFullLogo } from '../logos/designsystemet';
@@ -94,7 +100,7 @@ const Header = ({
     ) {
       setOpen(false);
     }
-  }
+  };
 
   const handleThemeChange = (
     newTheme: 'dark' | 'light',
@@ -161,6 +167,7 @@ const Header = ({
   }, [menu, isHamburger, viewportWidth]);
 
   return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: onBlur bubbles from children that are interactive and must be captured here
     <header
       className={cl(
         classes.header,
@@ -265,52 +272,54 @@ const Header = ({
           </Dropdown.TriggerContext>
           {isHamburger && (
             <>
-            <Button
-              variant='tertiary'
-              icon={true}
-              data-color='neutral'
-              aria-expanded={open}
-              aria-label={open ? t('header.close-menu') : t('header.open-menu')}
-              className={cl(classes.toggle, 'ds-focus')}
-              onClick={() => {
-                setOpen(!open);
-              }}
-            >
-              {open && (
-                <XMarkIcon
-                  aria-hidden
-                  fontSize={26}
-                  color='var(--ds-color-neutral-text-default)'
-                />
-              )}
-              {!open && (
-                <MenuHamburgerIcon
-                  aria-hidden
-                  fontSize={26}
-                  color='var(--ds-color-neutral-text-default)'
-                />
-              )}
-            </Button>
-            <ul data-open={open}>
-            {menu.map((item, index) => (
-              <li key={index}>
-                <Paragraph data-size='md' asChild>
-                  <Link
-                    suppressHydrationWarning
-                    to={item.href}
-                    onClick={() => setOpen(false)}
-                    className={cl(
-                      pathname?.includes(item.href) && classes.active,
-                      'ds-focus',
-                    )}
-                  >
-                    {t(item.name)}
-                  </Link>
-                </Paragraph>
-              </li>
-            ))}
-          </ul>
-          </>
+              <Button
+                variant='tertiary'
+                icon={true}
+                data-color='neutral'
+                aria-expanded={open}
+                aria-label={
+                  open ? t('header.close-menu') : t('header.open-menu')
+                }
+                className={cl(classes.toggle, 'ds-focus')}
+                onClick={() => {
+                  setOpen(!open);
+                }}
+              >
+                {open && (
+                  <XMarkIcon
+                    aria-hidden
+                    fontSize={26}
+                    color='var(--ds-color-neutral-text-default)'
+                  />
+                )}
+                {!open && (
+                  <MenuHamburgerIcon
+                    aria-hidden
+                    fontSize={26}
+                    color='var(--ds-color-neutral-text-default)'
+                  />
+                )}
+              </Button>
+              <ul data-open={open}>
+                {menu.map((item, index) => (
+                  <li key={index}>
+                    <Paragraph data-size='md' asChild>
+                      <Link
+                        suppressHydrationWarning
+                        to={item.href}
+                        onClick={() => setOpen(false)}
+                        className={cl(
+                          pathname?.includes(item.href) && classes.active,
+                          'ds-focus',
+                        )}
+                      >
+                        {t(item.name)}
+                      </Link>
+                    </Paragraph>
+                  </li>
+                ))}
+              </ul>
+            </>
           )}
         </nav>
       </div>


### PR DESCRIPTION
resolves #4011 

- Fixed skip-link being clipped behind header
- Fixed tab-order of header elements in mobile view
- mobile menu if open is closed when tabbing out of the header
- Added logic to restore to desktop mode when resizing window up again (its still dynamic js instead of media query) 
- themebuilder: fixed the sidebar toggle button overlaying the mobile menu

since `reading-flow: flex-visual;` is only in chromium for now I opted to create a conditionally rendered mobile only menu after the hamburger button so it works in all browsers