### PR TITLE
fix(avatar,spinner): aria-hidden & aria-label improvement

### DIFF
--- a/.changeset/fruity-snails-play.md
+++ b/.changeset/fruity-snails-play.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+**Spinner**: Allow using `aria-hidden` when `aria-label` is set, which can be useful to hide or show the element from the accessibility tree based on some UI state like whether a visual label is also rendered.

--- a/.changeset/modern-bobcats-begin.md
+++ b/.changeset/modern-bobcats-begin.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+**Avatar**: Allow using `aria-hidden` instead of `aria-label` in situations with visible text

--- a/packages/react/src/components/avatar/avatar.mdx
+++ b/packages/react/src/components/avatar/avatar.mdx
@@ -27,6 +27,12 @@ import { Avatar } from '@digdir/designsystemet-react';
 <Avatar aria-label="Ola Nordmann">
   <img src="..." />
 </Avatar>
+
+/* Sammen med synlig tekst */
+<>
+  <Avatar aria-hidden>ON</Avatar>
+  <span>Ola Nordmann</span>
+</>
 ```
 
 ## Kodeeksempler
@@ -93,7 +99,7 @@ Du må selv sette styling dersom du skal ha en interaktiv `Avatar`.
 `Avatar` skal som hovedregel ikke inneholde tekst i selve komponenten, med unntak av når initialer brukes. Annen tekst, for eksempel fullt navn, rolle eller organisasjon, bør vises utenfor avataren for å sikre god lesbarhet. 
 
 ## Tilgjengelighet
-`Avatar` må alltid ha en `aria-label` som forklarer hvem eller hva avataren representerer, spesielt dersom den er interaktiv eller del av et brukargrensesnitt med flere brukere. Ikke spesifiser i `aria-label`  at det er et bilde, skjermleseren formidler dette automatisk. Det holder å bruke navnet, som for eksempel `aria-label="Ola Nordmann"`.
+`Avatar` må enten ha en `aria-label` som forklarer hvem eller hva avataren representerer, eller ha `aria-hidden` og synlig tekst som formidler den samme informasjonen. Ikke spesifiser i `aria-label` at det er et bilde, skjermleseren formidler dette automatisk. Det holder å bruke navnet, som for eksempel `aria-label="Ola Nordmann"`.
 
 Bilder, og andre `children`, får automatisk `aria-hidden="true"` for å unngå dobbel informasjon.
 

--- a/packages/react/src/components/avatar/avatar.stories.tsx
+++ b/packages/react/src/components/avatar/avatar.stories.tsx
@@ -97,7 +97,7 @@ export const InDropdown: Story = () => (
           <Dropdown.Button>
             <Badge.Position overlap='circle'>
               <Badge data-color='danger' data-size='sm'></Badge>
-              <Avatar aria-label='Ola Nordmann' data-size='xs'>
+              <Avatar aria-hidden={true} data-size='xs'>
                 ON
               </Avatar>
             </Badge.Position>
@@ -106,8 +106,8 @@ export const InDropdown: Story = () => (
         </Dropdown.Item>
         <Dropdown.Item>
           <Dropdown.Button>
-            <Avatar data-size='xs' aria-label='Sogndal Kommune'>
-              <BriefcaseIcon aria-hidden />
+            <Avatar aria-hidden data-size='xs'>
+              <BriefcaseIcon />
             </Avatar>
             Sogndal kommune
           </Dropdown.Button>

--- a/packages/react/src/components/avatar/avatar.tsx
+++ b/packages/react/src/components/avatar/avatar.tsx
@@ -6,13 +6,17 @@ import { Fragment, forwardRef } from 'react';
 import type { DefaultProps } from '../../types';
 import type { MergeRight } from '../../utilities';
 
+type AriaLabel = {
+  /**
+   * The name of the person the avatar represents.
+   */
+  'aria-label': string;
+};
+type AriaHidden = Partial<AriaLabel> & { 'aria-hidden': true | 'true' };
+
 export type AvatarProps = MergeRight<
   DefaultProps & HTMLAttributes<HTMLSpanElement>,
-  {
-    /**
-     * The name of the person the avatar represents.
-     */
-    'aria-label': string;
+  (AriaLabel | AriaHidden) & {
     /**
      * The size of the avatar.
      */

--- a/packages/react/src/components/spinner/spinner.tsx
+++ b/packages/react/src/components/spinner/spinner.tsx
@@ -14,7 +14,7 @@ export type SpinnerProps = {
   'data-size'?: '2xs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 } & ComponentPropsWithoutRef<'svg'> &
   (
-    | { 'aria-label': string; 'aria-hidden'?: never }
+    | { 'aria-label': string }
     | { 'aria-label'?: string; 'aria-hidden': true | 'true' } // Make aria-label optional when aria-hidden is true
   );
 


### PR DESCRIPTION

## Summary

**Spinner**: Allow using `aria-hidden` when `aria-label` is set, which can be useful to hide or show the element from the accessibility tree based on some UI state like whether a visual label is also rendered.

**Avatar**: Allow using `aria-hidden` instead of `aria-label` in situations with visible text

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
