### PR TITLE
fix(Popover): only call `onClose` when popover is open

### DIFF
--- a/.changeset/unlucky-wombats-dream.md
+++ b/.changeset/unlucky-wombats-dream.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+**Popover**: Only call `onClose` when `Popover` is open

--- a/packages/react/src/components/popover/popover.test.tsx
+++ b/packages/react/src/components/popover/popover.test.tsx
@@ -163,4 +163,18 @@ describe('Popover', () => {
     );
     expect(content).toBeVisible();
   });
+
+  it('should not call onClose when the popover is closed', async () => {
+    const onClose = vi.fn();
+    const { user } = await render({ onClose });
+    const popoverTrigger = screen.getByRole('button');
+
+    await act(async () => await user.click(document.body));
+    expect(onClose).toHaveBeenCalledTimes(0);
+
+    await act(async () => await user.click(popoverTrigger));
+    expect(screen.queryByText(contentText)).toBeVisible();
+    await act(async () => await user.click(document.body));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/react/src/components/popover/popover.tsx
+++ b/packages/react/src/components/popover/popover.tsx
@@ -134,7 +134,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
           setInternalOpen((open) => !open);
           onOpen?.();
         }
-        if (isOutside) {
+        if (isOutside && internalOpen) {
           setInternalOpen(false);
           onClose?.();
         }


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

resolves #4064

## Checks

- [ ] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)
