### PR TITLE
fix: proper CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,3 @@
-apps/www/app/content @mrosvik @Febakke
-/.github/CODEOWNERS @digdir/designsystemet
 * @mimarz @Barsnes @eirikbacker
-
+apps/www/app/content @mrosvik @Febakke @mimarz @Barsnes @eirikbacker
+/.github/CODEOWNERS @digdir/designsystemet

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 * @mimarz @Barsnes @eirikbacker
 apps/www/app/content @mrosvik @Febakke @mimarz @Barsnes @eirikbacker
+# The next line is purely for Team Sikkerhet and their filtering logic
 /.github/CODEOWNERS @digdir/designsystemet


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

The `*` was overriding our earlier statement for the content folder.
[https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)

## Checks

- [ ] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)
