### PR TITLE
fix(clickdelegatefor): `<summary>` is the clickable part of `<details>`

### DIFF
--- a/.changeset/afraid-numbers-lose.md
+++ b/.changeset/afraid-numbers-lose.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-web": patch
+---
+
+**clickdelegatefor**: Fixes an issue with using `data-clickdelegatefor` inside of `<details>`

--- a/packages/web/src/clickdelegatefor/clickdelegatefor.ts
+++ b/packages/web/src/clickdelegatefor/clickdelegatefor.ts
@@ -7,7 +7,7 @@ const CLASS_HOVER = ':click-delegate-hover';
 const ATTR_CLICKDELEGATEFOR = 'data-clickdelegatefor';
 const SELECTOR_CLICKDELEGATEFOR = `[${ATTR_CLICKDELEGATEFOR}]`;
 const SELECTOR_SKIP =
-  'a,button,label,input,select,textarea,details,dialog,[role="button"],[popover],[contenteditable]';
+  'a,button,label,input,select,textarea,summary,dialog,[role="button"],[popover],[contenteditable]';
 
 const handleClickDelegateFor = (event: MouseEvent) => {
   const isNewTab = event.button === 1 || event.metaKey || event.ctrlKey; // Middle click or cmd/ctrl + click should open in new tab


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

<!-- Explain in short what this PR does -->

## Checks

- [ ] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)
