### PR TITLE
fix(Field): styling ds-input only

### DIFF
--- a/.changeset/some-sites-flow.md
+++ b/.changeset/some-sites-flow.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**Field, Fieldset:** `disabled` and `read only` styling is now only affected by form elements with class name set to `ds-input`

--- a/packages/css/src/field.css
+++ b/packages/css/src/field.css
@@ -40,19 +40,19 @@
 
   /* Using pure HTML elements in selector to make this work if consumer changes name of .ds-input */
   &:not([hidden]),
-  & :is(label, input, select, textarea, .ds-input):where(:not([hidden])) {
+  & :where(label:not([hidden]), .ds-input:not([hidden])) {
     display: block; /* Ensure input is not placed on same line as label/description/validation, but respect [hidden] attribute */
   }
 
   /**
    * States
    */
-  &:has([aria-disabled='true']:not(u-option, [role='option'][aria-disabled='true']), :disabled:not(option)) > * {
+  &:has(.ds-input[aria-disabled='true'], .ds-input:disabled) > * {
     cursor: not-allowed;
     opacity: var(--ds-opacity-disabled);
   }
 
-  &:has([aria-readonly='true'], [readonly]) label {
+  &:where(:has(.ds-input[aria-readonly='true'], .ds-input[readonly])) label {
     @composes ds-readonly-icon from './base.css'; /* Activate lock icon for label when readonly */
   }
 
@@ -62,7 +62,7 @@
   &[data-clickdelegatefor] {
     cursor: pointer;
   }
-  &:has(input:is([type='radio'], [type='checkbox'])) {
+  &:has(input[type='radio'], input[type='checkbox']) {
     grid-template-areas: 'input content';
     grid-template-columns: auto 1fr;
     width: fit-content; /* Rather do display: grid + width: fit-content than display: inline-grid to encourage stacked radios */
@@ -92,7 +92,7 @@
       grid-row: 1; /* Always place input in row 1 */
     }
 
-    &:not(:has([readonly], [aria-disabled='true']:not(u-option), :disabled:not(option))) label {
+    &:not(:has(.ds-input[readonly], .ds-input[aria-disabled='true'], .ds-input:disabled)) label {
       cursor: pointer;
     }
 

--- a/packages/css/src/fieldset.css
+++ b/packages/css/src/fieldset.css
@@ -13,7 +13,7 @@
   }
 
   /* Add lock icon to legend when only containing readonly inputs */
-  &:has(input[readonly]):not(:has(input:not([readonly]))) > legend {
+  &:has(.ds-input[readonly]):not(:has(.ds-input:not([readonly]))) > legend {
     @composes ds-readonly-icon from './base.css'; /* Activate lock icon for legend when all inputs are readonly */
   }
 


### PR DESCRIPTION
Resolves #4795
Also fixes fieldset not being set to readonly if containing i.e. readonly `select` and `textarea`.