### PR TITLE
fix: add ds-icon-size and ds-icon-size--lg for consistent icon sizing

### DIFF
--- a/.changeset/blue-webs-attend.md
+++ b/.changeset/blue-webs-attend.md
@@ -3,5 +3,5 @@
 ---
 
 **Root:** Add `--ds-icon-size` variable for easier consistent icon sizing
-**Alert, Chip, Suggestion Chip, Search, IconButton:** Ajust icons from size `7` to `6` so all icons can use `--ds-icon-size`
+**Alert, Chip, Suggestion Chip, Search, IconButton:** Decreased icon size from `7` to `6` for consistency and configurable using `--ds-icon-size`
 **Dialog:** Add missing `--dsc-dialog-icon-size` variable

--- a/.changeset/blue-webs-attend.md
+++ b/.changeset/blue-webs-attend.md
@@ -2,5 +2,5 @@
 "@digdir/designsystemet-css": patch
 ---
 
-**Root:** Add `--ds-icon-size` and `--ds-icon-size--lg` variables for easier consistent icon sizing
+**Root:** Add `--ds-icon-size` variable for easier consistent icon sizing
 **Dialog:** Add missing `--dsc-dialog-icon-size` variable

--- a/.changeset/blue-webs-attend.md
+++ b/.changeset/blue-webs-attend.md
@@ -2,6 +2,6 @@
 "@digdir/designsystemet-css": minor
 ---
 
-**Root:** Add `--ds-icon-size` variable for easier consistent icon sizing
+**Root:** Add `--ds-icon-size` variable for easier consistent icon sizing. Size `--ds-size-6` by default.
 **Alert, Chip, Suggestion Chip, Search, IconButton, Field:** Decreased icon size from `7` to `6` for consistency and configurable using `--ds-icon-size`
 **Dialog:** Add missing `--dsc-dialog-icon-size` variable

--- a/.changeset/blue-webs-attend.md
+++ b/.changeset/blue-webs-attend.md
@@ -1,0 +1,6 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**Root:** Add `--ds-icon-size` and `--ds-icon-size--lg` variables for easier consistent icon sizing
+**Dialog:** Add missing `--dsc-dialog-icon-size` variable

--- a/.changeset/blue-webs-attend.md
+++ b/.changeset/blue-webs-attend.md
@@ -3,4 +3,5 @@
 ---
 
 **Root:** Add `--ds-icon-size` variable for easier consistent icon sizing
+**Alert, Chip, Suggestion Chip, Search, IconButton:** Ajust icons from size `7` to `6` so all icons can use `--ds-icon-size`
 **Dialog:** Add missing `--dsc-dialog-icon-size` variable

--- a/.changeset/blue-webs-attend.md
+++ b/.changeset/blue-webs-attend.md
@@ -1,5 +1,5 @@
 ---
-"@digdir/designsystemet-css": patch
+"@digdir/designsystemet-css": minor
 ---
 
 **Root:** Add `--ds-icon-size` variable for easier consistent icon sizing

--- a/.changeset/blue-webs-attend.md
+++ b/.changeset/blue-webs-attend.md
@@ -3,5 +3,6 @@
 ---
 
 **Root:** Add `--ds-icon-size` variable for easier consistent icon sizing. Size `--ds-size-6` by default.
-**Alert, Chip, Suggestion Chip, Search, IconButton, Field:** Decreased icon size from `7` to `6` for consistency and configurable using `--ds-icon-size`
+**Root:** Increased `read-only` icon size from `1.2em` to `6` for consistency and configurable using `--ds-icon-size`
+**Alert, Chip, Suggestion Chip, Search, IconButton:** Decreased icon size from `7` to `6` for consistency and configurable using `--ds-icon-size`
 **Dialog:** Add missing `--dsc-dialog-icon-size` variable

--- a/.changeset/blue-webs-attend.md
+++ b/.changeset/blue-webs-attend.md
@@ -3,5 +3,5 @@
 ---
 
 **Root:** Add `--ds-icon-size` variable for easier consistent icon sizing
-**Alert, Chip, Suggestion Chip, Search, IconButton:** Decreased icon size from `7` to `6` for consistency and configurable using `--ds-icon-size`
+**Alert, Chip, Suggestion Chip, Search, IconButton, Field:** Decreased icon size from `7` to `6` for consistency and configurable using `--ds-icon-size`
 **Dialog:** Add missing `--dsc-dialog-icon-size` variable

--- a/internal/components/src/header/header.module.css
+++ b/internal/components/src/header/header.module.css
@@ -172,9 +172,6 @@
   }
 }
 
-.toggleButton svg {
-  font-size: calc(var(--_ds-captured-length) * 1.5);
-}
 @media (max-width: 600px) {
   .toggleButton span {
     display: none;

--- a/packages/css/src/alert.css
+++ b/packages/css/src/alert.css
@@ -9,7 +9,7 @@
   --dsc-alert-icon-url: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' d='M3.25 4A.75.75 0 0 1 4 3.25h16a.75.75 0 0 1 .75.75v16a.75.75 0 0 1-.75.75H4a.75.75 0 0 1-.75-.75zM11 7.75a1 1 0 1 1 2 0 1 1 0 0 1-2 0m-1.25 3a.75.75 0 0 1 .75-.75H12a.75.75 0 0 1 .75.75v4.75h.75a.75.75 0 0 1 0 1.5h-3a.75.75 0 0 1 0-1.5h.75v-4h-.75a.75.75 0 0 1-.75-.75'/%3E%3C/svg%3E");
   --dsc-alert-color: var(--ds-color-info-text-default);
   --dsc-alert-spacing: var(--ds-size-2);
-  --dsc-alert-icon-size: var(--ds-icon-size--lg);
+  --dsc-alert-icon-size: var(--ds-icon-size);
   --dsc-alert-padding-block: var(--ds-size-6);
   --dsc-alert-padding-inline-end: var(--ds-size-6);
 

--- a/packages/css/src/alert.css
+++ b/packages/css/src/alert.css
@@ -9,7 +9,7 @@
   --dsc-alert-icon-url: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' d='M3.25 4A.75.75 0 0 1 4 3.25h16a.75.75 0 0 1 .75.75v16a.75.75 0 0 1-.75.75H4a.75.75 0 0 1-.75-.75zM11 7.75a1 1 0 1 1 2 0 1 1 0 0 1-2 0m-1.25 3a.75.75 0 0 1 .75-.75H12a.75.75 0 0 1 .75.75v4.75h.75a.75.75 0 0 1 0 1.5h-3a.75.75 0 0 1 0-1.5h.75v-4h-.75a.75.75 0 0 1-.75-.75'/%3E%3C/svg%3E");
   --dsc-alert-color: var(--ds-color-info-text-default);
   --dsc-alert-spacing: var(--ds-size-2);
-  --dsc-alert-icon-size: var(--ds-size-7);
+  --dsc-alert-icon-size: var(--ds-icon-size--lg);
   --dsc-alert-padding-block: var(--ds-size-6);
   --dsc-alert-padding-inline-end: var(--ds-size-6);
 

--- a/packages/css/src/avatar-stack.css
+++ b/packages/css/src/avatar-stack.css
@@ -1,3 +1,10 @@
+/* Capture a length value, e.g. 1em, at the element where the variable is set */
+@property --_ds-captured-length {
+  syntax: '<length>';
+  inherits: true;
+  initial-value: 0px;
+}
+
 .ds-avatar-stack {
   --dsc-avatar-stack-size: var(--ds-size-12);
   --dsc-avatar-stack-gap: 2px;

--- a/packages/css/src/avatar.css
+++ b/packages/css/src/avatar.css
@@ -35,8 +35,8 @@
     padding: var(--dsc-avatar-padding);
   }
 
-  & img,
-  & svg {
+  & :is(img, svg) {
+    @composes ds-icon from './base.css';
     object-fit: cover;
     width: 100%;
     height: 100%;

--- a/packages/css/src/badge.css
+++ b/packages/css/src/badge.css
@@ -51,7 +51,6 @@
   position: relative;
   height: fit-content;
   width: fit-content;
-  --_ds-captured-length: 1em;
 
   &:not([hidden]) {
     display: inline-flex;
@@ -66,10 +65,8 @@
     z-index: 1; /*prevent focus-ring overlaying badge in certain cases*/
   }
 
-  > :where(img, svg) {
-    flex-shrink: 0; /* Never shrink icon */
-    /* using --_ds-captured-length fixes svg not scaling with zoom in Safari */
-    font-size: calc(var(--_ds-captured-length) * 1.25); /* Auto scale icon based on font-size */
+  & :is(img, svg) {
+    @composes ds-icon from './base.css';
   }
 
   &[data-placement='top-right'] .ds-badge::before {

--- a/packages/css/src/base.css
+++ b/packages/css/src/base.css
@@ -17,7 +17,6 @@
   --ds-font-size-plus-1: 1.1em; /* Default to 110% */
   --ds-readonly-icon-size: 1.2em;
   --ds-readonly-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' viewBox='0 0 24 24'%3E%3Cpath fill-rule='evenodd' d='M12 2.25A4.75 4.75 0 0 0 7.25 7v2.25H7A1.75 1.75 0 0 0 5.25 11v9c0 .41.34.75.75.75h12a.75.75 0 0 0 .75-.75v-9A1.75 1.75 0 0 0 17 9.25h-.25V7A4.75 4.75 0 0 0 12 2.25m3.25 7V7a3.25 3.25 0 0 0-6.5 0v2.25zM12 13a1.5 1.5 0 0 0-.75 2.8V17a.75.75 0 0 0 1.5 0v-1.2A1.5 1.5 0 0 0 12 13'/%3E%3C/svg%3E");
-  --ds-icon-size--lg: var(--ds-size-7);
   --ds-icon-size: var(--ds-size-6);
 
   /* font-size adjustments if supporting round() */

--- a/packages/css/src/base.css
+++ b/packages/css/src/base.css
@@ -17,6 +17,8 @@
   --ds-font-size-plus-1: 1.1em; /* Default to 110% */
   --ds-readonly-icon-size: 1.2em;
   --ds-readonly-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' viewBox='0 0 24 24'%3E%3Cpath fill-rule='evenodd' d='M12 2.25A4.75 4.75 0 0 0 7.25 7v2.25H7A1.75 1.75 0 0 0 5.25 11v9c0 .41.34.75.75.75h12a.75.75 0 0 0 .75-.75v-9A1.75 1.75 0 0 0 17 9.25h-.25V7A4.75 4.75 0 0 0 12 2.25m3.25 7V7a3.25 3.25 0 0 0-6.5 0v2.25zM12 13a1.5 1.5 0 0 0-.75 2.8V17a.75.75 0 0 0 1.5 0v-1.2A1.5 1.5 0 0 0 12 13'/%3E%3C/svg%3E");
+  --ds-icon-size--lg: var(--ds-size-7);
+  --ds-icon-size: var(--ds-size-6);
 
   /* font-size adjustments if supporting round() */
   @supports (width: round(down, 0.1em, 1px)) {
@@ -38,6 +40,16 @@ body,
 [data-color-scheme] {
   color: var(--ds-color-neutral-text-default);
   background: var(--ds-color-neutral-background-default);
+}
+
+.ds-icon {
+  display: inline-block; /* Overwrite Tailwind setting display: block on <svg> */
+  fill: currentcolor;
+  flex-shrink: 0;
+  font-size: 1em;
+  height: var(--ds-icon-size);
+  vertical-align: middle;
+  width: var(--ds-icon-size);
 }
 
 .ds-readonly-icon::before {
@@ -243,11 +255,4 @@ body {
 /* Recalculate font-size variable when changing size mode */
 [data-size] {
   font-size: var(--ds-body-md-font-size);
-}
-
-/* Capture a length value, e.g. 1em, at the element where the variable is set */
-@property --_ds-captured-length {
-  syntax: '<length>';
-  inherits: true;
-  initial-value: 0px;
 }

--- a/packages/css/src/base.css
+++ b/packages/css/src/base.css
@@ -15,7 +15,7 @@
 :root {
   --ds-font-size-minus-1: max(0.9em, 0.875rem); /* Default to 90% of font-size, but minimum 14px */
   --ds-font-size-plus-1: 1.1em; /* Default to 110% */
-  --ds-readonly-icon-size: 1.2em;
+  --ds-readonly-icon-size: var(--ds-icon-size);
   --ds-readonly-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' aria-hidden='true' viewBox='0 0 24 24'%3E%3Cpath fill-rule='evenodd' d='M12 2.25A4.75 4.75 0 0 0 7.25 7v2.25H7A1.75 1.75 0 0 0 5.25 11v9c0 .41.34.75.75.75h12a.75.75 0 0 0 .75-.75v-9A1.75 1.75 0 0 0 17 9.25h-.25V7A4.75 4.75 0 0 0 12 2.25m3.25 7V7a3.25 3.25 0 0 0-6.5 0v2.25zM12 13a1.5 1.5 0 0 0-.75 2.8V17a.75.75 0 0 0 1.5 0v-1.2A1.5 1.5 0 0 0 12 13'/%3E%3C/svg%3E");
   --ds-icon-size: var(--ds-size-6);
 

--- a/packages/css/src/breadcrumbs.css
+++ b/packages/css/src/breadcrumbs.css
@@ -1,6 +1,6 @@
 .ds-breadcrumbs {
   --dsc-breadcrumbs-spacing: var(--ds-size-2);
-  --dsc-breadcrumbs-icon-size: var(--ds-size-6);
+  --dsc-breadcrumbs-icon-size: var(--ds-icon-size);
   --dsc-breadcrumbs-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 24 24'%3E%3Cpath d='M9.47 5.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 0 1 0 1.06l-5.5 5.5a.75.75 0 1 1-1.06-1.06L14.44 12 9.47 7.03a.75.75 0 0 1 0-1.06'/%3E%3C/svg%3E");
   --dsc-breadcrumbs-color: var(--ds-color-text-subtle);
   --_ds-aria-label: var(--dsc-breadcrumbs-label); /* "proxy" so attrOrCSS works even if changing --ds- prefix */

--- a/packages/css/src/button.css
+++ b/packages/css/src/button.css
@@ -65,7 +65,6 @@
   }
 
   &[data-icon] {
-    --ds-icon-size: var(--ds-icon-size--lg); /* TODO: Should we really? */
     width: var(--dsc-button-size); /* Ensure it keeps square shape */
     height: var(--dsc-button-size); /* Ensure it keeps square shape */
     padding: 0;

--- a/packages/css/src/button.css
+++ b/packages/css/src/button.css
@@ -10,7 +10,6 @@
   --dsc-button-gap: var(--ds-size-2);
   --dsc-button-padding: var(--ds-size-2) var(--ds-size-4);
   --dsc-button-size: var(--ds-size-12);
-  --_ds-captured-length: 1em;
 
   align-items: center;
   background: var(--dsc-button-background);
@@ -53,39 +52,28 @@
     font-size: inherit; /* Ensure inheriting font-size when <button> */
   }
 
-  & :where(img, svg):not(.ds-spinner) {
-    flex-shrink: 0;
-    /* using --_ds-captured-length fixes svg not scaling with zoom in Safari */
-    font-size: calc(var(--_ds-captured-length) * 1.3);
+  & :is(img, svg) {
+    @composes ds-icon from './base.css';
   }
 
   &:focus-visible {
     position: relative; /* Place focusring on top */
   }
 
-  &:where(:not([hidden])) {
+  &:not([hidden]) {
     display: flex;
   }
 
   &[data-icon] {
+    --ds-icon-size: var(--ds-icon-size--lg); /* TODO: Should we really? */
     width: var(--dsc-button-size); /* Ensure it keeps square shape */
     height: var(--dsc-button-size); /* Ensure it keeps square shape */
     padding: 0;
-
-    & :where(img, svg):not(.ds-spinner) {
-      /* using --_ds-captured-length fixes svg not scaling with zoom in Safari */
-      font-size: calc(var(--_ds-captured-length) * 1.5);
-    }
   }
 
   &[data-fullwidth] {
     width: 100%;
     text-align: center;
-  }
-
-  /* Style spinner when in button */
-  & .ds-spinner {
-    height: 1.4em;
   }
 
   /**

--- a/packages/css/src/chip.css
+++ b/packages/css/src/chip.css
@@ -18,7 +18,7 @@
   --dsc-chip-border-radius--checkbox: var(--ds-border-radius-md);
   --dsc-chip-border-radius--checkbox-input: var(--ds-border-radius-sm);
   --dsc-chip-height: var(--ds-size-8);
-  --dsc-chip-icon-size: var(--ds-icon-size--lg);
+  --dsc-chip-icon-size: var(--ds-icon-size);
   --dsc-chip-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1em' height='1em' fill='none' viewBox='0 0 24 24' focusable='false' role='img'%3E%3Cpath fill='currentColor' d='M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z'%3E%3C/path%3E%3C/svg%3E");
   --dsc-chip-input-size: var(--ds-size-5);
   --dsc-chip-spacing: calc((var(--dsc-chip-height) - var(--dsc-chip-input-size)) / 2); /* Distance between edge of input and chip */

--- a/packages/css/src/chip.css
+++ b/packages/css/src/chip.css
@@ -18,7 +18,7 @@
   --dsc-chip-border-radius--checkbox: var(--ds-border-radius-md);
   --dsc-chip-border-radius--checkbox-input: var(--ds-border-radius-sm);
   --dsc-chip-height: var(--ds-size-8);
-  --dsc-chip-icon-size: var(--ds-size-7);
+  --dsc-chip-icon-size: var(--ds-icon-size--lg);
   --dsc-chip-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1em' height='1em' fill='none' viewBox='0 0 24 24' focusable='false' role='img'%3E%3Cpath fill='currentColor' d='M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z'%3E%3C/path%3E%3C/svg%3E");
   --dsc-chip-input-size: var(--ds-size-5);
   --dsc-chip-spacing: calc((var(--dsc-chip-height) - var(--dsc-chip-input-size)) / 2); /* Distance between edge of input and chip */

--- a/packages/css/src/details.css
+++ b/packages/css/src/details.css
@@ -6,7 +6,7 @@
   --dsc-details-border-block-style: solid;
   --dsc-details-border-color: var(--ds-color-border-subtle);
   --dsc-details-icon-gap: var(--ds-size-2);
-  --dsc-details-icon-size: var(--ds-size-6);
+  --dsc-details-icon-size: var(--ds-icon-size);
   --dsc-details-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M5.97 9.47a.75.75 0 0 1 1.06 0L12 14.44l4.97-4.97a.75.75 0 1 1 1.06 1.06l-5.5 5.5a.75.75 0 0 1-1.06 0l-5.5-5.5a.75.75 0 0 1 0-1.06'/%3E%3C/svg%3E");
   --dsc-details-padding: var(--ds-size-2) var(--ds-size-4);
   --dsc-details-size: var(--ds-size-14);

--- a/packages/css/src/dialog.css
+++ b/packages/css/src/dialog.css
@@ -2,6 +2,7 @@
   --dsc-dialog-backdrop-background: rgb(0 0 0 / 0.5);
   --dsc-dialog-background: var(--ds-color-neutral-surface-default);
   --dsc-dialog-icon-spacing: var(--ds-size-3);
+  --dsc-dialog-icon-size: var(--ds-icon-size);
   --dsc-dialog-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1em' height='1em' fill='none' viewBox='0 0 24 24' focusable='false' role='img'%3E%3Cpath fill='currentColor' d='M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z'%3E%3C/path%3E%3C/svg%3E");
   --dsc-dialog-color: var(--ds-color-neutral-text-default);
   --dsc-dialog-divider-border-width: var(--ds-border-width-default);
@@ -120,8 +121,8 @@
   & button[data-command='close']:empty::before {
     content: '';
     background: currentcolor;
-    height: var(--ds-size-6);
-    width: var(--ds-size-6);
+    height: var(--dsc-dialog-icon-size);
+    width: var(--dsc-dialog-icon-size);
     mask: center / contain no-repeat var(--dsc-dialog-icon-url);
 
     @media (forced-colors: active) {

--- a/packages/css/src/link.css
+++ b/packages/css/src/link.css
@@ -29,7 +29,7 @@
   }
 
   & > :is(img, svg) {
-    vertical-align: middle; /* Align img or svg icon with text */
+    @composes ds-icon from './base.css';
   }
 
   /*

--- a/packages/css/src/pagination.css
+++ b/packages/css/src/pagination.css
@@ -1,6 +1,6 @@
 .ds-pagination {
   --dsc-pagination-gap: var(--ds-size-2);
-  --dsc-pagination-icon-size: var(--ds-size-6);
+  --dsc-pagination-icon-size: var(--ds-icon-size);
   --dsc-pagination-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 24 24'%3E%3Cpath d='M9.47 5.97a.75.75 0 0 1 1.06 0l5.5 5.5a.75.75 0 0 1 0 1.06l-5.5 5.5a.75.75 0 1 1-1.06-1.06L14.44 12 9.47 7.03a.75.75 0 0 1 0-1.06'/%3E%3C/svg%3E");
   --dsc-pagination-ellipsis: '\2026';
   --_ds-aria-label: var(--dsc-pagination-label); /* "proxy" so attrOrCSS works even if changing --ds- prefix */

--- a/packages/css/src/search.css
+++ b/packages/css/src/search.css
@@ -4,7 +4,7 @@
   --dsc-search-clear-size: var(--ds-size-9);
   --dsc-search-clear-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24'%3E%3Cpath fill='currentColor' d='M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z'/%3E%3C/svg%3E");
   --dsc-search-magnifying-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24'%3E%3Cpath d='M10.5 3.25a7.25 7.25 0 1 0 4.57 12.88l5.41 5.41a.75.75 0 1 0 1.06-1.06l-5.41-5.41A7.25 7.25 0 0 0 10.5 3.25M4.75 10.5a5.75 5.75 0 1 1 11.5 0 5.75 5.75 0 0 1-11.5 0'/%3E%3C/svg%3E");
-  --dsc-search-magnifying-icon-size: var(--ds-size-7);
+  --dsc-search-magnifying-icon-size: var(--ds-icon-size--lg);
 
   align-items: center;
   grid-template-columns: 1fr auto;

--- a/packages/css/src/search.css
+++ b/packages/css/src/search.css
@@ -4,7 +4,7 @@
   --dsc-search-clear-size: var(--ds-size-9);
   --dsc-search-clear-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24'%3E%3Cpath fill='currentColor' d='M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z'/%3E%3C/svg%3E");
   --dsc-search-magnifying-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24'%3E%3Cpath d='M10.5 3.25a7.25 7.25 0 1 0 4.57 12.88l5.41 5.41a.75.75 0 1 0 1.06-1.06l-5.41-5.41A7.25 7.25 0 0 0 10.5 3.25M4.75 10.5a5.75 5.75 0 1 1 11.5 0 5.75 5.75 0 0 1-11.5 0'/%3E%3C/svg%3E");
-  --dsc-search-magnifying-icon-size: var(--ds-icon-size--lg);
+  --dsc-search-magnifying-icon-size: var(--ds-icon-size);
 
   align-items: center;
   grid-template-columns: 1fr auto;

--- a/packages/css/src/suggestion.css
+++ b/packages/css/src/suggestion.css
@@ -41,7 +41,7 @@
   --dsc-suggestion-chip-padding: 0 var(--ds-size-3);
   --dsc-suggestion-chip-color: var(--ds-color-base-contrast-default);
   --dsc-suggestion-chip-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1em' height='1em' fill='none' viewBox='0 0 24 24' focusable='false' role='img'%3E%3Cpath fill='currentColor' d='M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z'%3E%3C/path%3E%3C/svg%3E");
-  --dsc-suggestion-chip-icon-size: var(--ds-size-7);
+  --dsc-suggestion-chip-icon-size: var(--ds-icon-size--lg);
   --dsc-suggestion-chip-input-size: var(--ds-size-5);
   --dsc-suggestion-chip-spacing: calc(
     (var(--dsc-suggestion-chip-height) - var(--dsc-suggestion-chip-input-size)) /

--- a/packages/css/src/suggestion.css
+++ b/packages/css/src/suggestion.css
@@ -41,7 +41,7 @@
   --dsc-suggestion-chip-padding: 0 var(--ds-size-3);
   --dsc-suggestion-chip-color: var(--ds-color-base-contrast-default);
   --dsc-suggestion-chip-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1em' height='1em' fill='none' viewBox='0 0 24 24' focusable='false' role='img'%3E%3Cpath fill='currentColor' d='M6.53 5.47a.75.75 0 0 0-1.06 1.06L10.94 12l-5.47 5.47a.75.75 0 1 0 1.06 1.06L12 13.06l5.47 5.47a.75.75 0 1 0 1.06-1.06L13.06 12l5.47-5.47a.75.75 0 0 0-1.06-1.06L12 10.94z'%3E%3C/path%3E%3C/svg%3E");
-  --dsc-suggestion-chip-icon-size: var(--ds-icon-size--lg);
+  --dsc-suggestion-chip-icon-size: var(--ds-icon-size);
   --dsc-suggestion-chip-input-size: var(--ds-size-5);
   --dsc-suggestion-chip-spacing: calc(
     (var(--dsc-suggestion-chip-height) - var(--dsc-suggestion-chip-input-size)) /

--- a/packages/css/src/table.css
+++ b/packages/css/src/table.css
@@ -15,7 +15,7 @@
   --dsc-table-header-background--sticky: var(--ds-color-surface-default);
   --dsc-table-header-background: transparent;
   --dsc-table-padding: var(--ds-size-2) var(--ds-size-3);
-  --dsc-table-sort-size: var(--ds-size-6);
+  --dsc-table-sort-size: var(--ds-icon-size);
   --_dsc-table-border-radius--inner: calc(var(--dsc-table-border-radius) - var(--dsc-table-border-width)); /* Shrink border radius to match border-width */
 
   border-collapse: separate; /* Using separate mode to enable border-radius */

--- a/packages/css/src/tabs.css
+++ b/packages/css/src/tabs.css
@@ -44,7 +44,6 @@
       position: relative;
       text-align: center;
       white-space: nowrap;
-      --_ds-captured-length: 1em;
 
       @composes ds-focus--inset from './base.css';
 
@@ -56,10 +55,8 @@
         font-size: inherit; /* Ensure inheriting font-size when <button> */
       }
 
-      & :where(img, svg) {
-        flex-shrink: 0; /* Never shrink icon */
-        /* using --_ds-captured-length fixes svg not scaling with zoom in Safari */
-        font-size: calc(var(--_ds-captured-length) * 1.25); /* Auto scale icon based on font-size */
+      & :is(img, svg) {
+        @composes ds-icon from './base.css';
       }
 
       &::after {

--- a/packages/css/src/tag.css
+++ b/packages/css/src/tag.css
@@ -7,8 +7,6 @@
   --dsc-tag-border-color: transparent;
   --dsc-tag-border-style: solid;
 
-  --_ds-captured-length: 1em;
-
   align-items: center;
   background: var(--dsc-tag-background);
   border-radius: var(--ds-border-radius-sm);
@@ -26,10 +24,8 @@
   word-break: break-word;
   @composes ds-print-preserve from './base.css';
 
-  & :where(img, svg) {
-    flex-shrink: 0;
-    /* using --_ds-captured-length fixes svg not scaling with zoom in Safari */
-    font-size: calc(var(--_ds-captured-length) * 1.25);
+  & :is(img, svg) {
+    @composes ds-icon from './base.css';
   }
 
   &:not([hidden]) {

--- a/packages/css/src/validation-message.css
+++ b/packages/css/src/validation-message.css
@@ -4,7 +4,7 @@
 .ds-validation-message {
   /* Default is danger */
   --dsc-validation-message-icon-url: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill-rule='evenodd' d='M7.74 2.47a.75.75 0 0 1 .53-.22h7.46a.75.75 0 0 1 .53.22l5.27 5.27c.14.14.22.33.22.53v7.46a.75.75 0 0 1-.22.53l-5.27 5.27a.75.75 0 0 1-.53.22H8.27a.75.75 0 0 1-.53-.22l-5.27-5.27a.75.75 0 0 1-.22-.53V8.27a.75.75 0 0 1 .22-.53zm1.29 5.5a.75.75 0 0 0-1.06 1.06L10.94 12l-2.97 2.97a.75.75 0 1 0 1.06 1.06L12 13.06l2.97 2.97a.75.75 0 1 0 1.06-1.06L13.06 12l2.97-2.97a.75.75 0 0 0-1.06-1.06L12 10.94z'/%3E%3C/svg%3E");
-  --dsc-validation-message-icon-size: var(--ds-size-7);
+  --dsc-validation-message-icon-size: var(--ds-icon-size);
   --dsc-validation-message-spacing: var(--ds-size-2);
   --dsc-validation-message-color: var(--ds-color-danger-text-subtle);
 

--- a/packages/react/src/components/avatar/avatar.stories.tsx
+++ b/packages/react/src/components/avatar/avatar.stories.tsx
@@ -1,4 +1,4 @@
-import { BriefcaseIcon } from '@navikt/aksel-icons';
+import { BriefcaseIcon, HeartIcon } from '@navikt/aksel-icons';
 import type { Meta, StoryFn } from '@storybook/react-vite';
 import { cat3Img, themeColors } from '../../../stories/constants';
 
@@ -37,12 +37,24 @@ export const Sizes: Story = () => (
   <>
     <Avatar data-size='xs' aria-label='extra small' initials='xs' />
     <Avatar data-size='xs' aria-label='extra small' />
+    <Avatar data-size='xs' aria-label='extra small'>
+      <HeartIcon aria-hidden />
+    </Avatar>
     <Avatar data-size='sm' aria-label='small' initials='sm' />
     <Avatar data-size='sm' aria-label='small' />
+    <Avatar data-size='sm' aria-label='small'>
+      <HeartIcon aria-hidden />
+    </Avatar>
     <Avatar data-size='md' aria-label='medium' initials='md' />
     <Avatar data-size='md' aria-label='medium' />
+    <Avatar data-size='md' aria-label='medium'>
+      <HeartIcon aria-hidden />
+    </Avatar>
     <Avatar data-size='lg' aria-label='large' initials='lg' />
     <Avatar data-size='lg' aria-label='large' />
+    <Avatar data-size='lg' aria-label='large'>
+      <HeartIcon aria-hidden />
+    </Avatar>
   </>
 );
 


### PR DESCRIPTION
- Resolves https://github.com/digdir/designsystemet/issues/4813 
- Introduces as `ds-icon` mixin to ensure all icon "fixes" (fill color, tailwind overwrite, scaling) are added everywhere
- Add missing `--dsc-dialog-icon-size` variable
- Safari scaling issues are fixed in MacOS so reverting this workaround https://github.com/digdir/designsystemet/issues/4038 as the workaround now causes new scaling issues