### PR TITLE
fix(base): revert `ds-icon` defining `fill`

### DIFF
--- a/.changeset/sour-webs-notice.md
+++ b/.changeset/sour-webs-notice.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**base**: `ds-icon` no longer defines `fill`. Users must make sure their icons inherit color the correct way for their icons.

--- a/packages/css/src/base.css
+++ b/packages/css/src/base.css
@@ -43,7 +43,6 @@ body,
 
 .ds-icon {
   display: inline-block; /* Overwrite Tailwind setting display: block on <svg> */
-  fill: currentcolor;
   flex-shrink: 0;
   font-size: 1em;
   height: var(--ds-icon-size);


### PR DESCRIPTION
Not all icons are created equally, so it might be to opinionated for use to define fill for icons (svg).

Given an icon that is defined using lines (outline), defining `fill` on the svg breaks the icon. For example:

```svg
<svg
    xmlns="http://www.w3.org/2000/svg"
    width={size}
    height={size}
    fill="none"
    stroke="currentColor"
    strokeLinecap="round"
    strokeLinejoin="round"
    strokeWidth={2}
    viewBox="0 0 24 24"
    {...props}
  >
    <circle cx={6} cy={15} r={4} />
    <circle cx={18} cy={15} r={4} />
    <path d="M14 15a2 2 0 0 0-2-2 2 2 0 0 0-2 2M2.5 13 5 7c.7-1.3 1.4-2 3-2M21.5 13 19 7c-.7-1.3-1.5-2-3-2" />
  </svg>
```

https://designsystemet.slack.com/archives/C05RK9VEGJ0/p1781778192765679