### PR TITLE
docs: fix UUTilsynet links

### DIFF
--- a/apps/www/app/content/components/alert/en/accessibility.mdx
+++ b/apps/www/app/content/components/alert/en/accessibility.mdx
@@ -6,7 +6,7 @@ Use `role="alert"` for critical messages that require immediate attention.
 Use `role="status"` for less critical messages.
 
 <span data-size="sm"> 
-WCAG: [4.1.3 Status messages](https://www.uutilsynet.no/wcag-standarden/413-statusbeskjeder-niva-aa/152)
+WCAG: [4.1.3 Status messages](https://www.uutilsynet.no/veiledning/413-statusbeskjeder/1268)
 </span> 
 
 <Divider/>
@@ -16,7 +16,7 @@ WCAG: [4.1.3 Status messages](https://www.uutilsynet.no/wcag-standarden/413-stat
 This means the Alert must appear in the DOM in a way that provides a logical reading order for screen readers. If the Alert has a heading, the heading level must be correct in the page structure.
 
 <span data-size="sm"> 
-WCAG: [1.3.1 Info and relationships](https://www.uutilsynet.no/wcag-standarden/131-informasjon-og-relasjoner-niva/90)
+WCAG: [1.3.1 Info and relationships](https://www.uutilsynet.no/veiledning/131-informasjon-og-relasjoner/1234)
 </span> 
 
 <Divider/>

--- a/apps/www/app/content/components/alert/no/accessibility.mdx
+++ b/apps/www/app/content/components/alert/no/accessibility.mdx
@@ -6,7 +6,7 @@ Bruk `role="alert"` for kritiske meldinger som krever umiddelbar oppmerksomhet.
 Bruk `role="status"` for mindre kritiske meldinger.
 
 <span data-size="sm"> 
-WCAG: [4.1.3 Statusbeskjeder](https://www.uutilsynet.no/wcag-standarden/413-statusbeskjeder-niva-aa/152)
+WCAG: [4.1.3 Statusbeskjeder](https://www.uutilsynet.no/veiledning/413-statusbeskjeder/1268)
 </span> 
 
 <Divider/>
@@ -17,7 +17,7 @@ Dette betyr at alert skal ligge i DOM på en måte som gir en logisk leserekkef�
 Hvis alert har en overskrift, skal overskriftsnivået være korrekt i sidestrukturen.
 
 <span data-size="sm"> 
-WCAG: [1.3.1 Informasjon og relasjoner](https://www.uutilsynet.no/wcag-standarden/131-informasjon-og-relasjoner-niva/90)
+WCAG: [1.3.1 Informasjon og relasjoner](https://www.uutilsynet.no/veiledning/131-informasjon-og-relasjoner/1234)
 </span> 
 
 <Divider/>

--- a/apps/www/app/content/components/avatar/en/accessibility.mdx
+++ b/apps/www/app/content/components/avatar/en/accessibility.mdx
@@ -5,7 +5,7 @@
 The accessible name can be provided using `aria-label`. If multiple avatars are displayed together, each name must be unique.
 
 <span data-size="sm"> 
-WCAG: [1.3.1 Info and relationships](https://www.uutilsynet.no/wcag-standarden/131-informasjon-og-relasjoner-niva/90)
+WCAG: [1.3.1 Info and relationships](https://www.uutilsynet.no/veiledning/131-informasjon-og-relasjoner/1234)
 </span> 
 
 <Divider/>
@@ -16,7 +16,7 @@ This applies when the avatar is purely decorative and does not convey informatio
 
 
 <span data-size="sm"> 
-WCAG: [1.1.1 Non-text content](https://www.uutilsynet.no/wcag-standarden/111-ikke-tekstlig-innhold-niva/87)
+WCAG: [1.1.1 Non-text content](https://www.uutilsynet.no/veiledning/111-ikke-tekstlig-innhold/1231)
 </span> 
 
 <Divider/>
@@ -26,7 +26,7 @@ WCAG: [1.1.1 Non-text content](https://www.uutilsynet.no/wcag-standarden/111-ikk
 The accessible name can be provided using `aria-label`. Example: “Profile for Ola Nordmann”. Avoid: just initials or “Avatar”.
 
 <span data-size="sm"> 
-WCAG: [4.1.2 Name, role, value](https://www.uutilsynet.no/wcag-standarden/412-navn-rolle-verdi-niva/121)
+WCAG: [4.1.2 Name, role, value](https://www.uutilsynet.no/veiledning/412-navn-rolle-verdi/1267)
 </span> 
 
 

--- a/apps/www/app/content/components/avatar/no/accessibility.mdx
+++ b/apps/www/app/content/components/avatar/no/accessibility.mdx
@@ -5,7 +5,7 @@
 Tilgjengelig navn kan legges til med `aria-label`. Hvis flere avatarer vises sammen, skal hvert navn være unikt.
 
 <span data-size="sm"> 
-WCAG: [1.3.1 Informasjon og relasjoner](https://www.uutilsynet.no/wcag-standarden/131-informasjon-og-relasjoner-niva/90)
+WCAG: [1.3.1 Informasjon og relasjoner](https://www.uutilsynet.no/veiledning/131-informasjon-og-relasjoner/1234)
 </span> 
 
 <Divider/>
@@ -15,7 +15,7 @@ WCAG: [1.3.1 Informasjon og relasjoner](https://www.uutilsynet.no/wcag-standarde
 Dette gjelder når avatar kun er dekorativ og ikke formidler informasjon. Eksempel: Hvis en avatar vises i en knapp med teksten “Ola Nordmann”, kan avataren skjules med `aria-hidden` fordi navnet allerede identifiserer personen.
 
 <span data-size="sm"> 
-WCAG: [1.1.1 Ikke-tekstlig innhold](https://www.uutilsynet.no/wcag-standarden/111-ikke-tekstlig-innhold-niva/87)
+WCAG: [1.1.1 Ikke-tekstlig innhold](https://www.uutilsynet.no/veiledning/111-ikke-tekstlig-innhold/1231)
 </span> 
 
 <Divider/>
@@ -25,7 +25,7 @@ WCAG: [1.1.1 Ikke-tekstlig innhold](https://www.uutilsynet.no/wcag-standarden/11
 Tilgjengelig navn kan legges til med `aria-label`. Eksempel: “Profil for Ola Nordmann”. Unngå: kun initialer eller “Avatar”.
 
 <span data-size="sm"> 
-WCAG: [4.1.2 Navn, rolle, verdi](https://www.uutilsynet.no/wcag-standarden/412-navn-rolle-verdi-niva/121)
+WCAG: [4.1.2 Navn, rolle, verdi](https://www.uutilsynet.no/veiledning/412-navn-rolle-verdi/1267)
 </span> 
 
 

--- a/apps/www/app/content/components/badge/en/accessibility.mdx
+++ b/apps/www/app/content/components/badge/en/accessibility.mdx
@@ -5,7 +5,7 @@
 If badge is placed inline (inside the element), the content becomes part of the accessible name. Example: `<button>` with the text "Inbox" and a badge with "2" will be announced as "Inbox 2".
 
 <span data-size="sm"> 
-WCAG: [1.3.1 Info and relationships](https://www.uutilsynet.no/wcag-standarden/131-informasjon-og-relasjoner-niva/90)
+WCAG: [1.3.1 Info and relationships](https://www.uutilsynet.no/veiledning/131-informasjon-og-relasjoner/1234)
 </span> 
 
 <Divider/>
@@ -15,7 +15,7 @@ WCAG: [1.3.1 Info and relationships](https://www.uutilsynet.no/wcag-standarden/1
 This often applies when a badge is shown in the corner of a button or icon. In such cases, the badge value must be added manually to the element’s accessible name (for example via `aria-label`).
 
 <span data-size="sm"> 
-WCAG: [1.3.1 Info and relationships](https://www.uutilsynet.no/wcag-standarden/131-informasjon-og-relasjoner-niva/90)
+WCAG: [1.3.1 Info and relationships](https://www.uutilsynet.no/veiledning/131-informasjon-og-relasjoner/1234)
 </span> 
 
 <Divider/>
@@ -23,6 +23,6 @@ WCAG: [1.3.1 Info and relationships](https://www.uutilsynet.no/wcag-standarden/1
 **Badge that changes value (for example 1 → 2) must be announced to screen readers**
 
 <span data-size="sm"> 
-WCAG: [4.1.3 Status messages](https://www.uutilsynet.no/wcag-standarden/413-statusbeskjeder-niva-aa/152)
+WCAG: [4.1.3 Status messages](https://www.uutilsynet.no/veiledning/413-statusbeskjeder/1268)
 </span> 
 

--- a/apps/www/app/content/components/badge/no/accessibility.mdx
+++ b/apps/www/app/content/components/badge/no/accessibility.mdx
@@ -5,7 +5,7 @@
 Hvis badge plasseres inline (inni elementet), blir innholdet en del av det tilgjengelige navnet. Eksempel: `<button>` med teksten "Innboks" og badge med "2" leses opp som "Innboks 2".
 
 <span data-size="sm"> 
-WCAG: [1.3.1 informasjon og relasjoner](https://www.uutilsynet.no/wcag-standarden/131-informasjon-og-relasjoner-niva/90)
+WCAG: [1.3.1 informasjon og relasjoner](https://www.uutilsynet.no/veiledning/131-informasjon-og-relasjoner/1234)
 </span> 
 
 <Divider/>
@@ -15,7 +15,7 @@ WCAG: [1.3.1 informasjon og relasjoner](https://www.uutilsynet.no/wcag-standarde
 Dette gjelder ofte når badge vises i hjørnet av en knapp eller ikon. I slike tilfeller skal badge-verdien legges til manuelt i elementets tilgjengelige navn (for eksempel via `aria-label`).
 
 <span data-size="sm"> 
-WCAG: [1.3.1 informasjon og relasjoner](https://www.uutilsynet.no/wcag-standarden/131-informasjon-og-relasjoner-niva/90)
+WCAG: [1.3.1 informasjon og relasjoner](https://www.uutilsynet.no/veiledning/131-informasjon-og-relasjoner/1234)
 </span> 
 
 <Divider/>
@@ -23,6 +23,6 @@ WCAG: [1.3.1 informasjon og relasjoner](https://www.uutilsynet.no/wcag-standarde
 **Badge som endrer verdi (for eksempel 1 → 2) skal annonseres til skjermlesere**
 
 <span data-size="sm"> 
-WCAG: [4.1.3 Statusbeskjeder](https://www.uutilsynet.no/wcag-standarden/413-statusbeskjeder-niva-aa/152)
+WCAG: [4.1.3 Statusbeskjeder](https://www.uutilsynet.no/veiledning/413-statusbeskjeder/1268)
 </span> 
 

--- a/apps/www/app/content/components/breadcrumbs/en/accessibility.mdx
+++ b/apps/www/app/content/components/breadcrumbs/en/accessibility.mdx
@@ -8,7 +8,7 @@ If the trail becomes too long, it should be replaced with a back link.
 See the [Breadcrumbs documentation](/en/components/docs/breadcrumbs/code) for the recommended solution.
 
 <span data-size="sm"> 
-WCAG: [1.4.10 Reflow](https://www.uutilsynet.no/wcag-standarden/1410-dynamisk-tilpasning-reflow-niva-aa/144)
+WCAG: [1.4.10 Reflow](https://www.uutilsynet.no/veiledning/1410-dynamisk-tilpasning-reflow/1240)
 </span>
 
 
@@ -33,7 +33,7 @@ Example: “Tax for businesses”
 Not just: “Page 2” or “Info”
 
 <span data-size="sm"> 
-WCAG: [2.4.4 Link purpose (in context)](https://www.uutilsynet.no/wcag-standarden/244-formal-med-lenke-i-kontekst-niva/106)
+WCAG: [2.4.4 Link purpose (in context)](https://www.uutilsynet.no/veiledning/244-formal-med-lenke-i-kontekst/1251)
 </span>
 
 

--- a/apps/www/app/content/components/breadcrumbs/no/accessibility.mdx
+++ b/apps/www/app/content/components/breadcrumbs/no/accessibility.mdx
@@ -7,7 +7,7 @@ Test at brødsmulestien ikke går utenfor synlig område ved smal viewport eller
 Se [dokumentasjon for Breadcrumbs](/no/components/docs/breadcrumbs/code) for anbefalt løsning.
 
 <span data-size="sm"> 
-WCAG: [1.4.10 Dynamisk tilpasning (Reflow)](https://www.uutilsynet.no/wcag-standarden/1410-dynamisk-tilpasning-reflow-niva-aa/144)
+WCAG: [1.4.10 Dynamisk tilpasning (Reflow)](https://www.uutilsynet.no/veiledning/1410-dynamisk-tilpasning-reflow/1240)
 </span>
 
 <Divider/>
@@ -32,7 +32,7 @@ Ikke bare: “Side 2” eller “Info”
 
 <span data-size="sm"> 
 
-WCAG: [2.4.4 Formål med lenke (i kontekst)](https://www.uutilsynet.no/wcag-standarden/244-formal-med-lenke-i-kontekst-niva/106)
+WCAG: [2.4.4 Formål med lenke (i kontekst)](https://www.uutilsynet.no/veiledning/244-formal-med-lenke-i-kontekst/1251)
 
 </span>
 

--- a/apps/www/app/content/components/button/en/accessibility.mdx
+++ b/apps/www/app/content/components/button/en/accessibility.mdx
@@ -6,7 +6,7 @@ Avoid vague text such as “Click here”.
 
 <span data-size="sm"> 
 
-WCAG: [2.4.4 Link purpose (in context)](https://www.uutilsynet.no/wcag-standarden/244-formal-med-lenke-i-kontekst-niva/106)
+WCAG: [2.4.4 Link purpose (in context)](https://www.uutilsynet.no/veiledning/244-formal-med-lenke-i-kontekst/1251)
 
 </span>
 
@@ -19,7 +19,7 @@ If you use `aria-label` or other techniques that override the accessible name, i
 
 <span data-size="sm"> 
 
-WCAG: [2.5.3 Label in Name](https://www.uutilsynet.no/wcag-standarden/253-ledetekst-i-navn-niva/150)
+WCAG: [2.5.3 Label in Name](https://www.uutilsynet.no/veiledning/253-ledetekst-i-navn/1256)
 
 </span>
 
@@ -30,7 +30,7 @@ WCAG: [2.5.3 Label in Name](https://www.uutilsynet.no/wcag-standarden/253-ledete
 The icon should not be announced if the text already describes the action.
 
 <span data-size="sm"> 
-WCAG: [1.1.1 Non-text content](https://www.uutilsynet.no/wcag-standarden/111-ikke-tekstlig-innhold-niva/87)
+WCAG: [1.1.1 Non-text content](https://www.uutilsynet.no/veiledning/111-ikke-tekstlig-innhold/1231)
 </span>
 
 
@@ -41,7 +41,7 @@ WCAG: [1.1.1 Non-text content](https://www.uutilsynet.no/wcag-standarden/111-ikk
 This applies when the button consists only of an icon.
 
 <span data-size="sm"> 
-WCAG: [4.1.2 Name, role, value](https://www.uutilsynet.no/wcag-standarden/412-navn-rolle-verdi-niva/121)
+WCAG: [4.1.2 Name, role, value](https://www.uutilsynet.no/veiledning/412-navn-rolle-verdi/1267)
 </span>
 
 
@@ -54,7 +54,7 @@ If the button shows a loading indicator, remember to add `aria-busy="true"` to i
 In addition, you must consider how status is communicated, for example by updating the text.
 
 <span data-size="sm"> 
-WCAG: [4.1.3 Status messages](https://www.uutilsynet.no/wcag-standarden/413-statusbeskjeder-niva-aa/152)
+WCAG: [4.1.3 Status messages](https://www.uutilsynet.no/veiledning/413-statusbeskjeder/1268)
 </span>
 
 <Divider/>

--- a/apps/www/app/content/components/button/no/accessibility.mdx
+++ b/apps/www/app/content/components/button/no/accessibility.mdx
@@ -6,7 +6,7 @@ Unngå generiske tekster som “Klikk her”.
 
 <span data-size="sm"> 
 
-WCAG: [2.4.4 Formål med lenke (i kontekst)](https://www.uutilsynet.no/wcag-standarden/244-formal-med-lenke-i-kontekst-niva/106)
+WCAG: [2.4.4 Formål med lenke (i kontekst)](https://www.uutilsynet.no/veiledning/244-formal-med-lenke-i-kontekst/1251)
 
 </span>
 
@@ -19,7 +19,7 @@ Hvis du bruker `aria-label` eller andre teknikker som overstyrer det tilgjengeli
 
 <span data-size="sm"> 
 
-WCAG: [2.5.3 Ledetekst i navn](https://www.uutilsynet.no/wcag-standarden/253-ledetekst-i-navn-niva/150)
+WCAG: [2.5.3 Ledetekst i navn](https://www.uutilsynet.no/veiledning/253-ledetekst-i-navn/1256)
 
 </span>
 
@@ -31,7 +31,7 @@ WCAG: [2.5.3 Ledetekst i navn](https://www.uutilsynet.no/wcag-standarden/253-led
 Ikonet skal ikke leses opp hvis teksten allerede beskriver handlingen.
 
 <span data-size="sm"> 
-WCAG: [1.1.1 Ikke-tekstlig innhold](https://www.uutilsynet.no/wcag-standarden/111-ikke-tekstlig-innhold-niva/87)
+WCAG: [1.1.1 Ikke-tekstlig innhold](https://www.uutilsynet.no/veiledning/111-ikke-tekstlig-innhold/1231)
 </span>
 
 
@@ -42,7 +42,7 @@ WCAG: [1.1.1 Ikke-tekstlig innhold](https://www.uutilsynet.no/wcag-standarden/11
 Dette gjelder når button kun består av et ikon.
 
 <span data-size="sm"> 
-WCAG: [4.1.2 Navn, rolle, verdi](https://www.uutilsynet.no/wcag-standarden/412-navn-rolle-verdi-niva/121)
+WCAG: [4.1.2 Navn, rolle, verdi](https://www.uutilsynet.no/veiledning/412-navn-rolle-verdi/1267)
 </span>
 
 
@@ -55,7 +55,7 @@ Hvis knappen viser en lasteindikator, huske å legg på `aria-busy="true"` for �
 I tillegg må du vurdere hvordan status kommuniseres, for eksempel ved å oppdatere teksten.
 
 <span data-size="sm"> 
-WCAG: [4.1.3 Statusbeskjeder](https://www.uutilsynet.no/wcag-standarden/413-statusbeskjeder-niva-aa/152)
+WCAG: [4.1.3 Statusbeskjeder](https://www.uutilsynet.no/veiledning/413-statusbeskjeder/1268)
 </span>
 
 <Divider/>

--- a/apps/www/app/content/components/card/en/accessibility.mdx
+++ b/apps/www/app/content/components/card/en/accessibility.mdx
@@ -17,7 +17,7 @@ WCAG: [2.4.4 Link purpose (in context)](https://www.uutilsynet.no/veiledning/244
 If you use `aria-label` or other techniques that override the accessible name, it must still match the visible text.
 
 <span data-size="sm"> 
-WCAG: [2.5.3 Label in Name](https://www.uutilsynet.no/wcag-standarden/253-ledetekst-i-navn-niva/150)
+WCAG: [2.5.3 Label in Name](https://www.uutilsynet.no/veiledning/253-ledetekst-i-navn/1256)
 </span>
 
 
@@ -28,7 +28,7 @@ WCAG: [2.5.3 Label in Name](https://www.uutilsynet.no/wcag-standarden/253-ledete
 If the entire card is a link with an image, the image must not be informative and should have an empty `alt` attribute.
 
 <span data-size="sm"> 
-WCAG: [1.1.1 Non-text content](https://www.uutilsynet.no/wcag-standarden/111-ikke-tekstlig-innhold-niva/87)
+WCAG: [1.1.1 Non-text content](https://www.uutilsynet.no/veiledning/111-ikke-tekstlig-innhold/1231)
 </span>
 
 
@@ -39,6 +39,6 @@ WCAG: [1.1.1 Non-text content](https://www.uutilsynet.no/wcag-standarden/111-ikk
 Do not skip heading levels (for example from `h1` to `h3`).
 
 <span data-size="sm"> 
-WCAG: [1.3.1 Info and relationships](https://www.uutilsynet.no/wcag-standarden/131-informasjon-og-relasjoner-niva/90)
+WCAG: [1.3.1 Info and relationships](https://www.uutilsynet.no/veiledning/131-informasjon-og-relasjoner/1234)
 </span>
 

--- a/apps/www/app/content/components/card/no/accessibility.mdx
+++ b/apps/www/app/content/components/card/no/accessibility.mdx
@@ -17,7 +17,7 @@ WCAG: [2.4.4 Formål med lenke (i kontekst)](https://www.uutilsynet.no/veilednin
 Hvis du bruker `aria-label` eller andre teknikker som overstyrer det tilgjengelige navnet, må det fortsatt samsvare med den synlige teksten.
 
 <span data-size="sm"> 
-WCAG: [2.5.3 Ledetekst i navn](https://www.uutilsynet.no/wcag-standarden/253-ledetekst-i-navn-niva/150)
+WCAG: [2.5.3 Ledetekst i navn](https://www.uutilsynet.no/veiledning/253-ledetekst-i-navn/1256)
 </span>
 
 
@@ -28,7 +28,7 @@ WCAG: [2.5.3 Ledetekst i navn](https://www.uutilsynet.no/wcag-standarden/253-led
 Hvis hele card er en lenke med bilde, skal bildet ikke være informativt og ha tom `alt`-tekst.
 
 <span data-size="sm"> 
-WCAG: [1.1.1 Ikke-tekstlig innhold](https://www.uutilsynet.no/wcag-standarden/111-ikke-tekstlig-innhold-niva/87)
+WCAG: [1.1.1 Ikke-tekstlig innhold](https://www.uutilsynet.no/veiledning/111-ikke-tekstlig-innhold/1231)
 </span>
 
 
@@ -39,6 +39,6 @@ WCAG: [1.1.1 Ikke-tekstlig innhold](https://www.uutilsynet.no/wcag-standarden/11
 Ikke hopp over nivåer (for eksempel fra `h1` til `h3`).
 
 <span data-size="sm"> 
-WCAG: [1.3.1 Informasjon og relasjoner](https://www.uutilsynet.no/wcag-standarden/131-informasjon-og-relasjoner-niva/90)
+WCAG: [1.3.1 Informasjon og relasjoner](https://www.uutilsynet.no/veiledning/131-informasjon-og-relasjoner/1234)
 </span>
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

Resolves #5079 

## Summary
fixing links in our accessibility docs so that we link to the same kind of article at UUTilsynet. We had a combination of "WCAG-standarden" and "veiledning". The guidance articles made more sense to me for the use case, but if anyone feels it would be better to link directly to the success criteria we could do that instead. 

## Checks

- [ ] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)
