### PR TITLE
fix(Field.Counter): update when react controls input

### DIFF
--- a/.changeset/rotten-pans-ring.md
+++ b/.changeset/rotten-pans-ring.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+**Field.Counter**: Update count when react controls the input

--- a/packages/react/src/components/field/field-counter.tsx
+++ b/packages/react/src/components/field/field-counter.tsx
@@ -47,6 +47,7 @@ export const FieldCounter = forwardRef<HTMLParagraphElement, FieldCounterProps>(
     ref,
   ) {
     const [count, setCount] = useState(0);
+    const fieldInputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
     const counterRef = useRef<HTMLDivElement>(null);
     const hasExceededLimit = count > limit;
     const remainder = limit - count;
@@ -62,6 +63,7 @@ export const FieldCounter = forwardRef<HTMLParagraphElement, FieldCounterProps>(
       };
 
       if (input) onInput({ target: input }); // Initial setup
+      fieldInputRef.current = input as HTMLInputElement | HTMLTextAreaElement;
 
       field?.addEventListener('input', onInput);
       return () => field?.removeEventListener('input', onInput);
@@ -70,12 +72,8 @@ export const FieldCounter = forwardRef<HTMLParagraphElement, FieldCounterProps>(
     /* React does not dispatch a native input event when the value prop changes externally.
     Since the parent re-renders this component when value changes, we can sync on render. */
     useEffect(() => {
-      const field = counterRef.current?.closest('.ds-field');
-      const input = Array.from(field?.getElementsByTagName('*') || []).find(
-        isInputLike,
-      );
-      if (input) {
-        const valueLength = input.value.length;
+      if (fieldInputRef.current) {
+        const valueLength = fieldInputRef.current.value.length;
         setCount((prev) => (prev === valueLength ? prev : valueLength));
       }
     });

--- a/packages/react/src/components/field/field-counter.tsx
+++ b/packages/react/src/components/field/field-counter.tsx
@@ -51,6 +51,7 @@ export const FieldCounter = forwardRef<HTMLParagraphElement, FieldCounterProps>(
     const hasExceededLimit = count > limit;
     const remainder = limit - count;
 
+    // Listen to native input events (user typing) to update the counter in real time
     useEffect(() => {
       const field = counterRef.current?.closest('.ds-field');
       const input = Array.from(field?.getElementsByTagName('*') || []).find(
@@ -64,7 +65,20 @@ export const FieldCounter = forwardRef<HTMLParagraphElement, FieldCounterProps>(
 
       field?.addEventListener('input', onInput);
       return () => field?.removeEventListener('input', onInput);
-    }, [setCount]);
+    }, []);
+
+    /* React does not dispatch a native input event when the value prop changes externally.
+    Since the parent re-renders this component when value changes, we can sync on render. */
+    useEffect(() => {
+      const field = counterRef.current?.closest('.ds-field');
+      const input = Array.from(field?.getElementsByTagName('*') || []).find(
+        isInputLike,
+      );
+      if (input) {
+        const valueLength = input.value.length;
+        setCount((prev) => (prev === valueLength ? prev : valueLength));
+      }
+    });
 
     return (
       <>

--- a/packages/react/src/components/textfield/textfield.stories.tsx
+++ b/packages/react/src/components/textfield/textfield.stories.tsx
@@ -48,7 +48,7 @@ export const Counter: Story = {
 };
 
 export const Controlled: StoryFn<typeof Textfield> = () => {
-  const [value, setValue] = useState<string>('');
+  const [value, setValue] = useState<string>('Ost');
   return (
     <>
       <Textfield

--- a/packages/react/src/components/textfield/textfield.stories.tsx
+++ b/packages/react/src/components/textfield/textfield.stories.tsx
@@ -55,6 +55,7 @@ export const Controlled: StoryFn<typeof Textfield> = () => {
         label='Kontroller meg!'
         value={value}
         onChange={(e) => setValue(e.target.value)}
+        counter={5}
       />
 
       <Divider style={{ marginTop: 'var(--ds-size-4)' }} />

--- a/packages/react/src/components/textfield/textfield.test.tsx
+++ b/packages/react/src/components/textfield/textfield.test.tsx
@@ -105,15 +105,12 @@ describe('Textfield', () => {
       <Textfield label='Test' counter={5} value='' onChange={() => {}} />,
     );
 
-    // Initial counter text
     expect(screen.getByText('5 tegn igjen')).toBeInTheDocument();
 
-    // Update value programmatically
     rerender(
       <Textfield label='Test' counter={5} value='123' onChange={() => {}} />,
     );
 
-    // Effect runs synchronously after render cycle, so no need for waitFor/async
     expect(screen.getByText('2 tegn igjen')).toBeInTheDocument();
   });
 

--- a/packages/react/src/components/textfield/textfield.test.tsx
+++ b/packages/react/src/components/textfield/textfield.test.tsx
@@ -99,6 +99,37 @@ describe('Textfield', () => {
     render({ type, 'aria-label': 'label' });
     expect(screen.getByRole('textbox')).toHaveAttribute('type', type);
   });
+
+  it('updates counter when value prop changes programmatically', () => {
+    const { rerender } = renderRtl(
+      <Textfield label='Test' counter={5} value='' onChange={() => {}} />,
+    );
+
+    // Initial counter text
+    expect(screen.getByText('5 tegn igjen')).toBeInTheDocument();
+
+    // Update value programmatically
+    rerender(
+      <Textfield label='Test' counter={5} value='123' onChange={() => {}} />,
+    );
+
+    // Effect runs synchronously after render cycle, so no need for waitFor/async
+    expect(screen.getByText('2 tegn igjen')).toBeInTheDocument();
+  });
+
+  it('shows over limit message when value exceeds limit via prop change', () => {
+    const { rerender } = renderRtl(
+      <Textfield label='Test' counter={3} value='' onChange={() => {}} />,
+    );
+
+    expect(screen.getByText('3 tegn igjen')).toBeInTheDocument();
+
+    rerender(
+      <Textfield label='Test' counter={3} value={'abcd'} onChange={() => {}} />,
+    );
+
+    expect(screen.getAllByText('1 tegn for mye')[0]).toBeInTheDocument();
+  });
 });
 
 const render = (


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

resolves #3900

This is **NOT** an ideal solution, but I think this is fine.
It will rerender anyways, and a page will most likely not have a lot of counters, so this should not cause any huge performance impacts.
See https://pr-4047.storybook.designsystemet.no/?path=/story/komponenter-textfield--controlled

## Checks

- [ ] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)
