### PR TITLE
Chip nowrap truncation

### DIFF
--- a/.changeset/chip-nowrap-truncation.md
+++ b/.changeset/chip-nowrap-truncation.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**Chip**: Truncate long labels with an ellipsis on a single line by default. Set `data-wrap="wrap"` to opt out and allow the label to wrap onto multiple lines.

--- a/packages/css/src/chip.css
+++ b/packages/css/src/chip.css
@@ -40,9 +40,20 @@
   max-height: fit-content;
   max-width: fit-content;
   min-height: var(--dsc-chip-height);
+  min-width: 0; /* Allow text content to shrink so it can truncate */
+  overflow: hidden;
   padding: 0 var(--ds-size-3);
   text-align: inherit; /* Fix text alignment when removable is <button> */
   text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap; /* Truncate long labels by default; opt out with data-wrap="wrap" */
+
+  /* Opt-out: restore wrapping for cases where multi-line labels are wanted */
+  &[data-wrap='wrap'] {
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+  }
 
   @composes ds-print-preserve from './base.css';
   @composes ds-focus from './base.css';

--- a/packages/react/src/components/chip/chips.test.tsx
+++ b/packages/react/src/components/chip/chips.test.tsx
@@ -19,6 +19,20 @@ describe('Chip.Button', () => {
     const lastClassNameIndex = chip.classList.length - 1;
     expect(chip.classList[lastClassNameIndex]).toBe('testClass');
   });
+
+  it('does not set data-wrap by default (so default truncation applies)', () => {
+    render(<Chip.Button>Norwegian</Chip.Button>);
+
+    const chip = screen.getByRole('button', { name: 'Norwegian' });
+    expect(chip).not.toHaveAttribute('data-wrap');
+  });
+
+  it('passes data-wrap through to the DOM via rest props', () => {
+    render(<Chip.Button data-wrap='wrap'>A very long chip label</Chip.Button>);
+
+    const chip = screen.getByRole('button', { name: 'A very long chip label' });
+    expect(chip).toHaveAttribute('data-wrap', 'wrap');
+  });
 });
 
 describe('Chip.Removable', () => {


### PR DESCRIPTION
## Summary

Chip labels currently wrap onto multiple lines because `.ds-chip` is an `inline-flex` container with no text-overflow handling, which looks awkward for long labels. As discussed in the issue, this makes single-line truncation the default and adds a `data-wrap="wrap"` opt-out for cases where wrapping is still wanted.

Fixes #4981

## Changes

- `packages/css/src/chip.css`: `.ds-chip` now sets `white-space: nowrap`, `overflow: hidden`, `text-overflow: ellipsis`, and `min-width: 0` so long labels truncate with an ellipsis on a single line. The removable `::after` x-icon already has `flex-shrink: 0`, so it stays visible while the text shrinks. A `&[data-wrap='wrap']` rule restores `white-space: normal`, `overflow: visible`, and `text-overflow: clip` as an opt-out.
- `max-width: fit-content` is preserved, so short chips are unaffected; truncation only engages when an explicit width constrains the chip.
- The React components already spread `...rest` onto the rendered element, so `data-wrap` passes through to the DOM with no component change.

## Testing

- Added JSDOM tests asserting `data-wrap` reaches the rendered DOM via rest-prop passthrough and is absent by default (computed-style truncation is covered by visual/chromatic tests).
- `vitest run packages/react/src/components/chip/chips.test.tsx` passes (20/20 across both React-version projects).
- Verified the compiled `chip.css` contains both the default `white-space: nowrap; text-overflow: ellipsis` and the `.ds-chip[data-wrap=wrap]` override.

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (`@digdir/designsystemet-css`, patch)
