### PR TITLE
fix(button): dont render double icons on icon-only-button when loading

### DIFF
--- a/packages/react/src/components/button/button.test.tsx
+++ b/packages/react/src/components/button/button.test.tsx
@@ -8,6 +8,13 @@ import { Button } from './button';
 const user = userEvent.setup();
 
 describe('Button', () => {
+  beforeAll(() => {
+    // Spinner for loading state uses animations, which we need to mock
+    if (!document.getAnimations) {
+      document.getAnimations = () => [];
+    }
+  });
+
   it('should render as aria-disabled when aria-disabled is true regardless of variant', () => {
     render({
       'aria-disabled': true,
@@ -58,6 +65,12 @@ describe('Button', () => {
     render({ asChild: true, children: <a href='#'>Link</a> });
     expect(screen.getByRole('link')).not.toHaveAttribute('type');
     expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('should not render children when icon-only button is loading', () => {
+    render({ loading: true, icon: true, children: 'Button text' });
+    expect(screen.queryByText('Button text')).toBeNull();
+    expect(screen.getByRole('button')).toHaveAttribute('aria-busy');
   });
 });
 

--- a/packages/react/src/components/button/button.tsx
+++ b/packages/react/src/components/button/button.tsx
@@ -84,7 +84,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         ) : (
           loading // Allow custom loading spinner
         )}
-        <Slottable>{children}</Slottable>
+        <Slottable>{icon && loading ? null : children}</Slottable>
       </Component>
     );
   },


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

<!-- Explain in short what this PR does -->

## Checks

- [ ] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)
