### PR TITLE
fix: point to the right language in themebuilder menu

### DIFF
--- a/apps/www/app/root.tsx
+++ b/apps/www/app/root.tsx
@@ -100,7 +100,7 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
     },
     {
       name: 'navigation.theme-builder',
-      href: 'https://theme.designsystemet.no',
+      href: `https://theme.designsystemet.no/${lang}`,
     },
   ];
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

<!-- Explain in short what this PR does -->

Fixes a bug where the menu in the English version of  https://www.designsystemet.no's menu would take you to the Norwegian version of the themebuilder.

Steps to reproduce the original problem:
- Go to https://www.designsystemet.no/no
- Change language to English (url is now https://www.designsystemet.no/en)
- Click themebuilder
- You are taken to https://theme.designsystemet.no/no (wrong language)

After the fix, it should instead:

- Go to https://www.designsystemet.no/no
- Change language to English (url is now https://www.designsystemet.no/en)
- Click themebuilder
- You are taken to https://theme.designsystemet.no/en (correct language)

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)
