### PR TITLE
chore: remove global declaration map config

### DIFF
--- a/.changeset/great-needles-read.md
+++ b/.changeset/great-needles-read.md
@@ -2,4 +2,4 @@
 "@digdir/designsystemet": patch
 ---
 
-Reduced package size by removing unintended source map files being generated.
+Reduced package size by removing unintended declaration map files being generated.

--- a/.changeset/great-needles-read.md
+++ b/.changeset/great-needles-read.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet": patch
+---
+
+Reduced package size by removing unintended source map files being generated.

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -36,7 +36,6 @@
     "plugins": [{ "name": "typescript-plugin-css-modules" }],
 
     "moduleDetection": "force",
-    "declarationMap": true,
     "allowJs": true,
     "noEmit": true,
     "incremental": true,


### PR DESCRIPTION
Removed `declarationMap:true` in base tsconfig as this forced source maps being generated for all typescript projects ignoring local configuration.

Souce maps will still be generated but decided by local bundler, (tsdown or tsc)