### PR TITLE
fix(cli,theme): round font variables

### DIFF
--- a/.changeset/cruel-breads-see.md
+++ b/.changeset/cruel-breads-see.md
@@ -1,0 +1,6 @@
+---
+"@digdir/designsystemet-theme": patch
+"@digdir/designsystemet": patch
+---
+
+Font size variables are now rounded to the nearest pixel. This affects size modes "sm" and "lg", which had subpixel values after v1.5.0.

--- a/apps/www/app/_components/tokens/design-tokens/type-scale.json
+++ b/apps/www/app/_components/tokens/design-tokens/type-scale.json
@@ -5,7 +5,7 @@
       "1"
     ],
     "variable": "--ds-font-size-1",
-    "value": "calc(0.75rem * var(--_ds-font-size-factor))"
+    "value": "round(calc(0.75rem * var(--_ds-font-size-factor)), 1px)"
   },
   {
     "path": [
@@ -13,7 +13,7 @@
       "2"
     ],
     "variable": "--ds-font-size-2",
-    "value": "calc(0.875rem * var(--_ds-font-size-factor))"
+    "value": "round(calc(0.875rem * var(--_ds-font-size-factor)), 1px)"
   },
   {
     "path": [
@@ -21,7 +21,7 @@
       "3"
     ],
     "variable": "--ds-font-size-3",
-    "value": "calc(1rem * var(--_ds-font-size-factor))"
+    "value": "round(calc(1rem * var(--_ds-font-size-factor)), 1px)"
   },
   {
     "path": [
@@ -29,7 +29,7 @@
       "4"
     ],
     "variable": "--ds-font-size-4",
-    "value": "calc(1.125rem * var(--_ds-font-size-factor))"
+    "value": "round(calc(1.125rem * var(--_ds-font-size-factor)), 1px)"
   },
   {
     "path": [
@@ -37,7 +37,7 @@
       "5"
     ],
     "variable": "--ds-font-size-5",
-    "value": "calc(1.3125rem * var(--_ds-font-size-factor))"
+    "value": "round(calc(1.3125rem * var(--_ds-font-size-factor)), 1px)"
   },
   {
     "path": [
@@ -45,7 +45,7 @@
       "6"
     ],
     "variable": "--ds-font-size-6",
-    "value": "calc(1.5rem * var(--_ds-font-size-factor))"
+    "value": "round(calc(1.5rem * var(--_ds-font-size-factor)), 1px)"
   },
   {
     "path": [
@@ -53,7 +53,7 @@
       "7"
     ],
     "variable": "--ds-font-size-7",
-    "value": "calc(1.875rem * var(--_ds-font-size-factor))"
+    "value": "round(calc(1.875rem * var(--_ds-font-size-factor)), 1px)"
   },
   {
     "path": [
@@ -61,7 +61,7 @@
       "8"
     ],
     "variable": "--ds-font-size-8",
-    "value": "calc(2.25rem * var(--_ds-font-size-factor))"
+    "value": "round(calc(2.25rem * var(--_ds-font-size-factor)), 1px)"
   },
   {
     "path": [
@@ -69,7 +69,7 @@
       "9"
     ],
     "variable": "--ds-font-size-9",
-    "value": "calc(3rem * var(--_ds-font-size-factor))"
+    "value": "round(calc(3rem * var(--_ds-font-size-factor)), 1px)"
   },
   {
     "path": [
@@ -77,7 +77,7 @@
       "10"
     ],
     "variable": "--ds-font-size-10",
-    "value": "calc(3.75rem * var(--_ds-font-size-factor))"
+    "value": "round(calc(3.75rem * var(--_ds-font-size-factor)), 1px)"
   },
   {
     "path": [

--- a/design-tokens/$designsystemet.jsonc
+++ b/design-tokens/$designsystemet.jsonc
@@ -1,4 +1,4 @@
 {
   "name": "@digdir/designsystemet",
-  "version": "1.4.0"
+  "version": "1.5.1"
 }

--- a/internal/design-tokens/$designsystemet.jsonc
+++ b/internal/design-tokens/$designsystemet.jsonc
@@ -1,4 +1,4 @@
 {
   "name": "@digdir/designsystemet",
-  "version": "1.4.0"
+  "version": "1.5.1"
 }

--- a/packages/cli/src/tokens/process/formats/css/size.ts
+++ b/packages/cli/src/tokens/process/formats/css/size.ts
@@ -61,7 +61,7 @@ const formatSizingTokens = (format: (t: TransformedToken) => string, tokens: Tra
     tokens,
   );
 
-const sizingTemplate = ({ round, calc }: { round: string[]; calc: string[] }) => {
+export const sizingTemplate = ({ round, calc }: { round: string[]; calc: string[] }) => {
   const usesRounding = round.filter((val, i) => val !== calc[i]);
   return `
 ${calc.join('\n')}\n

--- a/packages/cli/src/tokens/process/formats/css/type-scale.ts
+++ b/packages/cli/src/tokens/process/formats/css/type-scale.ts
@@ -3,22 +3,50 @@ import type { Format, TransformedToken } from 'style-dictionary/types';
 import { createPropertyFormatter } from 'style-dictionary/utils';
 import { basePxFontSize } from '../../configs/shared.js';
 import { buildOptions } from '../../platform.js';
+import { sizingTemplate } from './size.js';
 
 // Predicate to filter tokens with .path array that includes both typography and fontFamily
-const typographyFontFamilyPredicate = R.allPass([
+const isTypographyFontFamilyToken = R.allPass([
   R.pathSatisfies(R.includes('typography'), ['path']),
   R.pathSatisfies(R.includes('fontFamily'), ['path']),
 ]);
 
-function formatTypographySizeToken(token: TransformedToken): TransformedToken {
-  return { ...token, $value: `calc(${token.$value} * var(--_ds-font-size-factor))` };
-}
+type TokensWithCalcAndRoundFormatting = { tokens: TransformedToken[]; calc: string[]; round: string[] };
+
+const formatTypographySizeToken = (
+  format: (t: TransformedToken) => string,
+  token: TransformedToken,
+): { name: string; calc: string; round: string } => {
+  const [name, value] = format(token).replace(/;$/, '').split(': ');
+  let calc: string;
+  let round: string | undefined;
+  if (R.startsWith(['font-size'], token.path)) {
+    calc = `calc(${value} * var(--_ds-font-size-factor))`;
+    round = `round(${calc}, 1px)`;
+  } else {
+    calc = value;
+  }
+  return { name, calc, round: round ?? calc };
+};
+
+const formatTypographySizeTokens = (format: (t: TransformedToken) => string, tokens: TransformedToken[]) =>
+  R.reduce<TransformedToken, TokensWithCalcAndRoundFormatting>(
+    (acc, token) => {
+      const { name, calc, round } = formatTypographySizeToken(format, token);
+      acc.tokens.push(token);
+      acc.calc.push(`${name}: ${calc};`);
+      acc.round.push(`${name}: ${round};`);
+      return acc;
+    },
+    { tokens: [], calc: [], round: [] },
+    tokens,
+  );
 
 export const typeScale: Format = {
   name: 'ds/css-type-scale',
   format: async ({ dictionary, file, options, platform }) => {
     const { outputReferences, usesDtcg } = options;
-    const { selector, layer } = platform;
+    const { selector, layer } = platform as { selector: string; layer: string };
     const destination = file.destination as string;
 
     const format = createPropertyFormatter({
@@ -28,20 +56,18 @@ export const typeScale: Format = {
       usesDtcg,
     });
 
-    const filteredTokens = R.reject(typographyFontFamilyPredicate, dictionary.allTokens);
-    const tokens = R.map(formatTypographySizeToken, filteredTokens);
+    const filteredTokens = R.reject(R.anyPass([isTypographyFontFamilyToken]), dictionary.allTokens);
+    const formattedTokens = formatTypographySizeTokens(format, filteredTokens);
 
-    const formattedMap = tokens.map((token) => ({
-      token,
-      formatted: format(token),
+    const formattedMap = formattedTokens.round.map((t, i) => ({
+      token: formattedTokens.tokens[i],
+      formatted: t,
     }));
 
     buildOptions.buildTokenFormats[destination] = formattedMap;
 
-    const formattedTokens = formattedMap.map(R.prop('formatted')).join('\n');
-
     const sizeFactor = `  --_ds-font-size-factor: calc(var(--ds-size-mode-font-size) / (var(--ds-size-base) / ${basePxFontSize}));`;
-    const content = `${selector} {\n${sizeFactor}\n${formattedTokens}\n}`;
+    const content = `${selector} {\n${sizeFactor}${sizingTemplate(formattedTokens)}\n}`;
     const body = R.isNotNil(layer) ? `@layer ${layer} {\n${content}\n}` : content;
 
     return body;

--- a/packages/theme/brand/altinn.css
+++ b/packages/theme/brand/altinn.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
-build: v1.4.0
-design-tokens: v1.4.0
+build: v1.5.1
+design-tokens: v1.5.1
 */
 
 @layer ds.theme.size-mode {
@@ -74,6 +74,19 @@ design-tokens: v1.4.0
   --ds-body-long-md-font-size: var(--ds-font-size-4);
   --ds-body-long-sm-font-size: var(--ds-font-size-3);
   --ds-body-long-xs-font-size: var(--ds-font-size-2);
+
+  @supports (width: round(down, .1em, 1px)) {
+    --ds-font-size-1: round(calc(0.75rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-2: round(calc(0.875rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-3: round(calc(1rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-4: round(calc(1.125rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-5: round(calc(1.3125rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-6: round(calc(1.5rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-7: round(calc(1.875rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-8: round(calc(2.25rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-9: round(calc(3rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-10: round(calc(3.75rem * var(--_ds-font-size-factor)), 1px);
+  }
 }
 }
 @layer ds.theme.color-scheme.light {

--- a/packages/theme/brand/colors.d.ts
+++ b/packages/theme/brand/colors.d.ts
@@ -1,5 +1,5 @@
 /* This file is deprecated and will be removed in a future release. Use types.d.ts instead */
-/* build: v1.4.0 */
+/* build: v1.5.1 */
 import type {} from '@digdir/designsystemet/types';
 
 // Augment types based on theme

--- a/packages/theme/brand/digdir.css
+++ b/packages/theme/brand/digdir.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
-build: v1.4.0
-design-tokens: v1.4.0
+build: v1.5.1
+design-tokens: v1.5.1
 */
 
 @layer ds.theme.size-mode {
@@ -74,6 +74,19 @@ design-tokens: v1.4.0
   --ds-body-long-md-font-size: var(--ds-font-size-4);
   --ds-body-long-sm-font-size: var(--ds-font-size-3);
   --ds-body-long-xs-font-size: var(--ds-font-size-2);
+
+  @supports (width: round(down, .1em, 1px)) {
+    --ds-font-size-1: round(calc(0.75rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-2: round(calc(0.875rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-3: round(calc(1rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-4: round(calc(1.125rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-5: round(calc(1.3125rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-6: round(calc(1.5rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-7: round(calc(1.875rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-8: round(calc(2.25rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-9: round(calc(3rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-10: round(calc(3.75rem * var(--_ds-font-size-factor)), 1px);
+  }
 }
 }
 @layer ds.theme.color-scheme.light {

--- a/packages/theme/brand/portal.css
+++ b/packages/theme/brand/portal.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
-build: v1.4.0
-design-tokens: v1.4.0
+build: v1.5.1
+design-tokens: v1.5.1
 */
 
 @layer ds.theme.size-mode {
@@ -74,6 +74,19 @@ design-tokens: v1.4.0
   --ds-body-long-md-font-size: var(--ds-font-size-4);
   --ds-body-long-sm-font-size: var(--ds-font-size-3);
   --ds-body-long-xs-font-size: var(--ds-font-size-2);
+
+  @supports (width: round(down, .1em, 1px)) {
+    --ds-font-size-1: round(calc(0.75rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-2: round(calc(0.875rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-3: round(calc(1rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-4: round(calc(1.125rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-5: round(calc(1.3125rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-6: round(calc(1.5rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-7: round(calc(1.875rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-8: round(calc(2.25rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-9: round(calc(3rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-10: round(calc(3.75rem * var(--_ds-font-size-factor)), 1px);
+  }
 }
 }
 @layer ds.theme.color-scheme.light {

--- a/packages/theme/brand/types.d.ts
+++ b/packages/theme/brand/types.d.ts
@@ -1,4 +1,4 @@
-/* build: v1.4.0 */
+/* build: v1.5.1 */
 import type {} from '@digdir/designsystemet/types';
 
 // Augment types based on theme

--- a/packages/theme/brand/uutilsynet.css
+++ b/packages/theme/brand/uutilsynet.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
-build: v1.4.0
-design-tokens: v1.4.0
+build: v1.5.1
+design-tokens: v1.5.1
 */
 
 @layer ds.theme.size-mode {
@@ -74,6 +74,19 @@ design-tokens: v1.4.0
   --ds-body-long-md-font-size: var(--ds-font-size-4);
   --ds-body-long-sm-font-size: var(--ds-font-size-3);
   --ds-body-long-xs-font-size: var(--ds-font-size-2);
+
+  @supports (width: round(down, .1em, 1px)) {
+    --ds-font-size-1: round(calc(0.75rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-2: round(calc(0.875rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-3: round(calc(1rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-4: round(calc(1.125rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-5: round(calc(1.3125rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-6: round(calc(1.5rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-7: round(calc(1.875rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-8: round(calc(2.25rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-9: round(calc(3rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-10: round(calc(3.75rem * var(--_ds-font-size-factor)), 1px);
+  }
 }
 }
 @layer ds.theme.color-scheme.light {

--- a/packages/theme/src/themes/colors.d.ts
+++ b/packages/theme/src/themes/colors.d.ts
@@ -1,5 +1,5 @@
 /* This file is deprecated and will be removed in a future release. Use types.d.ts instead */
-/* build: v1.4.0 */
+/* build: v1.5.1 */
 import type {} from '@digdir/designsystemet/types';
 
 // Augment types based on theme

--- a/packages/theme/src/themes/designsystemet.css
+++ b/packages/theme/src/themes/designsystemet.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
-build: v1.4.0
-design-tokens: v1.4.0
+build: v1.5.1
+design-tokens: v1.5.1
 */
 
 @layer ds.theme.size-mode {
@@ -74,6 +74,19 @@ design-tokens: v1.4.0
   --ds-body-long-md-font-size: var(--ds-font-size-4);
   --ds-body-long-sm-font-size: var(--ds-font-size-3);
   --ds-body-long-xs-font-size: var(--ds-font-size-2);
+
+  @supports (width: round(down, .1em, 1px)) {
+    --ds-font-size-1: round(calc(0.75rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-2: round(calc(0.875rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-3: round(calc(1rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-4: round(calc(1.125rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-5: round(calc(1.3125rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-6: round(calc(1.5rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-7: round(calc(1.875rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-8: round(calc(2.25rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-9: round(calc(3rem * var(--_ds-font-size-factor)), 1px);
+    --ds-font-size-10: round(calc(3.75rem * var(--_ds-font-size-factor)), 1px);
+  }
 }
 }
 @layer ds.theme.color-scheme.light {

--- a/packages/theme/src/themes/types.d.ts
+++ b/packages/theme/src/themes/types.d.ts
@@ -1,4 +1,4 @@
-/* build: v1.4.0 */
+/* build: v1.5.1 */
 import type {} from '@digdir/designsystemet/types';
 
 // Augment types based on theme


### PR DESCRIPTION

## Summary

Font size variables are now rounded to the nearest pixel. This affects size modes "sm" and "lg", which had subpixel values after v1.5.0 / #3866


## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
