### PR TITLE
fix(css): ensure font-size for Tag and Chip scales correctly with data-size

### DIFF
--- a/.changeset/silver-buttons-shine.md
+++ b/.changeset/silver-buttons-shine.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**Chip, Tag**: Ensure font size scales correctly with the current size mode by using the token `--ds-body-sm-font-size`. Note: there might be a small visual change for `Chip` used without explicit `data-size`, since it used to have `font-size: 90%`.

--- a/.github/workflows/test-visual.yml
+++ b/.github/workflows/test-visual.yml
@@ -4,7 +4,7 @@ on:
   # pr runs ONLY when the pr is in review, and on new pushes to that pr
   pull_request:
     branches: [main, next]
-    types: [ready_for_review, synchronize, reopened]
+    types: [opened, ready_for_review, synchronize, reopened]
     paths:
       - .github/workflows/test-visual.yml
       - 'packages/**/*.tsx?'

--- a/packages/css/src/chip.css
+++ b/packages/css/src/chip.css
@@ -32,6 +32,7 @@
   color: var(--dsc-chip-color);
   cursor: pointer;
   font-family: inherit;
+  font-size: var(--ds-body-sm-font-size);
   gap: var(--dsc-chip-spacing);
   line-height: var(--ds-line-height-sm);
   margin: 0;
@@ -54,10 +55,6 @@
 
   &:not([hidden]) {
     display: inline-flex;
-  }
-
-  &:not([data-size]) {
-    font-size: var(--ds-font-size-minus-1);
   }
 
   /* Show focus ring when input inside is focused by keyboard interaction */

--- a/packages/css/src/tag.css
+++ b/packages/css/src/tag.css
@@ -10,6 +10,7 @@
   box-sizing: border-box;
   color: var(--dsc-tag-color);
   height: fit-content; /* In case placed in display: flex */
+  font-size: var(--ds-body-sm-font-size);
   line-height: var(--ds-line-height-sm);
   min-height: var(--dsc-tag-min-height);
   padding: var(--dsc-tag-padding);


### PR DESCRIPTION
## Summary

**Chip, Tag**: Ensure font size scales correctly with the current size mode by using the token `--ds-body-sm-font-size`. Note: there might be a small visual change for `Chip` used without explicit `data-size`, since it used to have `font-size: 90%`.

Closes: #3604

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
