### PR TITLE
fix(cli): now correctly creates CSS variables when color name has hyphen

### DIFF
--- a/.changeset/modern-lands-rescue.md
+++ b/.changeset/modern-lands-rescue.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet": patch
+---
+
+Now correctly creates CSS variables when color name has hyphen

--- a/packages/cli/src/tokens/process/formats/css/color.ts
+++ b/packages/cli/src/tokens/process/formats/css/color.ts
@@ -73,7 +73,10 @@ export const colorCategory: Format = {
       }),
       (token: TransformedToken) => ({
         ...token,
-        name: token.name.replace(/color-\w+-/, 'color-'),
+        // Strip the color name (e.g. "color-brand1-" -> "color-"). Color names can
+        // contain hyphens (e.g. "my-brand"), so remove the exact name from the path
+        // rather than matching with \w+, which would stop at the first hyphen.
+        name: token.name.replace(`color-${token.path[1]}-`, 'color-'),
         original: {
           ...token.original,
           $value: `{${token.path.join('.')}}`,


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

<!-- Explain in short what this PR does -->

## Checks

- [ ] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)
