### PR TITLE
chore: remove `remix-i18next` as dependency

### DIFF
--- a/apps/themebuilder/app/_hooks/use-change-language.ts
+++ b/apps/themebuilder/app/_hooks/use-change-language.ts
@@ -1,0 +1,9 @@
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export function useChangeLanguage(locale?: string) {
+  const { i18n } = useTranslation();
+  useEffect(() => {
+    if (locale && i18n.language !== locale) i18n.changeLanguage(locale);
+  }, [locale, i18n]);
+}

--- a/apps/themebuilder/app/entry.client.tsx
+++ b/apps/themebuilder/app/entry.client.tsx
@@ -3,7 +3,6 @@ import { StrictMode, startTransition } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
 import { HydratedRouter } from 'react-router/dom';
-import { getInitialNamespaces } from 'remix-i18next/client';
 import en from '~/locales/en';
 import no from '~/locales/no';
 import i18n from './i18n';
@@ -23,7 +22,6 @@ async function hydrate() {
         translation: no,
       },
     },
-    ns: getInitialNamespaces(),
     detection: {
       order: ['htmlTag'],
       caches: [],

--- a/apps/themebuilder/app/entry.server.tsx
+++ b/apps/themebuilder/app/entry.server.tsx
@@ -10,7 +10,6 @@ import { ServerRouter } from 'react-router';
 import en from '~/locales/en';
 import no from '~/locales/no';
 import i18n from './i18n';
-import i18next from './i18next.server';
 
 export const streamTimeout = 5_000;
 
@@ -21,7 +20,6 @@ export default async function handleRequest(
   routerContext: EntryContext,
 ) {
   const instance = createInstance();
-  const ns = i18next.getRouteNamespaces(routerContext);
 
   const url = new URL(request.url);
   const lng = url.pathname.startsWith('/no')
@@ -33,7 +31,6 @@ export default async function handleRequest(
   await instance.use(initReactI18next).init({
     ...i18n,
     lng,
-    ns,
     resources: {
       en: {
         translation: en,

--- a/apps/themebuilder/app/i18next.server.ts
+++ b/apps/themebuilder/app/i18next.server.ts
@@ -1,25 +1,25 @@
-import { RemixI18Next } from 'remix-i18next/server';
+import { createInstance } from 'i18next';
 import i18n from '~/i18n';
 import en from '~/locales/en';
 import no from '~/locales/no';
 
-const i18next = new RemixI18Next({
-  detection: {
-    supportedLanguages: i18n.supportedLngs,
-    fallbackLanguage: i18n.fallbackLng,
-  },
-  i18next: {
-    ...i18n,
-    resources: {
-      en: {
-        translation: en,
-      },
-      no: {
-        translation: no,
-      },
+const instance = createInstance({
+  ...i18n,
+  resources: {
+    en: {
+      translation: en,
+    },
+    no: {
+      translation: no,
     },
   },
-  plugins: [],
 });
 
-export default i18next;
+const ready = instance.init();
+
+export async function getFixedT(lang: string) {
+  await ready;
+  return instance.getFixedT(lang);
+}
+
+export default { getFixedT };

--- a/apps/themebuilder/app/root.tsx
+++ b/apps/themebuilder/app/root.tsx
@@ -14,7 +14,7 @@ import '@internal/digdir/themes/digdir.css';
 import '@digdir/designsystemet-css';
 import './app.css';
 import { useTranslation } from 'react-i18next';
-import { useChangeLanguage } from 'remix-i18next/react';
+import { useChangeLanguage } from '~/_hooks/use-change-language';
 
 export const links: Route.LinksFunction = () => {
   return [
@@ -146,6 +146,7 @@ function Document({ children }: DocumentProps) {
 
 export default function App({ loaderData: { lang } }: Route.ComponentProps) {
   useChangeLanguage(lang);
+
   return (
     <Document>
       <Outlet />

--- a/apps/themebuilder/package.json
+++ b/apps/themebuilder/package.json
@@ -29,8 +29,7 @@
     "react-color-palette": "7.3.1",
     "react-dom": "19.2.7",
     "react-i18next": "17.0.8",
-    "react-router": "8.1.0",
-    "remix-i18next": "7.5.0"
+    "react-router": "8.1.0"
   },
   "devDependencies": {
     "@react-router/dev": "8.1.0",

--- a/apps/www/app/_hooks/use-change-language.ts
+++ b/apps/www/app/_hooks/use-change-language.ts
@@ -1,0 +1,9 @@
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export function useChangeLanguage(locale?: string) {
+  const { i18n } = useTranslation();
+  useEffect(() => {
+    if (locale && i18n.language !== locale) i18n.changeLanguage(locale);
+  }, [locale, i18n]);
+}

--- a/apps/www/app/entry.client.tsx
+++ b/apps/www/app/entry.client.tsx
@@ -3,7 +3,6 @@ import { StrictMode, startTransition } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
 import { HydratedRouter } from 'react-router/dom';
-import { getInitialNamespaces } from 'remix-i18next/client';
 import en from '~/locales/en';
 import no from '~/locales/no';
 import i18n from './i18n';
@@ -23,7 +22,6 @@ async function hydrate() {
         translation: no,
       },
     },
-    ns: getInitialNamespaces(),
     detection: {
       caches: [],
     },

--- a/apps/www/app/entry.server.tsx
+++ b/apps/www/app/entry.server.tsx
@@ -10,7 +10,6 @@ import { ServerRouter } from 'react-router';
 import en from '~/locales/en';
 import no from '~/locales/no';
 import i18n from './i18n';
-import i18next from './i18next.server';
 
 export const streamTimeout = 5_000;
 
@@ -21,7 +20,6 @@ export default async function handleRequest(
   routerContext: EntryContext,
 ) {
   const instance = createInstance();
-  const ns = i18next.getRouteNamespaces(routerContext);
 
   const url = new URL(request.url);
 
@@ -34,7 +32,6 @@ export default async function handleRequest(
   await instance.use(initReactI18next).init({
     ...i18n,
     lng,
-    ns,
     resources: {
       en: {
         translation: en,

--- a/apps/www/app/i18next.server.ts
+++ b/apps/www/app/i18next.server.ts
@@ -1,25 +1,25 @@
-import { RemixI18Next } from 'remix-i18next/server';
+import { createInstance } from 'i18next';
 import i18n from './i18n';
 import en from './locales/en';
 import no from './locales/no';
 
-const i18next = new RemixI18Next({
-  detection: {
-    supportedLanguages: i18n.supportedLngs,
-    fallbackLanguage: i18n.fallbackLng,
-  },
-  i18next: {
-    ...i18n,
-    resources: {
-      en: {
-        translation: en,
-      },
-      no: {
-        translation: no,
-      },
+const instance = createInstance({
+  ...i18n,
+  resources: {
+    en: {
+      translation: en,
+    },
+    no: {
+      translation: no,
     },
   },
-  plugins: [],
 });
 
-export default i18next;
+const ready = instance.init();
+
+export async function getFixedT(lang: string) {
+  await ready;
+  return instance.getFixedT(lang);
+}
+
+export default { getFixedT };

--- a/apps/www/app/layouts/root/layout.tsx
+++ b/apps/www/app/layouts/root/layout.tsx
@@ -10,6 +10,7 @@ import { Figma } from '~/_components/logos/figma';
 import { Github } from '~/_components/logos/github';
 import { Slack } from '~/_components/logos/slack';
 import { SearchDialog } from '~/_components/search-dialog';
+import { useChangeLanguage } from '~/_hooks/use-change-language';
 import { useShowConsentBanner } from '~/_hooks/use-show-consent-banner';
 import i18n from '~/i18n';
 import type { Route as RootRoute } from './../../+types/root';
@@ -49,7 +50,7 @@ const rightLinks: FooterLinkListItemProps[] = [
 ];
 
 export default function RootLayout() {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const { lang, centerLinks, menu } = useRouteLoaderData('root') as Omit<
     RootRoute.ComponentProps['loaderData'],
     'centerLinks'
@@ -62,7 +63,7 @@ export default function RootLayout() {
   };
   const { showBanner } = useShowConsentBanner();
 
-  i18n.changeLanguage(lang);
+  useChangeLanguage(lang);
 
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const openSearch = useCallback(() => setIsSearchOpen(true), []);

--- a/apps/www/app/layouts/root/layout.tsx
+++ b/apps/www/app/layouts/root/layout.tsx
@@ -5,7 +5,6 @@ import { EnvelopeClosedIcon } from '@navikt/aksel-icons';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { isRouteErrorResponse, Outlet, useRouteLoaderData } from 'react-router';
-import { useChangeLanguage } from 'remix-i18next/react';
 import { ConsentBanner } from '~/_components/consent-banner/consent-banner';
 import { Figma } from '~/_components/logos/figma';
 import { Github } from '~/_components/logos/github';
@@ -50,7 +49,7 @@ const rightLinks: FooterLinkListItemProps[] = [
 ];
 
 export default function RootLayout() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { lang, centerLinks, menu } = useRouteLoaderData('root') as Omit<
     RootRoute.ComponentProps['loaderData'],
     'centerLinks'
@@ -63,7 +62,7 @@ export default function RootLayout() {
   };
   const { showBanner } = useShowConsentBanner();
 
-  useChangeLanguage(lang);
+  i18n.changeLanguage(lang);
 
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const openSearch = useCallback(() => setIsSearchOpen(true), []);

--- a/apps/www/app/root.tsx
+++ b/apps/www/app/root.tsx
@@ -14,8 +14,8 @@ import '@digdir/designsystemet-css';
 import './app.css';
 import { Error404 } from '@internal/components';
 import { useTranslation } from 'react-i18next';
-import { useChangeLanguage } from 'remix-i18next/react';
 import { SiteimproveScript } from './_components/siteimprove-script';
+import { useChangeLanguage } from './_hooks/use-change-language';
 import { designsystemetRedirects } from './_utils/redirects.server';
 
 export const links = () => {

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -41,8 +41,7 @@
     "react-router": "8.1.0",
     "rehype-autolink-headings": "7.1.0",
     "rehype-slug": "6.0.0",
-    "remark-gfm": "4.0.1",
-    "remix-i18next": "7.5.0"
+    "remark-gfm": "4.0.1"
   },
   "devDependencies": {
     "@react-router/dev": "8.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,9 +198,6 @@ importers:
       react-router:
         specifier: 8.1.0
         version: 8.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      remix-i18next:
-        specifier: 7.5.0
-        version: 7.5.0(i18next@26.3.4(typescript@5.9.3))(react-i18next@17.0.8(i18next@26.3.4(typescript@5.9.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3))(react-router@8.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@react-router/dev':
         specifier: 8.1.0
@@ -337,9 +334,6 @@ importers:
       remark-gfm:
         specifier: 4.0.1
         version: 4.0.1
-      remix-i18next:
-        specifier: 7.5.0
-        version: 7.5.0(i18next@26.3.4(typescript@5.9.3))(react-i18next@17.0.8(i18next@26.3.4(typescript@5.9.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3))(react-router@8.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@react-router/dev':
         specifier: 8.1.0
@@ -5298,15 +5292,6 @@ packages:
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
-  remix-i18next@7.5.0:
-    resolution: {integrity: sha512-7vAwnNkAXzr/YQwFkV1FHrY+3utgGrDwn7oP/aM2gFHrwbGT0+uVtuUx3USpTrJvhzAN+2YU/mnmgyBi9EhYyw==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      i18next: ^24.0.0 || ^25.0.0 || ^26.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-i18next: ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-      react-router: ^7.0.0
-
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -6878,6 +6863,7 @@ snapshots:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.17
       react: 19.2.7
+
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -8126,7 +8112,9 @@ snapshots:
       js-tokens: 10.0.0
 
   astring@1.9.0: {}
+
   attr-accept@2.2.5: {}
+
   autoprefixer@10.5.2(postcss@8.5.16):
     dependencies:
       browserslist: 4.28.4
@@ -10593,12 +10581,14 @@ snapshots:
     dependencies:
       react: 19.2.7
       scheduler: 0.27.0
+
   react-dropzone@15.0.0(react@19.2.7):
     dependencies:
       attr-accept: 2.2.5
       file-selector: 2.1.2
       prop-types: 15.8.1
       react: 19.2.7
+
   react-i18next@17.0.8(i18next@26.3.4(typescript@5.9.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3):
     dependencies:
       '@babel/runtime': 7.29.2
@@ -10783,13 +10773,6 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  remix-i18next@7.5.0(i18next@26.3.4(typescript@5.9.3))(react-i18next@17.0.8(i18next@26.3.4(typescript@5.9.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3))(react-router@8.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7):
-    dependencies:
-      i18next: 26.3.4(typescript@5.9.3)
-      react: 19.2.7
-      react-i18next: 17.0.8(i18next@26.3.4(typescript@5.9.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@5.9.3)
-      react-router: 8.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-
   require-directory@2.1.1: {}
 
   reserved-words@0.1.2: {}
@@ -10810,6 +10793,7 @@ snapshots:
     dependencies:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
+
   rolldown-plugin-dts@0.26.0(oxc-resolver@11.19.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))(rolldown@1.1.3)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 8.0.0


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

While updating this dependency I noticed we don't need it anymore. It does nothing for us, especially since our URLs own the language.
Upgrading is also hard, since it has removed lots of functions we were using.

To me it also seems like local dev is faster.
Translations still work fine.
Schemas still work fine: https://www-pr-5085.victoriousglacier-eb9399b9.norwayeast.azurecontainerapps.io/schemas/cli/1.18.0.json

## Checks

- [ ] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)
