### PR TITLE
refactor(server): improve server bootstrap and configuration

### DIFF
--- a/apps/themebuilder/package.json
+++ b/apps/themebuilder/package.json
@@ -22,6 +22,7 @@
     "compression": "1.8.1",
     "cross-env": "10.1.0",
     "express": "5.2.1",
+    "helmet": "^8.2.0",
     "i18next": "26.3.3",
     "isbot": "5.1.44",
     "morgan": "1.11.0",

--- a/apps/themebuilder/server.js
+++ b/apps/themebuilder/server.js
@@ -2,19 +2,51 @@ import { createRequestHandler } from '@react-router/express';
 import compression from 'compression';
 import express from 'express';
 import morgan from 'morgan';
-import { securityHeaders } from './server/security-headers.js';
+import {
+  extraSecurityHeaders,
+  helmetMiddleware,
+} from './server/security-headers.js';
 
 // Short-circuit the type-checking of the built output.
 const BUILD_PATH = './dist/server/index.js';
+const CLIENT_DIR = 'dist/client';
 const DEVELOPMENT = process.env.NODE_ENV === 'development';
 const PORT = Number.parseInt(process.env.PORT || '3001', 10);
 
+const isValidPort = (n) => Number.isInteger(n) && n >= 1 && n <= 65535;
+
+if (!isValidPort(PORT)) {
+  console.error(
+    `Invalid PORT: "${process.env.PORT}". Must be an integer between 1 and 65535.`,
+  );
+  process.exit(1);
+}
+
 const app = express();
 
-app.use(compression());
 app.disable('x-powered-by');
 
+if (!DEVELOPMENT) app.set('trust proxy', 1); // single reverse-proxy hop in front of prod
+
+app.use(compression());
+app.use(morgan(DEVELOPMENT ? 'dev' : 'tiny'));
+
+// Server startup
 if (DEVELOPMENT) {
+  await startDevServer(app);
+} else {
+  await startProdServer(app);
+}
+
+const server = app.listen(PORT, () => {
+  console.log(`Server is running on http://localhost:${PORT}`);
+});
+server.headersTimeout = 60_000;
+server.requestTimeout = 60_000;
+
+// --- route handlers & setup functions ----------------------------------
+
+async function startDevServer(app) {
   console.log('Starting development server');
   const viteDevServer = await import('vite').then((vite) =>
     vite.createServer({
@@ -33,30 +65,30 @@ if (DEVELOPMENT) {
       next(error);
     }
   });
-} else {
+}
+
+async function startProdServer(app) {
   console.log('Starting production server');
   app.use(
     '/assets',
-    express.static('dist/client/assets', { immutable: true, maxAge: '1y' }),
+    express.static(`${CLIENT_DIR}/assets`, { immutable: true, maxAge: '1y' }),
   );
-  app.use(morgan('tiny'));
   app.use(
     '/.well-known',
-    express.static('dist/client/.well-known', { maxAge: '1y' }),
+    express.static(`${CLIENT_DIR}/.well-known`, { maxAge: '1y' }),
   );
-  app.use(express.static('dist/client', { maxAge: '30d' }));
+  app.use(express.static(CLIENT_DIR, { maxAge: '30d' }));
 
   // RR v8 emits the server build (not the bundled `server/app.ts`) at
-  // BUILD_PATH, so drive the request handler from it directly. `securityHeaders`
-  // replaces the middleware that the bundled `server/app.ts` used to provide.
-  app.use(securityHeaders);
+  // BUILD_PATH, so drive the request handler from it directly. `helmetMiddleware`
+  // + `extraSecurityHeaders` replace the middleware that the bundled
+  // `server/app.ts` used to provide.
+  app.use(helmetMiddleware);
+  app.use(extraSecurityHeaders);
+
   app.use(
     createRequestHandler({
       build: () => import(BUILD_PATH),
     }),
   );
 }
-
-app.listen(PORT, () => {
-  console.log(`Server is running on http://localhost:${PORT}`);
-});

--- a/apps/themebuilder/server/app.ts
+++ b/apps/themebuilder/server/app.ts
@@ -1,41 +1,12 @@
 import 'react-router';
 import { createRequestHandler } from '@react-router/express';
 import express from 'express';
-
-const DEVELOPMENT = process.env.NODE_ENV === 'development';
-
-const connectSrc = [
-  "'self'",
-  'https://altinncdn.no',
-  DEVELOPMENT && 'ws://localhost:*',
-]
-  .filter(Boolean)
-  .join(' ');
+import { extraSecurityHeaders, helmetMiddleware } from './security-headers';
 
 export const app = express();
 
-app.use((req, res, next) => {
-  res.setHeader('X-Content-Type-Options', 'nosniff');
-  res.setHeader(
-    'Strict-Transport-Security',
-    'max-age=31536000; includeSubDomains',
-  );
-  res.setHeader('X-Frame-Options', 'SAMEORIGIN');
-  res.setHeader(
-    'Content-Security-Policy-Report-Only',
-    `default-src 'none';base-uri 'self';script-src 'self' 'unsafe-inline' 'unsafe-eval';style-src 'self' https://altinncdn.no https://siteimproveanalytics.com 'unsafe-inline';font-src 'self' https://altinncdn.no;img-src 'self' data:;connect-src ${connectSrc};frame-ancestors 'self';form-action 'self';manifest-src 'self'; report-uri https://csp-report.digdir.no/api/reports`,
-  );
-  res.setHeader('Cache-Control', 'max-age');
-  /* Stop TRACE request */
-  if (req.method === 'TRACE') {
-    res
-      .status(405)
-      .type('text/plain; charset=utf-8')
-      .send('method not allowed');
-    return;
-  }
-  next();
-});
+app.use(helmetMiddleware);
+app.use(extraSecurityHeaders);
 
 app.use(
   createRequestHandler({

--- a/apps/themebuilder/server/security-headers.js
+++ b/apps/themebuilder/server/security-headers.js
@@ -1,3 +1,5 @@
+import helmet from 'helmet';
+
 const DEVELOPMENT = process.env.NODE_ENV === 'development';
 
 const connectSrc = [
@@ -8,27 +10,53 @@ const connectSrc = [
   .filter(Boolean)
   .join(' ');
 
+export const helmetMiddleware = helmet({
+  contentSecurityPolicy: {
+    reportOnly: true,
+    directives: {
+      defaultSrc: ["'none'"],
+      baseUri: ["'self'"],
+      scriptSrc: ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+      styleSrc: [
+        "'self'",
+        'https://altinncdn.no',
+        'https://siteimproveanalytics.com',
+        "'unsafe-inline'",
+      ],
+      fontSrc: ["'self'", 'https://altinncdn.no'],
+      imgSrc: ["'self'", 'data:'],
+      connectSrc,
+      frameAncestors: ["'self'"],
+      formAction: ["'self'"],
+      manifestSrc: ["'self'"],
+      reportUri: ['https://csp-report.digdir.no/api/reports'],
+    },
+  },
+
+  strictTransportSecurity: {
+    maxAge: 31536000,
+    includeSubDomains: true,
+  },
+  frameguard: { action: 'sameorigin' },
+  noSniff: true,
+});
+
 /**
- * Security/CSP headers and TRACE blocking.
- *
- * In RR v7 these were applied by the bundled `server/app.ts`. Under RR v8 the
- * SSR build no longer bundles `server/app.ts` (it emits the React Router server
- * build instead), so the production server in `server.js` drives the request
- * handler directly and applies this middleware itself. Keep in sync with the
- * inline copy in `server/app.ts`, which still serves the dev server.
+ * Homepage Link headers (RFC 8288 / RFC 9727) and TRACE blocking.
+ * Complements helmetMiddleware, which handles
+ * the standard security headers and CSP.
  */
-export function securityHeaders(req, res, next) {
-  res.setHeader('X-Content-Type-Options', 'nosniff');
-  res.setHeader(
-    'Strict-Transport-Security',
-    'max-age=31536000; includeSubDomains',
-  );
-  res.setHeader('X-Frame-Options', 'SAMEORIGIN');
-  res.setHeader(
-    'Content-Security-Policy-Report-Only',
-    `default-src 'none';base-uri 'self';script-src 'self' 'unsafe-inline' 'unsafe-eval';style-src 'self' https://altinncdn.no https://siteimproveanalytics.com 'unsafe-inline';font-src 'self' https://altinncdn.no;img-src 'self' data:;connect-src ${connectSrc};frame-ancestors 'self';form-action 'self';manifest-src 'self'; report-uri https://csp-report.digdir.no/api/reports`,
-  );
+export function extraSecurityHeaders(req, res, next) {
   res.setHeader('Cache-Control', 'max-age');
+
+  /* Add Link headers for agent discovery (RFC 8288 / RFC 9727) on the homepage */
+  if (req.path === '/') {
+    res.setHeader('Link', [
+      '</.well-known/api-catalog>; rel="api-catalog"',
+      '</.well-known/security.txt>; rel="disclosure"',
+      '</sitemap.xml>; rel="sitemap"',
+    ]);
+  }
 
   /* Stop TRACE request */
   if (req.method === 'TRACE') {

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -23,6 +23,7 @@
     "express": "5.2.1",
     "express-rate-limit": "8.5.2",
     "gray-matter": "^4.0.3",
+    "helmet": "^8.2.0",
     "htmlfy": "1.0.2",
     "i18next": "26.3.3",
     "isbot": "5.1.44",

--- a/apps/www/server.js
+++ b/apps/www/server.js
@@ -1,28 +1,63 @@
 import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { createRequestHandler } from '@react-router/express';
 import compression from 'compression';
 import express from 'express';
-//import rateLimit from 'express-rate-limit';
+// import rateLimit from 'express-rate-limit';
 import morgan from 'morgan';
 import { markdownNegotiation } from './server/markdown-negotiation.js';
-import { securityHeaders } from './server/security-headers.js';
+import {
+  extraSecurityHeaders,
+  helmetMiddleware,
+} from './server/security-headers.js';
 
 // Short-circuit the type-checking of the built output.
 const BUILD_PATH = './dist/server/index.js';
+const CLIENT_DIR = 'dist/client';
 const DEVELOPMENT = process.env.NODE_ENV === 'development';
 const PORT = Number.parseInt(process.env.PORT || '3000', 10);
 
+const isValidPort = (n) => Number.isInteger(n) && n >= 1 && n <= 65535;
+
+if (!isValidPort(PORT)) {
+  console.error(
+    `Invalid PORT: "${process.env.PORT}". Must be an integer between 1 and 65535.`,
+  );
+  process.exit(1);
+}
+
 const app = express();
 
-app.use(compression());
-app.use(markdownNegotiation);
 app.disable('x-powered-by');
 
-/* Serve /.well-known/api-catalog with correct Content-Type (RFC 9727) */
-app.get('/.well-known/api-catalog', (_req, res) => {
+if (!DEVELOPMENT) app.set('trust proxy', 1); // single reverse-proxy hop in front of prod
+
+app.use(compression());
+app.use(morgan(DEVELOPMENT ? 'dev' : 'tiny'));
+app.use(markdownNegotiation);
+app.get('/.well-known/api-catalog', serveApiCatalog);
+
+// Server startup
+if (DEVELOPMENT) {
+  await startDevServer(app);
+} else {
+  await startProdServer(app);
+}
+
+const server = app.listen(PORT, () => {
+  console.log(`Server is running on http://localhost:${PORT}`);
+});
+server.headersTimeout = 60_000;
+server.requestTimeout = 60_000;
+
+// --- route handlers & setup functions ----------------------------------
+
+// Serve /.well-known/api-catalog with correct Content-Type (RFC 9727)
+function serveApiCatalog(_req, res) {
   const filePath = DEVELOPMENT
     ? 'public/.well-known/api-catalog'
-    : 'dist/client/.well-known/api-catalog';
+    : `${CLIENT_DIR}/.well-known/api-catalog`;
+
   try {
     const content = readFileSync(filePath, 'utf-8');
     res.setHeader(
@@ -34,16 +69,19 @@ app.get('/.well-known/api-catalog', (_req, res) => {
   } catch {
     res.status(404).send('Not Found');
   }
-});
+}
 
-if (DEVELOPMENT) {
+async function startDevServer(app) {
   console.log('Starting development server');
+
   const viteDevServer = await import('vite').then((vite) =>
     vite.createServer({
       server: { middlewareMode: true },
     }),
   );
+
   app.use(viteDevServer.middlewares);
+
   app.use(async (req, res, next) => {
     try {
       const source = await viteDevServer.ssrLoadModule('./server/app.ts');
@@ -55,45 +93,39 @@ if (DEVELOPMENT) {
       next(error);
     }
   });
-} else {
+}
+
+async function startProdServer(app) {
   console.log('Starting production server');
   app.use(
     '/assets',
-    express.static('dist/client/assets', { immutable: true, maxAge: '1y' }),
+    express.static(`${CLIENT_DIR}/assets`, { immutable: true, maxAge: '1y' }),
   );
-  app.use(morgan('tiny'));
   app.use(
     '/.well-known',
-    express.static('dist/client/.well-known', { maxAge: '1y' }),
+    express.static(`${CLIENT_DIR}/.well-known`, { maxAge: '1y' }),
   );
-  app.use(express.static('dist/client/img', { maxAge: '30d' }));
-  app.use(express.static('dist/client/animations', { maxAge: '30d' }));
+  app.use(express.static(`${CLIENT_DIR}/img`, { maxAge: '30d' }));
+  app.use(express.static(`${CLIENT_DIR}/animations`, { maxAge: '30d' }));
 
-  /*   const htmlRateLimiter = rateLimit({
-    windowMs: 15 * 60 * 1000, // 15 minutes
-    max: 100, // limit each IP to 100 requests per windowMs for prerendered HTML
-  }); */
+  // const htmlRateLimiter = rateLimit({
+  //   windowMs: 15 * 60 * 1000, // 15 minutes
+  //   max: 100, // limit each IP to 100 requests per windowMs for prerendered HTML
+  //   skip: (req) => !req.accepts('html'),
+  // });
 
-  /* Serve prerendered HTML files for clean URLs (e.g., /no/intro -> /no/intro/index.html) */
-  app.use((req, res, next) => {
-    if (req.path.includes('.') || req.path.startsWith('/assets')) {
-      return next();
-    }
+  // app.use(htmlRateLimiter);
 
-    const indexPath = `dist/client${req.path}/index.html`;
-    res.sendFile(indexPath, { root: '.' }, (err) => {
-      if (err) {
-        next();
-      }
-    });
-  });
-
-  app.use(express.static('dist/client', { redirect: false }));
+  app.use(servePrerenderedHtml);
+  app.use(express.static(CLIENT_DIR, { redirect: false }));
 
   // RR v8 emits the server build (not the bundled `server/app.ts`) at
-  // BUILD_PATH, so drive the request handler from it directly. `securityHeaders`
-  // replaces the middleware that the bundled `server/app.ts` used to provide.
-  app.use(securityHeaders);
+  // BUILD_PATH, so drive the request handler from it directly. `helmetMiddleware`
+  // + `extraSecurityHeaders` replace the middleware that the bundled
+  // `server/app.ts` used to provide.
+  app.use(helmetMiddleware);
+  app.use(extraSecurityHeaders);
+
   app.use(
     createRequestHandler({
       build: () => import(BUILD_PATH),
@@ -101,6 +133,20 @@ if (DEVELOPMENT) {
   );
 }
 
-app.listen(PORT, () => {
-  console.log(`Server is running on http://localhost:${PORT}`);
-});
+/** Serve prerendered HTML for clean URLs (e.g. /no/intro -> /no/intro/index.html) */
+function servePrerenderedHtml(req, res, next) {
+  if (req.path.includes('.') || req.path.startsWith('/assets')) {
+    return next();
+  }
+
+  const clientRoot = path.resolve(CLIENT_DIR);
+  const indexPath = path.join(clientRoot, req.path, 'index.html');
+
+  if (!indexPath.startsWith(clientRoot + path.sep)) {
+    return res.status(400).send('Bad Request');
+  }
+
+  res.sendFile(indexPath, (err) => {
+    if (err) next();
+  });
+}

--- a/apps/www/server/app.ts
+++ b/apps/www/server/app.ts
@@ -1,52 +1,12 @@
 import 'react-router';
 import { createRequestHandler } from '@react-router/express';
 import express from 'express';
-
-const DEVELOPMENT = process.env.NODE_ENV === 'development';
-
-const connectSrc = [
-  "'self'",
-  'https://altinncdn.no',
-  DEVELOPMENT && 'ws://localhost:*',
-]
-  .filter(Boolean)
-  .join(' ');
+import { extraSecurityHeaders, helmetMiddleware } from './security-headers';
 
 export const app = express();
 
-app.use((req, res, next) => {
-  res.setHeader('X-Content-Type-Options', 'nosniff');
-  res.setHeader(
-    'Strict-Transport-Security',
-    'max-age=31536000; includeSubDomains',
-  );
-  res.setHeader('X-Frame-Options', 'SAMEORIGIN');
-  res.setHeader(
-    'Content-Security-Policy-Report-Only',
-    `default-src 'none';base-uri 'self';script-src 'self' 'unsafe-inline' 'unsafe-eval';style-src 'self' https://altinncdn.no https://siteimproveanalytics.com 'unsafe-inline';font-src 'self' https://altinncdn.no;img-src 'self' data:;connect-src ${connectSrc};frame-ancestors 'self';form-action 'self';manifest-src 'self'; report-uri https://csp-report.digdir.no/api/reports`,
-  );
-
-  res.setHeader('Cache-Control', 'max-age');
-
-  /* Add Link headers for agent discovery (RFC 8288 / RFC 9727) on the homepage */
-  if (req.path === '/') {
-    res.setHeader('Link', [
-      '</.well-known/api-catalog>; rel="api-catalog"',
-      '</.well-known/security.txt>; rel="disclosure"',
-      '</sitemap.xml>; rel="sitemap"',
-    ]);
-  }
-
-  /* Stop TRACE request */
-  if (req.method === 'TRACE') {
-    res
-      .status(405)
-      .type('text/plain; charset=utf-8')
-      .send('method not allowed');
-    return;
-  }
-  next();
-});
+app.use(helmetMiddleware);
+app.use(extraSecurityHeaders);
 
 app.use(
   createRequestHandler({

--- a/apps/www/server/security-headers.js
+++ b/apps/www/server/security-headers.js
@@ -1,3 +1,5 @@
+import helmet from 'helmet';
+
 const DEVELOPMENT = process.env.NODE_ENV === 'development';
 
 const connectSrc = [
@@ -8,28 +10,43 @@ const connectSrc = [
   .filter(Boolean)
   .join(' ');
 
-/**
- * Security/CSP headers, homepage Link headers (RFC 8288 / RFC 9727) and TRACE
- * blocking.
- *
- * In RR v7 these were applied by the bundled `server/app.ts`. Under RR v8 the
- * SSR build no longer bundles `server/app.ts` (it emits the React Router server
- * build instead), so the production server in `server.js` drives the request
- * handler directly and applies this middleware itself. Keep in sync with the
- * inline copy in `server/app.ts`, which still serves the dev server.
- */
-export function securityHeaders(req, res, next) {
-  res.setHeader('X-Content-Type-Options', 'nosniff');
-  res.setHeader(
-    'Strict-Transport-Security',
-    'max-age=31536000; includeSubDomains',
-  );
-  res.setHeader('X-Frame-Options', 'SAMEORIGIN');
-  res.setHeader(
-    'Content-Security-Policy-Report-Only',
-    `default-src 'none';base-uri 'self';script-src 'self' 'unsafe-inline' 'unsafe-eval';style-src 'self' https://altinncdn.no https://siteimproveanalytics.com 'unsafe-inline';font-src 'self' https://altinncdn.no;img-src 'self' data:;connect-src ${connectSrc};frame-ancestors 'self';form-action 'self';manifest-src 'self'; report-uri https://csp-report.digdir.no/api/reports`,
-  );
+export const helmetMiddleware = helmet({
+  contentSecurityPolicy: {
+    reportOnly: true,
+    directives: {
+      defaultSrc: ["'none'"],
+      baseUri: ["'self'"],
+      scriptSrc: ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+      styleSrc: [
+        "'self'",
+        'https://altinncdn.no',
+        'https://siteimproveanalytics.com',
+        "'unsafe-inline'",
+      ],
+      fontSrc: ["'self'", 'https://altinncdn.no'],
+      imgSrc: ["'self'", 'data:'],
+      connectSrc,
+      frameAncestors: ["'self'"],
+      formAction: ["'self'"],
+      manifestSrc: ["'self'"],
+      reportUri: ['https://csp-report.digdir.no/api/reports'],
+    },
+  },
 
+  strictTransportSecurity: {
+    maxAge: 31536000,
+    includeSubDomains: true,
+  },
+  frameguard: { action: 'sameorigin' },
+  noSniff: true,
+});
+
+/**
+ * Homepage Link headers (RFC 8288 / RFC 9727) and TRACE blocking.
+ * Complements helmetMiddleware, which handles
+ * the standard security headers and CSP.
+ */
+export function extraSecurityHeaders(req, res, next) {
   res.setHeader('Cache-Control', 'max-age');
 
   /* Add Link headers for agent discovery (RFC 8288 / RFC 9727) on the homepage */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       express:
         specifier: 5.2.1
         version: 5.2.1
+      helmet:
+        specifier: ^8.2.0
+        version: 8.2.0
       i18next:
         specifier: 26.3.3
         version: 26.3.3(typescript@5.9.3)
@@ -275,6 +278,9 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      helmet:
+        specifier: ^8.2.0
+        version: 8.2.0
       htmlfy:
         specifier: 1.0.2
         version: 1.0.2
@@ -536,7 +542,7 @@ importers:
         version: 0.31.1
       tsdown:
         specifier: 0.22.2
-        version: 0.22.2(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(tsx@4.22.4)(typescript@5.9.3)
+        version: 0.22.2(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(tsx@4.22.4)(typescript@5.9.3)
       tsx:
         specifier: 4.22.4
         version: 4.22.4
@@ -3816,6 +3822,10 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
 
+  helmet@8.2.0:
+    resolution: {integrity: sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==}
+    engines: {node: '>=18.0.0'}
+
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
 
@@ -6908,13 +6918,6 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.2
-    optional: true
-
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -7127,14 +7130,6 @@ snapshots:
   '@oxc-resolver/binding-wasm32-wasi@11.16.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-    optional: true
-
-  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -8677,10 +8672,6 @@ snapshots:
 
   dotenv@16.5.0: {}
 
-  dts-resolver@3.0.0(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)):
-    optionalDependencies:
-      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-
   dts-resolver@3.0.0(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)):
     optionalDependencies:
       oxc-resolver: 11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
@@ -9150,6 +9141,8 @@ snapshots:
       '@types/hast': 3.0.4
 
   he@1.2.0: {}
+
+  helmet@8.2.0: {}
 
   hookable@6.1.1: {}
 
@@ -10187,33 +10180,6 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
-    optionalDependencies:
-      '@oxc-resolver/binding-android-arm-eabi': 11.19.1
-      '@oxc-resolver/binding-android-arm64': 11.19.1
-      '@oxc-resolver/binding-darwin-arm64': 11.19.1
-      '@oxc-resolver/binding-darwin-x64': 11.19.1
-      '@oxc-resolver/binding-freebsd-x64': 11.19.1
-      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.19.1
-      '@oxc-resolver/binding-linux-arm-musleabihf': 11.19.1
-      '@oxc-resolver/binding-linux-arm64-gnu': 11.19.1
-      '@oxc-resolver/binding-linux-arm64-musl': 11.19.1
-      '@oxc-resolver/binding-linux-ppc64-gnu': 11.19.1
-      '@oxc-resolver/binding-linux-riscv64-gnu': 11.19.1
-      '@oxc-resolver/binding-linux-riscv64-musl': 11.19.1
-      '@oxc-resolver/binding-linux-s390x-gnu': 11.19.1
-      '@oxc-resolver/binding-linux-x64-gnu': 11.19.1
-      '@oxc-resolver/binding-linux-x64-musl': 11.19.1
-      '@oxc-resolver/binding-openharmony-arm64': 11.19.1
-      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      '@oxc-resolver/binding-win32-arm64-msvc': 11.19.1
-      '@oxc-resolver/binding-win32-ia32-msvc': 11.19.1
-      '@oxc-resolver/binding-win32-x64-msvc': 11.19.1
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-    optional: true
-
   oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
     optionalDependencies:
       '@oxc-resolver/binding-android-arm-eabi': 11.19.1
@@ -10896,22 +10862,6 @@ snapshots:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
 
-  rolldown-plugin-dts@0.25.2(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.1.0)(typescript@5.9.3):
-    dependencies:
-      '@babel/generator': 8.0.0-rc.6
-      '@babel/helper-validator-identifier': 8.0.0-rc.6
-      '@babel/parser': 8.0.0-rc.6
-      ast-kit: 3.0.0-beta.1
-      birpc: 4.0.0
-      dts-resolver: 3.0.0(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
-      get-tsconfig: 5.0.0-beta.5
-      obug: 2.1.1
-      rolldown: 1.1.0
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - oxc-resolver
-
   rolldown-plugin-dts@0.25.2(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rolldown@1.1.0)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 8.0.0-rc.6
@@ -11407,32 +11357,6 @@ snapshots:
       json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
-
-  tsdown@0.22.2(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(tsx@4.22.4)(typescript@5.9.3):
-    dependencies:
-      ansis: 4.3.1
-      cac: 7.0.0
-      defu: 6.1.7
-      empathic: 2.0.1
-      hookable: 6.1.1
-      import-without-cache: 0.4.0
-      obug: 2.1.1
-      picomatch: 4.0.4
-      rolldown: 1.1.0
-      rolldown-plugin-dts: 0.25.2(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rolldown@1.1.0)(typescript@5.9.3)
-      semver: 7.8.1
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tree-kill: 1.2.2
-      unconfig-core: 7.5.0
-    optionalDependencies:
-      tsx: 4.22.4
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@ts-macro/tsc'
-      - '@typescript/native-preview'
-      - oxc-resolver
-      - vue-tsc
 
   tsdown@0.22.2(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(tsx@4.22.4)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

This PR refactors the server bootstrap and improves overall readability and structure across both `www` and `themebuilder` server setups.

It introduces `helmet` for centralized security header management which replaces most manual `setHeader` handling, and improves production robustness by adding trust proxy configuration (`if (!DEVELOPMENT) app.set('trust proxy', 1);`), `PORT` validation, and `request`/`response` server timeouts.

No functional changes to application behavior are intended. This is a structural and security hardening refactor.

## Checks

- [X] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)
