### PR TITLE
docs: fix broken links

### DIFF
--- a/apps/www/app/content/fundamentals/en/start-here/own-theme.mdx
+++ b/apps/www/app/content/fundamentals/en/start-here/own-theme.mdx
@@ -59,7 +59,7 @@ This will generate Design Tokens based on the configuration file and save them i
   boxShadow={false}
 />
 
-  - In the plugin, set up the connection to your Git repository. See Tokens Studio’s guide “[Sync your Design Tokens with code (tokens.studio)](https://docs.tokens.studio/token-storage-and-sync/sync-provider-overview)” which explains how to do this for different Git providers.
+  - In the plugin, set up the connection to your Git repository. See Tokens Studio’s guide “[Sync your Design Tokens with code (tokens.studio)](https://docs.tokens.studio/token-storage/remote/#sync-providers)” which explains how to do this for different Git providers.
   - Remember to set the “Token storage location” to `design-tokens` (or whatever you have named your Design Tokens folder).
 
 <Alert data-color="info">

--- a/apps/www/app/content/fundamentals/no/start-here/own-theme.mdx
+++ b/apps/www/app/content/fundamentals/no/start-here/own-theme.mdx
@@ -62,7 +62,7 @@ Dette vil generere Design Tokens basert på config-fila og lagre dem i en mappe 
   boxShadow={false}
 />
 
-  - I pluginen skal du nå sette opp kobling til ditt Git repo. Se Tokens Studio sin guide "[Sync your Design Tokens with code (tokens.studio)](https://docs.tokens.studio/token-storage-and-sync/sync-provider-overview)" som forklarer hvordan du gjør dette for ulike Git Providers. 
+  - I pluginen skal du nå sette opp kobling til ditt Git repo. Se Tokens Studio sin guide "[Sync your Design Tokens with code (tokens.studio)](https://docs.tokens.studio/token-storage/remote/#sync-providers)" som forklarer hvordan du gjør dette for ulike Git Providers. 
   - Husk å sette "Token storage location" til `design-tokens` (eller det du har valgt å kalle mappen din med Design Tokens).
 
 <Alert data-color="info">


### PR DESCRIPTION
Resolves #4980 

## Summary

Broken link for Token Studio documentation, changed to correct URLs

## Checks

- [ ] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)
