### PR TITLE
fix: remove redundant charset

### DIFF
--- a/.changeset/busy-friends-accept.md
+++ b/.changeset/busy-friends-accept.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+**@charset**: remove redundant `@charset` as this simplifies merging Designsystemet with other CSS files

--- a/packages/css/src/index.css
+++ b/packages/css/src/index.css
@@ -1,5 +1,3 @@
-@charset "UTF-8";
-
 @layer ds.theme, ds.base, ds.components;
 
 /** Import order defines ordinal specificity for layers */


### PR DESCRIPTION
- Resolves #4501
- `@charset` is only needed if using non-ASCII characters that are not [unicode-converted](https://r12a.github.io/app-conversion/) in CSS properties like `content`
- Designsystemet does not use non-ASCII characters, thus making the `@charset` definition redundant and just a hassle for consumers merging several CSS files together (as `@charset` has to be the top most declaration)