### PR TITLE
fix(web): support aria-labelledby

### DIFF
--- a/.changeset/cute-olives-leave.md
+++ b/.changeset/cute-olives-leave.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-web": patch
+---
+
+**Breadcrumbs, Pagination, ToggleGroup:** support `aria-labelledby`

--- a/.changeset/silent-taxis-make.md
+++ b/.changeset/silent-taxis-make.md
@@ -1,0 +1,6 @@
+---
+"@digdir/designsystemet-web": patch
+---
+
+**Tooltip:** allow `data-tooltip` with CSS ID selector like `#id` to retrieve text from another element
+**Breadcrumbs, Pagination, ToggleGroup:** support `aria-labelledby`

--- a/.changeset/silent-taxis-make.md
+++ b/.changeset/silent-taxis-make.md
@@ -3,4 +3,3 @@
 ---
 
 **Tooltip:** allow `data-tooltip` with CSS ID selector like `#id` to retrieve text from another element
-**Breadcrumbs, Pagination, ToggleGroup:** support `aria-labelledby`

--- a/apps/www/app/content/components/tooltip/en/code.mdx
+++ b/apps/www/app/content/components/tooltip/en/code.mdx
@@ -25,8 +25,8 @@ setTooltipElement(myTooltip);
 You can use the `data-tooltip` attribute with a CSS ID selector to point to another element that contains tooltip text.
 
 ```html
-<button data-tooltip="#tooltip-content" class="ds-button">venstre</button>
-<div id="tooltip-content" class="ds-sr-only">Dette er innholdet i tooltipen.</div>
+<button data-tooltip="#tooltip-content" class="ds-button">Button</button>
+<div id="tooltip-content" class="ds-sr-only">This is the tooltip content.</div>
 ```
 
 ## CSS variables and data attributes

--- a/apps/www/app/content/components/tooltip/en/code.mdx
+++ b/apps/www/app/content/components/tooltip/en/code.mdx
@@ -21,6 +21,14 @@ myTooltip.className = 'ds-tooltip my-custom-tooltip';
 setTooltipElement(myTooltip);
 ```
 
+## Text from another HTML element
+You can use the `data-tooltip` attribute with a CSS ID selector to point to another element that contains tooltip text.
+
+```html
+<button data-tooltip="#tooltip-content" class="ds-button">venstre</button>
+<div id="tooltip-content" class="ds-sr-only">Dette er innholdet i tooltipen.</div>
+```
+
 ## CSS variables and data attributes
 Sizes are controlled with [data-size](/en/fundamentals/code/sizes) and colors with [data-color](/en/fundamentals/code/colors). 
 The component will inherit from the nearest parent with these set.

--- a/apps/www/app/content/components/tooltip/no/code.mdx
+++ b/apps/www/app/content/components/tooltip/no/code.mdx
@@ -21,11 +21,11 @@ myTooltip.className = 'ds-tooltip my-custom-tooltip';
 setTooltipElement(myTooltip);
 ```
 
-## Tekst fra et annet HTML element
-Du kan bruke `data-tooltip`-attributtet med en CSS ID selector, for å peke til et annet elementet som inneholder tooltip tekst.
+## Tekst fra et annet HTML-element
+Du kan bruke `data-tooltip`-attributtet med en CSS-ID-selector, for å peke til et annet element som inneholder tooltip-tekst.
 
 ```html
-<button data-tooltip="#tooltip-content" class="ds-button">venstre</button>
+<button data-tooltip="#tooltip-content" class="ds-button">Knapp</button>
 <div id="tooltip-content" class="ds-sr-only">Dette er innholdet i tooltipen.</div>
 ```
 

--- a/apps/www/app/content/components/tooltip/no/code.mdx
+++ b/apps/www/app/content/components/tooltip/no/code.mdx
@@ -21,6 +21,14 @@ myTooltip.className = 'ds-tooltip my-custom-tooltip';
 setTooltipElement(myTooltip);
 ```
 
+## Tekst fra et annet HTML element
+Du kan bruke `data-tooltip`-attributtet med en CSS ID selector, for å peke til et annet elementet som inneholder tooltip tekst.
+
+```html
+<button data-tooltip="#tooltip-content" class="ds-button">venstre</button>
+<div id="tooltip-content" class="ds-sr-only">Dette er innholdet i tooltipen.</div>
+```
+
 ## CSS variablar og data-attributter
 Størrelser styres med [data-size](/no/fundamentals/code/sizes) og farger med[data-color](/no/fundamentals/code/colors). 
 Komponenten vil arve nærmeste forelder med disse satt.

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -398,11 +398,10 @@
       </button>
       <button
         class="ds-button"
-        data-tooltip
-        aria-labelledby="hei-labelledby"
+        data-tooltip="#hei-labelledby"
         data-color="danger"
       >
-        aria-labelledby
+        ID tooltip
       </button>
       <span class="ds-sr-only" id="hei-labelledby">Hei</span>
     </div>

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -396,6 +396,15 @@
       <button class="ds-button" data-tooltip="eg forklarer" data-color="danger">
         forklar meg
       </button>
+      <button
+        class="ds-button"
+        data-tooltip
+        aria-labelledby="hei-labelledby"
+        data-color="danger"
+      >
+        aria-labelledby
+      </button>
+      <span class="ds-sr-only" id="hei-labelledby">Hei</span>
     </div>
     <p>
       Eg ligger i tekst, men trenger ein

--- a/packages/web/src/breadcrumbs/breadcrumbs.ts
+++ b/packages/web/src/breadcrumbs/breadcrumbs.ts
@@ -37,7 +37,7 @@ export class DSBreadcrumbsElement extends DSElement {
   }
   attributeChangedCallback() {
     const label = getLabel(this); // Update cacheed label if aria-label attribute changes;
-    if (!this._unmutate || !label) return; // Ensure we do not run unless connected
+    if (!this._unmutate || !label) return; // Ensure we do not run unless connected, and keep cached label if aria-label/aria-labelledby is removed
     this._label = label;
     render(this);
   }
@@ -61,8 +61,8 @@ const render = (self: DSBreadcrumbsElement) => {
 };
 
 const getLabel = (el: Element): string | null =>
-  el.ariaLabelledByElements?.map((el) => el.textContent.trim()).join('') ??
-  attrOrCSS(el, ARIA_LABEL) ??
+  el.ariaLabelledByElements?.map((el) => el.textContent.trim()).join(' ') ||
+  attrOrCSS(el, ARIA_LABEL) ||
   null;
 
 customElements.define('ds-breadcrumbs', DSBreadcrumbsElement);

--- a/packages/web/src/breadcrumbs/breadcrumbs.ts
+++ b/packages/web/src/breadcrumbs/breadcrumbs.ts
@@ -1,7 +1,6 @@
 import {
   ARIA_LABEL,
   ARIA_LABELLEDBY,
-  ariaLabelledByText,
   attr,
   attrOrCSS,
   customElements,
@@ -28,7 +27,7 @@ export class DSBreadcrumbsElement extends DSElement {
   }
   connectedCallback() {
     const resize = debounce(() => render(this), 100);
-    this._label = attrOrCSS(this, ARIA_LABEL) || ariaLabelledByText(this); // Label can have been set by attributeChangedCallback before connectedCallback
+    this._label = getLabel(this); // Label can have been set by attributeChangedCallback before connectedCallback
     this._items = this.getElementsByTagName('a'); // Speed up by caching HTMLCollection
     this._unresize = on(window, 'resize', resize);
     this._unmutate = onMutation(this, render, {
@@ -37,7 +36,7 @@ export class DSBreadcrumbsElement extends DSElement {
     });
   }
   attributeChangedCallback() {
-    const label = attr(this, ARIA_LABEL) || ariaLabelledByText(this); // Update cacheed label if aria-label attribute changes;
+    const label = getLabel(this); // Update cacheed label if aria-label attribute changes;
     if (!this._unmutate || !label) return; // Ensure we do not run unless connected
     this._label = label;
     render(this);
@@ -60,5 +59,10 @@ const render = (self: DSBreadcrumbsElement) => {
   for (const item of self._items || [])
     attr(item, 'aria-current', item === lastItemInList ? 'page' : null);
 };
+
+const getLabel = (el: Element): string | null =>
+  el.ariaLabelledByElements?.map((el) => el.textContent.trim()).join('') ??
+  attrOrCSS(el, ARIA_LABEL) ??
+  null;
 
 customElements.define('ds-breadcrumbs', DSBreadcrumbsElement);

--- a/packages/web/src/breadcrumbs/breadcrumbs.ts
+++ b/packages/web/src/breadcrumbs/breadcrumbs.ts
@@ -61,7 +61,7 @@ const render = (self: DSBreadcrumbsElement) => {
 };
 
 const getLabel = (el: Element): string | null =>
-  el.ariaLabelledByElements?.map((el) => el.textContent.trim()).join(' ') ||
+  el.ariaLabelledByElements?.map((el) => el.textContent?.trim() || '').join(' ') ||
   attrOrCSS(el, ARIA_LABEL) ||
   null;
 

--- a/packages/web/src/breadcrumbs/breadcrumbs.ts
+++ b/packages/web/src/breadcrumbs/breadcrumbs.ts
@@ -1,4 +1,7 @@
 import {
+  ARIA_LABEL,
+  ARIA_LABELLEDBY,
+  ariaLabelledByText,
   attr,
   attrOrCSS,
   customElements,
@@ -14,8 +17,6 @@ declare global {
   }
 }
 
-const ATTR_LABEL = 'aria-label';
-
 export class DSBreadcrumbsElement extends DSElement {
   _items?: HTMLCollectionOf<HTMLAnchorElement>; // Using underscore instead of private fields for backwards compatibility
   _label: string | null = null;
@@ -23,11 +24,11 @@ export class DSBreadcrumbsElement extends DSElement {
   _unmutate?: () => void;
 
   static get observedAttributes() {
-    return [ATTR_LABEL]; // Using ES2015 syntax for backwards compatibility
+    return [ARIA_LABEL, ARIA_LABELLEDBY]; // Using ES2015 syntax for backwards compatibility
   }
   connectedCallback() {
     const resize = debounce(() => render(this), 100);
-    this._label = attrOrCSS(this, ATTR_LABEL); // Label can have been set by attributeChangedCallback before connectedCallback
+    this._label = attrOrCSS(this, ARIA_LABEL) || ariaLabelledByText(this); // Label can have been set by attributeChangedCallback before connectedCallback
     this._items = this.getElementsByTagName('a'); // Speed up by caching HTMLCollection
     this._unresize = on(window, 'resize', resize);
     this._unmutate = onMutation(this, render, {
@@ -35,9 +36,10 @@ export class DSBreadcrumbsElement extends DSElement {
       subtree: true,
     });
   }
-  attributeChangedCallback(_name: string, _prev?: string, next?: string) {
-    if (!this._unmutate || !next) return; // Ensure we do not run unless connected and we have a label to set
-    this._label = next; // Update cacheed label if aria-label attribute changes
+  attributeChangedCallback() {
+    const label = attr(this, ARIA_LABEL) || ariaLabelledByText(this); // Update cacheed label if aria-label attribute changes;
+    if (!this._unmutate || !label) return; // Ensure we do not run unless connected
+    this._label = label;
     render(this);
   }
   disconnectedCallback() {
@@ -53,7 +55,7 @@ const render = (self: DSBreadcrumbsElement) => {
   const isListHidden = !lastItemInList?.offsetHeight;
 
   attr(self, 'role', isListHidden ? null : 'navigation');
-  attr(self, ATTR_LABEL, isListHidden ? null : self._label); // Remove aria-label if list is hidden to prevent screen readers from announcing as breadcrumbs
+  attr(self, ARIA_LABEL, isListHidden ? null : self._label); // Remove aria-label if list is hidden to prevent screen readers from announcing as breadcrumbs
 
   for (const item of self._items || [])
     attr(item, 'aria-current', item === lastItemInList ? 'page' : null);

--- a/packages/web/src/breadcrumbs/breadcrumbs.ts
+++ b/packages/web/src/breadcrumbs/breadcrumbs.ts
@@ -61,7 +61,10 @@ const render = (self: DSBreadcrumbsElement) => {
 };
 
 const getLabel = (el: Element): string | null =>
-  el.ariaLabelledByElements?.map((el) => el.textContent?.trim() || '').join(' ') ||
+  el.ariaLabelledByElements
+    ?.map((el) => el.textContent?.trim() || '')
+    .filter(Boolean)
+    .join(' ') ||
   attrOrCSS(el, ARIA_LABEL) ||
   null;
 

--- a/packages/web/src/error-summary/error-summary.ts
+++ b/packages/web/src/error-summary/error-summary.ts
@@ -1,4 +1,6 @@
 import {
+  ARIA_LABEL,
+  ARIA_LABELLEDBY,
   attr,
   customElements,
   DSElement,
@@ -40,17 +42,17 @@ export class DSErrorSummaryElement extends DSElement {
 }
 
 const render = (self: DSErrorSummaryElement) => {
-  const label = attr(self, 'aria-label')?.trim();
-  const labelledBy = attr(self, 'aria-labelledby')?.trim();
+  const label = attr(self, ARIA_LABEL)?.trim();
+  const labelledBy = attr(self, ARIA_LABELLEDBY)?.trim();
   const heading = self.querySelector('h2,h3,h4,h5,h6');
   if (heading && !label && !labelledBy) {
-    attr(self, 'aria-labelledby', useId(heading));
+    attr(self, ARIA_LABELLEDBY, useId(heading));
   }
   if (!heading && !label && !labelledBy) {
     warn(
       'Missing accessible name on:',
       self,
-      '\nAdd a heading (h2–h6), or set aria-label or aria-labelledby to provide an accessible name for screen readers.',
+      `\nAdd a heading (h2–h6), or set ${ARIA_LABEL} or ${ARIA_LABELLEDBY} to provide an accessible name for screen readers.`,
     );
   }
 };

--- a/packages/web/src/field/field.ts
+++ b/packages/web/src/field/field.ts
@@ -146,11 +146,11 @@ export class DSFieldElement extends DSElement {
       const limit = Number(attr(_counter, 'data-limit')) || 0;
       const count = limit - _input.value.length;
       const state = count < 0 ? 'over' : 'under';
-      const label = (attrOrCSS(_counter, `data-${state}`) || TEXTS[state]) // Browser translation tools will not pick up dyanmic text anyway, so no need to use aria-labelledby here
+      const label = (attrOrCSS(_counter, `data-${state}`) || TEXTS[state]) // Browser translation tools will not pick up dynamic text anyway, so no need to use aria-labelledby here
         ?.replace('%d', `${Math.abs(count)}`);
 
       if (!label) warn(`Missing data-${state} on:`, this);
-      attr(_counter, 'data-label', label); // Using attribute to prevent hydation errors, not using aria-label to make axe tests happy
+      attr(_counter, 'data-label', label); // Using attribute to prevent hydration errors, not using aria-label to make axe tests happy
       attr(_counter, 'data-state', state);
       attr(_counter, 'data-color', count < 0 ? 'danger' : null);
 

--- a/packages/web/src/field/field.ts
+++ b/packages/web/src/field/field.ts
@@ -146,10 +146,10 @@ export class DSFieldElement extends DSElement {
       const limit = Number(attr(_counter, 'data-limit')) || 0;
       const count = limit - _input.value.length;
       const state = count < 0 ? 'over' : 'under';
-      const label = (
-        attrOrCSS(_counter, `data-${state}`) || TEXTS[state]
-      )?.replace('%d', `${Math.abs(count)}`);
+      const label = (attrOrCSS(_counter, `data-${state}`) || TEXTS[state]) // Browser translation tools will not pick up dyanmic text anyway, so no need to use aria-labelledby here
+        ?.replace('%d', `${Math.abs(count)}`);
 
+      if (!label) warn(`Missing data-${state} on:`, this);
       attr(_counter, 'data-label', label); // Using attribute to prevent hydation errors, not using aria-label to make axe tests happy
       attr(_counter, 'data-state', state);
       attr(_counter, 'data-color', count < 0 ? 'danger' : null);

--- a/packages/web/src/field/field.ts
+++ b/packages/web/src/field/field.ts
@@ -149,7 +149,7 @@ export class DSFieldElement extends DSElement {
       const label = (attrOrCSS(_counter, `data-${state}`) || TEXTS[state]) // Browser translation tools will not pick up dynamic text anyway, so no need to use aria-labelledby here
         ?.replace('%d', `${Math.abs(count)}`);
 
-      if (!label) warn(`Missing data-${state} on:`, this);
+      if (!label) warn(`Missing data-${state} on:`, _counter);
       attr(_counter, 'data-label', label); // Using attribute to prevent hydration errors, not using aria-label to make axe tests happy
       attr(_counter, 'data-state', state);
       attr(_counter, 'data-color', count < 0 ? 'danger' : null);

--- a/packages/web/src/fieldset/fieldset.ts
+++ b/packages/web/src/fieldset/fieldset.ts
@@ -1,4 +1,5 @@
 import {
+  ARIA_LABELLEDBY,
   attr,
   isBrowser,
   onHotReload,
@@ -18,9 +19,9 @@ const FIELDSETS = isBrowser() ? document.getElementsByTagName('fieldset') : [];
 // This approach is also verified by the chief of accessibility at NRK and the accessibility expert at NAV
 const handleFieldsetMutations = () => {
   for (const el of FIELDSETS) {
-    if (el.hasAttribute('aria-labelledby')) continue; // Speed up by skipping labelled fieldsets
+    if (el.hasAttribute(ARIA_LABELLEDBY)) continue; // Speed up by skipping labelled fieldsets
     const labelledby = `${useId(el.querySelector('legend'))} ${useId(el.querySelector(':scope > :is([data-field="description"],legend + p)'))}`;
-    attr(el, 'aria-labelledby', labelledby.trim() || null);
+    attr(el, ARIA_LABELLEDBY, labelledby.trim() || null);
   }
 };
 

--- a/packages/web/src/pagination/pagination.ts
+++ b/packages/web/src/pagination/pagination.ts
@@ -45,7 +45,7 @@ export class DSPaginationElement extends DSElement {
     if (total && !current) warn(`Missing ${ATTR_CURRENT} attribute on:`, this);
 
     const label = attrOrCSS(this, ARIA_LABEL);
-    const labelledby = this.hasAttribute(ARIA_LABELLEDBY);
+    const labelledby = attr(this, ARIA_LABELLEDBY);
     if (label || labelledby) attr(this, ARIA_LABEL, labelledby ? null : label);
     else warn(`Missing ${ARIA_LABEL} on:`, this);
 

--- a/packages/web/src/pagination/pagination.ts
+++ b/packages/web/src/pagination/pagination.ts
@@ -1,4 +1,6 @@
 import {
+  ARIA_LABEL,
+  ARIA_LABELLEDBY,
   attr,
   attrOrCSS,
   customElements,
@@ -13,7 +15,6 @@ declare global {
   }
 }
 
-const ATTR_LABEL = 'aria-label';
 const ATTR_CURRENT = 'data-current';
 const ATTR_TOTAL = 'data-total';
 const ATTR_HREF = 'data-href';
@@ -34,7 +35,7 @@ export class DSPaginationElement extends DSElement {
   _render?: () => void;
 
   static get observedAttributes() {
-    return [ATTR_LABEL, ATTR_CURRENT, ATTR_TOTAL, ATTR_HREF]; // Using ES2015 syntax for backwards compatibility
+    return [ARIA_LABEL, ARIA_LABELLEDBY, ATTR_CURRENT, ATTR_TOTAL, ATTR_HREF]; // Using ES2015 syntax for backwards compatibility
   }
   connectedCallback() {
     // Check for required attributes
@@ -43,7 +44,11 @@ export class DSPaginationElement extends DSElement {
     if (current && !total) warn(`Missing ${ATTR_TOTAL} attribute on:`, this);
     if (total && !current) warn(`Missing ${ATTR_CURRENT} attribute on:`, this);
 
-    attr(this, ATTR_LABEL, attrOrCSS(this, ATTR_LABEL));
+    const label = attrOrCSS(this, ARIA_LABEL);
+    const labelledby = this.hasAttribute(ARIA_LABELLEDBY);
+    if (label || labelledby) attr(this, ARIA_LABEL, labelledby ? null : label);
+    else warn(`Missing ${ARIA_LABEL} on:`, this);
+
     attr(this, 'role', 'navigation');
     this._unmutate = onMutation(this, render, {
       childList: true,
@@ -72,7 +77,7 @@ const render = (self: DSPaginationElement) => {
     items.forEach((item, i) => {
       const page = i ? (items[i + 1] ? pages[i - 1]?.page : next) : prev; // First is prev, last is next
       attr(item, 'aria-current', pages[i - 1]?.current ? 'true' : null);
-      attr(item, 'aria-label', `${page ?? 'hidden'}`); // Used for CSS content and to hide if more items than pages, using aria-label to make Axe tests and VoiceOver rotor happy
+      attr(item, ARIA_LABEL, `${page ?? 'hidden'}`); // Used for CSS content and to hide if more items than pages, using aria-label to make Axe tests and VoiceOver rotor happy
       attr(item, 'role', page ? null : 'none'); // Prevent validation errors for aria-hidden buttons
       attr(item, 'tabindex', page ? null : '-1');
       if (item instanceof HTMLButtonElement) attr(item, 'value', `${page}`);

--- a/packages/web/src/pagination/pagination.ts
+++ b/packages/web/src/pagination/pagination.ts
@@ -45,7 +45,7 @@ export class DSPaginationElement extends DSElement {
     if (total && !current) warn(`Missing ${ATTR_CURRENT} attribute on:`, this);
 
     const label = attrOrCSS(this, ARIA_LABEL);
-    const labelledby = attr(this, ARIA_LABELLEDBY);
+    const labelledby = attr(this, ARIA_LABELLEDBY)?.trim();
     if (label || labelledby) attr(this, ARIA_LABEL, labelledby ? null : label);
     else warn(`Missing ${ARIA_LABEL} on:`, this);
 

--- a/packages/web/src/toggle-group/toggle-group.ts
+++ b/packages/web/src/toggle-group/toggle-group.ts
@@ -15,7 +15,7 @@ const SELECTOR_TOGGLEGROUP = `[${ATTR_TOGGLEGROUP}]`;
 const handleAriaAttributes = () => {
   for (const group of document.querySelectorAll(SELECTOR_TOGGLEGROUP)) {
     const label = attrOrCSS(group, ATTR_TOGGLEGROUP);
-    const labelledby = attr(group, ARIA_LABELLEDBY);
+    const labelledby = attr(group, ARIA_LABELLEDBY)?.trim();
     if (label || labelledby) attr(group, ARIA_LABEL, labelledby ? null : label);
     else warn(`Missing ${ARIA_LABEL} on:`, group);
   }

--- a/packages/web/src/toggle-group/toggle-group.ts
+++ b/packages/web/src/toggle-group/toggle-group.ts
@@ -15,7 +15,7 @@ const SELECTOR_TOGGLEGROUP = `[${ATTR_TOGGLEGROUP}]`;
 const handleAriaAttributes = () => {
   for (const group of document.querySelectorAll(SELECTOR_TOGGLEGROUP)) {
     const label = attrOrCSS(group, ATTR_TOGGLEGROUP);
-    const labelledby = group.hasAttribute(ARIA_LABELLEDBY);
+    const labelledby = attr(group, ARIA_LABELLEDBY);
     if (label || labelledby) attr(group, ARIA_LABEL, labelledby ? null : label);
     else warn(`Missing ${ARIA_LABEL} on:`, group);
   }

--- a/packages/web/src/toggle-group/toggle-group.ts
+++ b/packages/web/src/toggle-group/toggle-group.ts
@@ -1,13 +1,24 @@
-import { attr, attrOrCSS, on, onHotReload, onMutation } from '../utils/utils';
+import {
+  ARIA_LABEL,
+  ARIA_LABELLEDBY,
+  attr,
+  attrOrCSS,
+  on,
+  onHotReload,
+  onMutation,
+  warn,
+} from '../utils/utils';
 
-const ARIA_LABELLEDBY = 'aria-labelledby';
-const ARIA_LABEL = 'aria-label';
 const ATTR_TOGGLEGROUP = 'data-toggle-group';
 const SELECTOR_TOGGLEGROUP = `[${ATTR_TOGGLEGROUP}]`;
 
 const handleAriaAttributes = () => {
-  for (const group of document.querySelectorAll(SELECTOR_TOGGLEGROUP))
-    attr(group, 'aria-label', attrOrCSS(group, ATTR_TOGGLEGROUP));
+  for (const group of document.querySelectorAll(SELECTOR_TOGGLEGROUP)) {
+    const label = attrOrCSS(group, ATTR_TOGGLEGROUP);
+    const labelledby = group.hasAttribute(ARIA_LABELLEDBY);
+    if (label || labelledby) attr(group, ARIA_LABEL, labelledby ? null : label);
+    else warn(`Missing ${ARIA_LABEL} on:`, this);
+  }
 };
 
 const handleKeydown = (event: Partial<KeyboardEvent>) => {
@@ -16,8 +27,6 @@ const handleKeydown = (event: Partial<KeyboardEvent>) => {
     el instanceof HTMLInputElement && el.closest(SELECTOR_TOGGLEGROUP);
 
   if (!group) return;
-  if (!attr(group, ARIA_LABEL) && !attr(group, ARIA_LABELLEDBY))
-    attr(group, ARIA_LABEL, attrOrCSS(group, ATTR_TOGGLEGROUP));
   if (key === 'Enter') el.click(); // Forward Enter, but no need to listen for space key, as this is handled by the browser
   if (key?.startsWith('Arrow')) {
     event.preventDefault?.();

--- a/packages/web/src/toggle-group/toggle-group.ts
+++ b/packages/web/src/toggle-group/toggle-group.ts
@@ -17,7 +17,7 @@ const handleAriaAttributes = () => {
     const label = attrOrCSS(group, ATTR_TOGGLEGROUP);
     const labelledby = group.hasAttribute(ARIA_LABELLEDBY);
     if (label || labelledby) attr(group, ARIA_LABEL, labelledby ? null : label);
-    else warn(`Missing ${ARIA_LABEL} on:`, this);
+    else warn(`Missing ${ARIA_LABEL} on:`, group);
   }
 };
 

--- a/packages/web/src/tooltip/tooltip.ts
+++ b/packages/web/src/tooltip/tooltip.ts
@@ -53,9 +53,9 @@ const handleAriaAttributes = () => {
     // Allow using another element as source
     if (text?.[0] === '#')
       text =
-        getRoot(el).getElementById(text.slice(1))?.textContent.trim() || null;
+        getRoot(el).getElementById(text.slice(1))?.textContent?.trim() || null;
 
-    if (!text) return; // Early return if no tooltip text
+    if (!text) continue; // Early return if no tooltip text
     if (text !== (el.getAttribute(ARIA_LABEL) || el.getAttribute(ARIA_DESC))) {
       const hasText = attr(el, 'role') !== 'img' && el.textContent?.trim(); // If role="img", ignore text
       attr(el, ATTR_TOOLTIP, text); // Set data-tooltip attribute to speed up future mutations

--- a/packages/web/src/tooltip/tooltip.ts
+++ b/packages/web/src/tooltip/tooltip.ts
@@ -48,16 +48,18 @@ export const setTooltipElement = (el?: HTMLElement | null) => {
 
 const handleAriaAttributes = () => {
   for (const el of document.querySelectorAll(SELECTOR_TOOLTIP)) {
-    let text = attrOrCSS(el, ATTR_TOOLTIP);
+      let text = attrOrCSS(el, ATTR_TOOLTIP);
 
-    // Allow using another element as source
+    // Allow using another element as source.
+    // Note: Only checks on initial mutation, as we do not want to keep checking if the source element is removed or changed, 
+    // since this would be a performance issue. If the source element is removed, the tooltip will be empty and not shown.
     if (text?.[0] === '#')
       text =
-        getRoot(el).getElementById(text.slice(1))?.textContent?.trim() || null;
+        getRoot(el).getElementById(text.slice(1))?.textContent?.trim() || null;    if (!text) continue; // Early return if no tooltip text
 
-    if (!text) continue; // Early return if no tooltip text
     if (text !== (el.getAttribute(ARIA_LABEL) || el.getAttribute(ARIA_DESC))) {
       const hasText = attr(el, 'role') !== 'img' && el.textContent?.trim(); // If role="img", ignore text
+      attr(el, ATTR_TOOLTIP, text); // Set data-tooltip attribute to speed up future mutations
       attr(el, ARIA_LABEL, hasText ? null : text); // Set aria-label if element does not have text
       attr(el, ARIA_DESC, hasText ? text : null); // Set aria-description if element has text
       if (!el.matches(SELECTOR_INTERACTIVE))

--- a/packages/web/src/tooltip/tooltip.ts
+++ b/packages/web/src/tooltip/tooltip.ts
@@ -3,9 +3,9 @@ import {
   ARIA_DESC,
   ARIA_LABEL,
   announce,
-  ariaLabelledByText,
   attr,
   attrOrCSS,
+  getRoot,
   isBrowser,
   on,
   onHotReload,
@@ -48,7 +48,12 @@ export const setTooltipElement = (el?: HTMLElement | null) => {
 
 const handleAriaAttributes = () => {
   for (const el of document.querySelectorAll(SELECTOR_TOOLTIP)) {
-    const text = attrOrCSS(el, ATTR_TOOLTIP) || ariaLabelledByText(el); // Allow empty `data-tooltip` attribute, but finding text from aria-labelledby
+    let text = attrOrCSS(el, ATTR_TOOLTIP);
+
+    // Allow using another element as source
+    if (text?.[0] === '#')
+      text =
+        getRoot(el).getElementById(text.slice(1))?.textContent.trim() || null;
 
     if (!text) return; // Early return if no tooltip text
     if (text !== (el.getAttribute(ARIA_LABEL) || el.getAttribute(ARIA_DESC))) {

--- a/packages/web/src/tooltip/tooltip.ts
+++ b/packages/web/src/tooltip/tooltip.ts
@@ -48,15 +48,16 @@ export const setTooltipElement = (el?: HTMLElement | null) => {
 
 const handleAriaAttributes = () => {
   for (const el of document.querySelectorAll(SELECTOR_TOOLTIP)) {
-      let text = attrOrCSS(el, ATTR_TOOLTIP);
+    let text = attrOrCSS(el, ATTR_TOOLTIP);
 
     // Allow using another element as source.
-    // Note: Only checks on initial mutation, as we do not want to keep checking if the source element is removed or changed, 
+    // Note: Only checks on initial mutation, as we do not want to keep checking if the source element is removed or changed,
     // since this would be a performance issue. If the source element is removed, the tooltip will be empty and not shown.
     if (text?.[0] === '#')
       text =
-        getRoot(el).getElementById(text.slice(1))?.textContent?.trim() || null;    if (!text) continue; // Early return if no tooltip text
+        getRoot(el).getElementById(text.slice(1))?.textContent?.trim() || null;
 
+    if (!text) continue; // Early return if no tooltip text
     if (text !== (el.getAttribute(ARIA_LABEL) || el.getAttribute(ARIA_DESC))) {
       const hasText = attr(el, 'role') !== 'img' && el.textContent?.trim(); // If role="img", ignore text
       attr(el, ATTR_TOOLTIP, text); // Set data-tooltip attribute to speed up future mutations

--- a/packages/web/src/tooltip/tooltip.ts
+++ b/packages/web/src/tooltip/tooltip.ts
@@ -1,6 +1,9 @@
 import '../popover/popover'; // Ensure popover is imported when using individual imports, since tooltip relies on it
 import {
+  ARIA_DESC,
+  ARIA_LABEL,
   announce,
+  ariaLabelledByText,
   attr,
   attrOrCSS,
   isBrowser,
@@ -20,8 +23,6 @@ let SKIP_TIMER: number | ReturnType<typeof setTimeout> = 0;
 const IS_IOS = isBrowser() && /iPad|iPhone|iPod/.test(navigator.userAgent); // Needed to omit DELAY_HOVER since iOS triggers mouseover before click
 const ATTR_TOOLTIP = 'data-tooltip';
 const ATTR_COLOR = 'data-color';
-const ARIA_LABEL = 'aria-label';
-const ARIA_DESC = 'aria-description';
 const SELECTOR_COLOR = `[${ATTR_COLOR}]`;
 const SELECTOR_TOOLTIP = `[${ATTR_TOOLTIP}]`;
 const ATTR_SCHEME = 'data-color-scheme';
@@ -47,7 +48,7 @@ export const setTooltipElement = (el?: HTMLElement | null) => {
 
 const handleAriaAttributes = () => {
   for (const el of document.querySelectorAll(SELECTOR_TOOLTIP)) {
-    const text = attrOrCSS(el, ATTR_TOOLTIP);
+    const text = attrOrCSS(el, ATTR_TOOLTIP) || ariaLabelledByText(el); // Allow empty `data-tooltip` attribute, but finding text from aria-labelledby
 
     if (!text) return; // Early return if no tooltip text
     if (text !== (el.getAttribute(ARIA_LABEL) || el.getAttribute(ARIA_DESC))) {

--- a/packages/web/src/tooltip/tooltip.ts
+++ b/packages/web/src/tooltip/tooltip.ts
@@ -58,7 +58,6 @@ const handleAriaAttributes = () => {
     if (!text) continue; // Early return if no tooltip text
     if (text !== (el.getAttribute(ARIA_LABEL) || el.getAttribute(ARIA_DESC))) {
       const hasText = attr(el, 'role') !== 'img' && el.textContent?.trim(); // If role="img", ignore text
-      attr(el, ATTR_TOOLTIP, text); // Set data-tooltip attribute to speed up future mutations
       attr(el, ARIA_LABEL, hasText ? null : text); // Set aria-label if element does not have text
       attr(el, ARIA_DESC, hasText ? text : null); // Set aria-description if element has text
       if (!el.matches(SELECTOR_INTERACTIVE))

--- a/packages/web/src/utils/utils.ts
+++ b/packages/web/src/utils/utils.ts
@@ -1,3 +1,6 @@
+export const ARIA_DESC = 'aria-description';
+export const ARIA_LABEL = 'aria-label';
+export const ARIA_LABELLEDBY = 'aria-labelledby';
 export const QUICK_EVENT = { passive: true, capture: true };
 
 import { version } from '../../package.json' with { type: 'json' };
@@ -86,9 +89,18 @@ export const attrOrCSS = (el: Element, name: string) => {
   let value = attr(el, name);
   if (!value)
     value = getCSSProp(el, `--_ds-${name}`).replace(STRIP_QUOTES, '').trim();
-  if (!value) warn(`Missing ${name} on:`, el);
   return value || null;
 };
+
+/**
+ * ariaLabelledByText
+ * @description Retrieves the text content of element referenced by aria-labelledby on the given element
+ * @param el The Element to read aria-labelledby from
+ * @return string text content of element referenced by aria-labelledby, or null if not found
+ */
+export const ariaLabelledByText = (el: Element): string | null =>
+  el.ariaLabelledByElements?.map((el) => el.textContent.trim()).join('') ??
+  null;
 
 /**
  * on

--- a/packages/web/src/utils/utils.ts
+++ b/packages/web/src/utils/utils.ts
@@ -100,9 +100,8 @@ export const attrOrCSS = (el: Element, name: string) => {
  */
 export const getRoot = (node: Node): Document | ShadowRoot => {
   const root = node.getRootNode?.() || node.ownerDocument;
-  return root instanceof Document || root instanceof ShadowRoot
-    ? root
-    : document;
+  if (root instanceof Document || root instanceof ShadowRoot) return root;
+  return node.ownerDocument || document;
 };
 
 /**

--- a/packages/web/src/utils/utils.ts
+++ b/packages/web/src/utils/utils.ts
@@ -93,14 +93,17 @@ export const attrOrCSS = (el: Element, name: string) => {
 };
 
 /**
- * ariaLabelledByText
- * @description Retrieves the text content of element referenced by aria-labelledby on the given element
- * @param el The Element to read aria-labelledby from
- * @return string text content of element referenced by aria-labelledby, or null if not found
+ * getRoot
+ * @description Helper for better compatibility
+ * @param node The target node
+ * @return The root document fragment or shadow root
  */
-export const ariaLabelledByText = (el: Element): string | null =>
-  el.ariaLabelledByElements?.map((el) => el.textContent.trim()).join('') ??
-  null;
+export const getRoot = (node: Node): Document | ShadowRoot => {
+  const root = node.getRootNode?.() || node.ownerDocument;
+  return root instanceof Document || root instanceof ShadowRoot
+    ? root
+    : document;
+};
 
 /**
  * on

--- a/packages/web/src/utils/utils.ts
+++ b/packages/web/src/utils/utils.ts
@@ -96,7 +96,7 @@ export const attrOrCSS = (el: Element, name: string) => {
  * getRoot
  * @description Helper for better compatibility
  * @param node The target node
- * @return The root document fragment or shadow root
+ * @return The shadow root or document
  */
 export const getRoot = (node: Node): Document | ShadowRoot => {
   const root = node.getRootNode?.() || node.ownerDocument;


### PR DESCRIPTION
- Adds support for `aria-labelledby` as alternative to `aria-label` on multiple components
- Resolves #4878