### PR TITLE
Filter internal selectors from the autogenerated CssAttributes table

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
       - .github/workflows/test.yml
       - "packages/**"
       - "apps/storybook/**"
+      - "apps/www/**"
 
 permissions:
   checks: write

--- a/apps/www/app/_components/css-attributes/css-attributes.test.ts
+++ b/apps/www/app/_components/css-attributes/css-attributes.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { getAttributes } from './css-attributes';
+
+describe('getAttributes', () => {
+  it('returns public data attributes', () => {
+    const attributes = getAttributes(`
+      .ds-chip[data-variant='primary'] {}
+      .ds-chip[data-removable] {}
+    `);
+
+    expect(attributes).toEqual({
+      removable: '',
+      variant: "'primary'",
+    });
+  });
+
+  it('filters internal floating UI selectors', () => {
+    const attributes = getAttributes(`
+      .ds-popover[data-floating] {}
+      .ds-tooltip[data-floating|='top'] {}
+      .ds-combobox [data-floating-ui-portal] {}
+      .ds-chip[data-removable] {}
+    `);
+
+    expect(attributes).toEqual({ removable: '' });
+  });
+
+  it('continues to filter global attributes', () => {
+    const attributes = getAttributes(`
+      [data-color='neutral'] {}
+      [data-size='sm'] {}
+      [data-color-scheme='dark'] {}
+      [data-removable] {}
+    `);
+
+    expect(attributes).toEqual({ removable: '' });
+  });
+
+  it('returns an empty object when no data attributes match', () => {
+    expect(getAttributes('.ds-button:hover {}')).toEqual({});
+  });
+});

--- a/apps/www/app/_components/css-attributes/css-attributes.tsx
+++ b/apps/www/app/_components/css-attributes/css-attributes.tsx
@@ -13,6 +13,15 @@ type CssAttributesProps = {
   };
 } & TableProps;
 
+const EXCLUDED_ATTRIBUTES = new Set([
+  'color',
+  'size',
+  'color-scheme',
+  // Floating UI positioning hooks are internal and not authored by consumers.
+  'floating',
+  'floating-ui-portal',
+]);
+
 export const CssAttributes = forwardRef<HTMLTableElement, CssAttributesProps>(
   function CssAttributes({ vars, className, ...rest }, ref) {
     const { t } = useTranslation();
@@ -62,8 +71,6 @@ export const CssAttributes = forwardRef<HTMLTableElement, CssAttributesProps>(
 /* returns data-attributes and their possible values as key value pairs*/
 export function getAttributes(css: string) {
   const res: { [key: string]: Set<unknown> | string } = {};
-  //filter out global attributes referenced locally
-  const globals = ['color', 'size', 'color-scheme'];
 
   const allAttrs = Array.from(
     css.matchAll(/\[data-([^=\]|$~*^]+)(?:([|$~*^]?=)([^\]]+))?\]/g),
@@ -71,7 +78,7 @@ export function getAttributes(css: string) {
 
   for (const attr of allAttrs) {
     for (const [key, value] of Object.entries(attr)) {
-      if (globals.includes(key)) continue;
+      if (EXCLUDED_ATTRIBUTES.has(key)) continue;
       if (!res[key]) {
         res[key] = new Set();
       }

--- a/apps/www/vite.config.ts
+++ b/apps/www/vite.config.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'node:url';
 import { reactRouter } from '@react-router/dev/vite';
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import { envOnlyMacros } from 'vite-env-only';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
@@ -50,5 +50,9 @@ export default defineConfig(({ isSsrBuild, command }) => ({
     warmup: {
       clientFiles: ['./app/root.tsx', './app/entry.client.tsx'],
     },
+  },
+  test: {
+    environment: 'node',
+    globals: true,
   },
 }));

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -3,7 +3,10 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    projects: ['{packages,internal}/*/vitest.config.mjs'],
+    projects: [
+      '{packages,internal}/*/vitest.config.mjs',
+      'apps/www/vite.config.ts',
+    ],
     reporters: [
       'default',
       ['junit', { suiteName: 'Unit tests', addFileAttribute: true }],


### PR DESCRIPTION
## Summary

The autogenerated CssAttributes documentation table no longer lists internal/private selectors. The generator now filters out selectors that are implementation details so the published attributes table only shows the public, author-facing CSS attributes. A regression test covers the filtering and is wired into the apps/www Vitest project so it runs in CI.

This is an `apps/www` (documentation website) change with no published-package impact, so no changeset is required.

Closes #4764

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
