### PR TITLE
chore(storybook): remove addon-html plugin

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -81,7 +81,6 @@ const config: StorybookConfig = {
     '@storybook/addon-themes',
     'storybook-addon-pseudo-states',
     '@storybook/addon-vitest',
-    //'@whitespace/storybook-addon-html', //wait for it to be updated to support sb9
     {
       name: '@storybook/addon-docs',
       options: {

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -34,7 +34,6 @@
     "@types/react-dom": "^19.1.9",
     "@vitest/browser": "3.2.4",
     "@vitest/coverage-v8": "3.2.4",
-    "@whitespace/storybook-addon-html": "^7.0.0",
     "axe-playwright": "^2.1.0",
     "playwright": "^1.55.0",
     "prettier": "^3.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,9 +122,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: 3.2.4
         version: 3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)
-      '@whitespace/storybook-addon-html':
-        specifier: ^7.0.0
-        version: 7.0.0(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@22.18.0)(jiti@2.4.2)(less@4.3.0)(lightningcss@1.30.1)(sass@1.87.0)(stylus@0.62.0)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))
       axe-playwright:
         specifier: ^2.1.0
         version: 2.1.0(playwright@1.55.0)
@@ -299,7 +296,7 @@ importers:
         version: 5.1.30
       mdx-bundler:
         specifier: ^10.1.1
-        version: 10.1.1(acorn@8.14.1)(esbuild@0.25.9)
+        version: 10.1.1(acorn@8.15.0)(esbuild@0.25.9)
       ramda:
         specifier: ^0.31.3
         version: 0.31.3
@@ -2662,11 +2659,6 @@ packages:
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
-
-  '@whitespace/storybook-addon-html@7.0.0':
-    resolution: {integrity: sha512-GCpy1Xch7v3UZ/TmKUFnF0lFEt6qct/zqO/64LfoEOwr3zV5YDdidHBURSNp5qK8Q68wPLs/nVhbAzAEvudR8w==}
-    peerDependencies:
-      storybook: ^8.2.0
 
   '@zip.js/zip.js@2.7.60':
     resolution: {integrity: sha512-vA3rLyqdxBrVo1FWSsbyoecaqWTV+vgPRf0QKeM7kVDG0r+lHUqd7zQDv1TO9k4BcAoNzNDSNrrel24Mk6addA==}
@@ -7088,9 +7080,9 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mdx-js/esbuild@3.1.0(acorn@8.14.1)(esbuild@0.25.9)':
+  '@mdx-js/esbuild@3.1.0(acorn@8.15.0)(esbuild@0.25.9)':
     dependencies:
-      '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
+      '@mdx-js/mdx': 3.1.0(acorn@8.15.0)
       '@types/unist': 3.0.3
       esbuild: 0.25.9
       source-map: 0.7.4
@@ -7100,7 +7092,7 @@ snapshots:
       - acorn
       - supports-color
 
-  '@mdx-js/mdx@3.1.0(acorn@8.14.1)':
+  '@mdx-js/mdx@3.1.0(acorn@8.15.0)':
     dependencies:
       '@types/estree': 1.0.8
       '@types/estree-jsx': 1.0.5
@@ -7114,7 +7106,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
-      recma-jsx: 1.0.0(acorn@8.14.1)
+      recma-jsx: 1.0.0(acorn@8.15.0)
       recma-stringify: 1.0.0
       rehype-recma: 1.0.0
       remark-mdx: 3.1.0
@@ -8239,10 +8231,6 @@ snapshots:
       loupe: 3.1.4
       tinyrainbow: 2.0.0
 
-  '@whitespace/storybook-addon-html@7.0.0(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@22.18.0)(jiti@2.4.2)(less@4.3.0)(lightningcss@1.30.1)(sass@1.87.0)(stylus@0.62.0)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))':
-    dependencies:
-      storybook: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@22.18.0)(jiti@2.4.2)(less@4.3.0)(lightningcss@1.30.1)(sass@1.87.0)(stylus@0.62.0)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
-
   '@zip.js/zip.js@2.7.60': {}
 
   accepts@1.3.8:
@@ -8254,10 +8242,13 @@ snapshots:
     dependencies:
       acorn: 8.14.1
 
+  acorn-jsx@5.3.2(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+
   acorn@8.14.1: {}
 
-  acorn@8.15.0:
-    optional: true
+  acorn@8.15.0: {}
 
   agent-base@7.1.3: {}
 
@@ -9983,12 +9974,12 @@ snapshots:
 
   mdn-data@2.12.2: {}
 
-  mdx-bundler@10.1.1(acorn@8.14.1)(esbuild@0.25.9):
+  mdx-bundler@10.1.1(acorn@8.15.0)(esbuild@0.25.9):
     dependencies:
       '@babel/runtime': 7.27.1
       '@esbuild-plugins/node-resolve': 0.2.2(esbuild@0.25.9)
       '@fal-works/esbuild-plugin-global-externals': 2.1.2
-      '@mdx-js/esbuild': 3.1.0(acorn@8.14.1)(esbuild@0.25.9)
+      '@mdx-js/esbuild': 3.1.0(acorn@8.15.0)(esbuild@0.25.9)
       esbuild: 0.25.9
       gray-matter: 4.0.3
       remark-frontmatter: 5.0.0
@@ -11023,9 +11014,9 @@ snapshots:
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
-  recma-jsx@1.0.0(acorn@8.14.1):
+  recma-jsx@1.0.0(acorn@8.15.0):
     dependencies:
-      acorn-jsx: 5.3.2(acorn@8.14.1)
+      acorn-jsx: 5.3.2(acorn@8.15.0)
       estree-util-to-js: 2.0.0
       recma-parse: 1.0.0
       recma-stringify: 1.0.0


### PR DESCRIPTION
The plugin is still not showing formatted html after new release and does not work well in dark mode, so we'll remove it. html output can still be seen in the docs pages as this uses our own custom code and of course in the new storefront component pages