### PR TITLE
fix(Field): restructured to ensure element cache is scoped to custom elements

### DIFF
--- a/.changeset/seven-wombats-crash.md
+++ b/.changeset/seven-wombats-crash.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-web": patch
+---
+
+**Field:** now scopes internal cache to DSFieldElement class to avoid version conflicts

--- a/packages/web/src/field/field.ts
+++ b/packages/web/src/field/field.ts
@@ -7,7 +7,6 @@ import {
   debounce,
   isWindows,
   on,
-  onHotReload,
   onMutation,
   QUICK_EVENT,
   useId,
@@ -25,26 +24,12 @@ const ATTR_INVALID = 'aria-invalid';
 const ATTR_DESCRIBEDBY = 'aria-describedby';
 const ATTR_INDETERMINATE = 'data-indeterminate';
 const COUNTER_DEBOUNCE = isWindows() ? 800 : 200; // Longer debounce on Windows due to NVDA performance
-const COUNTS = new WeakMap<HTMLInputElement, Element>(); // Using WeakMap so removed inputs/counts does not cause memory leaks
-const FIELDS = new Map<DSFieldElement, string[]>(); // Map of Field and its describedby IDs so we can identify the ones we add/remove
-const VALIDATIONS = new WeakSet<HTMLInputElement>(); // Used to ensure we only take control of aria-invalid if the current is or has been a validation element
 const WARNING_MULTIPLE_INPUTS = `Fields should only have one input element. Use <fieldset> to group multiple fields:`;
-
-const handleFieldMutations = (_doc: Node, records: MutationRecord[] = []) => {
-  for (const { target } of records) {
-    const isFieldset = target instanceof HTMLFieldSetElement;
-    for (const [field] of FIELDS)
-      if (isFieldset ? target.contains(field) : field.contains(target))
-        handleFieldMutation(field);
-  }
-};
 
 const handleFieldMutation = (field: DSFieldElement) => {
   const labels: HTMLLabelElement[] = [];
   const nextDescs: string[] = []; // Keep track of descriptions we are adding in this mutation
-  const prevDescs = FIELDS.get(field) || []; // Retrieve previously managed IDs for this field
-  let input: HTMLInputElement | undefined;
-  let counter: Element | undefined;
+  const prevDescs = field._descs || []; // Retrieve previously managed IDs for this field
   let hasValidation = false;
   let invalid = false;
 
@@ -52,11 +37,12 @@ const handleFieldMutation = (field: DSFieldElement) => {
     if (el instanceof HTMLLabelElement) labels.push(el);
     if ((el as HTMLElement).hidden) continue; // Skip hidden elements except labels
     if (isInputLike(el)) {
-      if (input) warn(WARNING_MULTIPLE_INPUTS, field);
-      else input = el; // Only register if visible input
+      if (field._input?.isConnected && field._input !== el)
+        warn(WARNING_MULTIPLE_INPUTS, field);
+      else field._input = el; // Only register if visible input
     } else {
       const type = el.getAttribute('data-field'); // Using getAttribute instead of attr for best performance
-      if (type === 'counter') counter = el;
+      if (type === 'counter') field._counter = el;
       if (type === 'validation') {
         nextDescs.unshift(useId(el));
         hasValidation = true;
@@ -65,9 +51,10 @@ const handleFieldMutation = (field: DSFieldElement) => {
     }
   }
 
-  if (!input) return; // Do not warn about missing input as virtual DOM libraries might give false positives
-  if (counter) COUNTS.set(input, counter);
-  for (const label of labels) attr(label, 'for', useId(input));
+  if (!field._input?.isConnected) return; // Do not warn about missing input as virtual DOM libraries might give false positives
+
+  const input = field._input;
+  for (const label of labels) attr(label, 'for', useId(input) || null);
 
   const fieldsetValidation = field
     .closest('fieldset')
@@ -81,6 +68,7 @@ const handleFieldMutation = (field: DSFieldElement) => {
   }
 
   // Add support for data-indeterminate attribute as this normally can only be set by javascript
+
   const indeterminate = attr(input, ATTR_INDETERMINATE);
   if (indeterminate) input.indeterminate = indeterminate === 'true';
 
@@ -92,51 +80,25 @@ const handleFieldMutation = (field: DSFieldElement) => {
   const describedby = attr(input, ATTR_DESCRIBEDBY)?.trim().split(/\s+/);
   const keep = describedby?.filter((id) => !prevDescs.includes(id)) || []; // Find non-ds-field-managed aria-describedby IDs
   attr(input, ATTR_DESCRIBEDBY, [...nextDescs, ...keep].join(' ') || null);
-  FIELDS.set(field, nextDescs);
+  field._descs = nextDescs;
 
   // Only manage aria-invalid when field has validation elements, and aria-invalid does not already exist
-  const hadValidation = VALIDATIONS.has(input);
+  const hadValidation = field._validation;
   if (hasValidation && !hadValidation && !input.hasAttribute(ATTR_INVALID)) {
     attr(input, ATTR_INVALID, 'true');
-    VALIDATIONS.add(input);
+    field._validation = true;
   } else if (!hasValidation && hadValidation) {
     attr(input, ATTR_INVALID, null); // Remove aria-invalid
-    VALIDATIONS.delete(input);
+    field._validation = undefined;
   }
 
-  handleFieldInput(input); // Update counter and textarea sizing
+  field.handleEvent(); // Update counter and textarea sizing
 };
 
 // Used as fallback in tests when CSS is not loaded
 const TEXTS = {
   over: '%d tegn for mye',
   under: '%d tegn igjen',
-};
-
-const handleFieldInput = (e: Event | Element) => {
-  const input = ((e as Event).target || e) as HTMLInputElement;
-  const counter = COUNTS.get(input);
-
-  if (counter?.isConnected) {
-    const limit = Number(attr(counter, 'data-limit')) || 0;
-    const count = limit - input.value.length;
-    const state = count < 0 ? 'over' : 'under';
-    const label = (
-      attrOrCSS(counter, `data-${state}`) || TEXTS[state]
-    )?.replace('%d', `${Math.abs(count)}`);
-
-    attr(counter, 'data-label', label); // Using attribute to prevent hydation errors, not using aria-label to make axe tests happy
-    attr(counter, 'data-state', state);
-    attr(counter, 'data-color', count < 0 ? 'danger' : null);
-
-    // Only update live region when user is actually typing
-    if ((e as Event).type === 'input' && label)
-      debouncedCounterLiveRegion(input, label); // Debounce live region to avoid NVDA interupting announcing typed text
-  }
-  if (input instanceof HTMLTextAreaElement) {
-    input.style.setProperty('--_ds-field-sizing', 'auto');
-    input.style.setProperty('--_ds-field-sizing', `${input.scrollHeight}px`);
-  }
 };
 
 const debouncedCounterLiveRegion = debounce((input: Element, text: string) => {
@@ -152,30 +114,62 @@ const isInputLike = (el: unknown): el is HTMLInputElement =>
 
 // Custom element is used to performantly keep track of fields on the page
 export class DSFieldElement extends DSElement {
+  _counter?: Element; // Using underscore instead of private fields for backwards compatibility
+  _descs?: string[];
+  _input?: HTMLInputElement;
+  _validation?: boolean;
+  _unevents?: () => void;
+  _unmutate?: () => void;
+
   connectedCallback() {
-    FIELDS.set(this, []); // Register field
-    handleFieldMutation(this); // Initial setup
+    this._unevents = on(document, 'input', this, QUICK_EVENT);
+    this._unmutate = onMutation(this, () => handleFieldMutation(this), {
+      attributeFilter: [
+        'data-field',
+        'data-limit',
+        'hidden', // Needed to check validation visibility
+        'id', // Needed to sync label "for" when ID of input/selec/textarea changes
+        'value', // Needed to detect changes in controlled React inputs as they do not trigger input events
+        ATTR_INDETERMINATE,
+      ],
+      attributes: true,
+      childList: true,
+      subtree: true,
+    });
+  }
+  handleEvent(event?: Event) {
+    const { _counter, _input } = this;
+
+    if (_counter?.isConnected && _input) {
+      const limit = Number(attr(_counter, 'data-limit')) || 0;
+      const count = limit - _input.value.length;
+      const state = count < 0 ? 'over' : 'under';
+      const label = (
+        attrOrCSS(_counter, `data-${state}`) || TEXTS[state]
+      )?.replace('%d', `${Math.abs(count)}`);
+
+      attr(_counter, 'data-label', label); // Using attribute to prevent hydation errors, not using aria-label to make axe tests happy
+      attr(_counter, 'data-state', state);
+      attr(_counter, 'data-color', count < 0 ? 'danger' : null);
+
+      // Only update live region when user is actually typing
+      if (event?.type === 'input' && label)
+        debouncedCounterLiveRegion(_input, label); // Debounce live region to avoid NVDA interupting announcing typed text
+    }
+    if (_input instanceof HTMLTextAreaElement) {
+      _input.style.setProperty('--_ds-field-sizing', 'auto');
+      _input.style.setProperty(
+        '--_ds-field-sizing',
+        `${_input.scrollHeight}px`,
+      );
+    }
   }
   disconnectedCallback() {
-    FIELDS.delete(this);
+    this._unevents?.();
+    this._unmutate?.();
+    this._unevents = this._unmutate = undefined;
+    this._input = this._counter = this._descs = this._validation = undefined;
   }
 }
 
 customElements.define('ds-field', DSFieldElement);
-
-onHotReload('field', () => [
-  on(document, 'input', handleFieldInput, QUICK_EVENT),
-  onMutation(document, handleFieldMutations, {
-    attributeFilter: [
-      'data-field',
-      'data-limit',
-      'hidden', // Needed to check validation visibility
-      'id', // Needed to sync label "for" when ID of input/selec/textarea changes
-      'value', // Needed to detect changes in controlled React inputs as they do not trigger input events
-      ATTR_INDETERMINATE,
-    ],
-    attributes: true,
-    childList: true,
-    subtree: true,
-  }),
-]);

--- a/packages/web/src/field/field.ts
+++ b/packages/web/src/field/field.ts
@@ -33,6 +33,8 @@ const handleFieldMutation = (field: DSFieldElement) => {
   let hasValidation = false;
   let invalid = false;
 
+  if (field._input?.hidden) field._input = undefined; // Reset input if it has been hidden
+
   for (const el of field.getElementsByTagName('*')) {
     if (el instanceof HTMLLabelElement) labels.push(el);
     if ((el as HTMLElement).hidden) continue; // Skip hidden elements except labels
@@ -122,7 +124,7 @@ export class DSFieldElement extends DSElement {
   _unmutate?: () => void;
 
   connectedCallback() {
-    this._unevents = on(document, 'input', this, QUICK_EVENT);
+    this._unevents = on(this, 'input', this, QUICK_EVENT);
     this._unmutate = onMutation(this, () => handleFieldMutation(this), {
       attributeFilter: [
         'data-field',

--- a/packages/web/src/utils/utils.ts
+++ b/packages/web/src/utils/utils.ts
@@ -1,9 +1,8 @@
 export const QUICK_EVENT = { passive: true, capture: true };
 
-// TODO EIRIK check built file of this
 import { version } from '../../package.json' with { type: 'json' };
 
-// Using function instead of constant to support evnironments where DOM can be unloaded (like Vitest with jsdom)
+// Using function instead of constant to support environments where DOM can be unloaded (like Vitest with jsdom)
 export const isBrowser = () =>
   typeof window !== 'undefined' && typeof document !== 'undefined';
 

--- a/packages/web/src/utils/utils.ts
+++ b/packages/web/src/utils/utils.ts
@@ -136,8 +136,7 @@ declare global {
 export const onHotReload = (key: string, setup: () => Array<() => void>) => {
   if (!isBrowser()) return; // Skip if not in modern browser environment, but on each call as Vitest might have unloaded jsdom between tests
   if (!window[HOT_RELOAD_KEY]) window[HOT_RELOAD_KEY] = new Map(); // Hot reload cleanup support supporting all build tools
-
-  window[HOT_RELOAD_KEY]?.get(key)?.map((cleanup: () => void) => cleanup()); // Run previous cleanup
+  for (const cleanup of window[HOT_RELOAD_KEY]?.get(key) || []) cleanup(); // Run previous cleanup
   window[HOT_RELOAD_KEY]?.set(key, setup()); // Store new cleanup
 };
 

--- a/packages/web/src/utils/utils.ts
+++ b/packages/web/src/utils/utils.ts
@@ -1,5 +1,8 @@
 export const QUICK_EVENT = { passive: true, capture: true };
 
+// TODO EIRIK check built file of this
+import { version } from '../../package.json' with { type: 'json' };
+
 // Using function instead of constant to support evnironments where DOM can be unloaded (like Vitest with jsdom)
 export const isBrowser = () =>
   typeof window !== 'undefined' && typeof document !== 'undefined';
@@ -118,9 +121,10 @@ export const off = (
 };
 
 // Used to store cleanup functions for hot-reloading
+const HOT_RELOAD_KEY = `_dsHotReloadCleanup${version}` as const; // Ensure multiple versions of Designsystemet can run on same page
 declare global {
   interface Window {
-    _dsHotReloadCleanup?: Map<string, Array<() => void>>;
+    [HOT_RELOAD_KEY]?: Map<string, Array<() => void>>;
   }
 }
 
@@ -132,10 +136,10 @@ declare global {
  */
 export const onHotReload = (key: string, setup: () => Array<() => void>) => {
   if (!isBrowser()) return; // Skip if not in modern browser environment, but on each call as Vitest might have unloaded jsdom between tests
-  if (!window._dsHotReloadCleanup) window._dsHotReloadCleanup = new Map(); // Hot reload cleanup support supporting all build tools
+  if (!window[HOT_RELOAD_KEY]) window[HOT_RELOAD_KEY] = new Map(); // Hot reload cleanup support supporting all build tools
 
-  window._dsHotReloadCleanup?.get(key)?.map((cleanup) => cleanup()); // Run previous cleanup
-  window._dsHotReloadCleanup?.set(key, setup()); // Store new cleanup
+  window[HOT_RELOAD_KEY]?.get(key)?.map((cleanup: () => void) => cleanup()); // Run previous cleanup
+  window[HOT_RELOAD_KEY]?.set(key, setup()); // Store new cleanup
 };
 
 /**

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -6,6 +6,6 @@
     "outDir": "dist/esm",
     "composite": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "package.json"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
- Field previously shared element cache between event listener and custom element.
- Since custom elements can mount once, while event listeners can mount several times (when loaded multiple times), we need to ensure element caching in field stays scoped to the field.
- Also, this PR makes `onHotReload` cache events on a variable with package version as part of variable name to ensure we can load multiple versions of Designsystemet on the same page.
- I have verified that Vite compiles down `with { type: 'json' }` to ensure backwards compatibility
- Resolves #5075