### PR TITLE
fix(react): align component and global React types for `data-size` and `data-color`

### DIFF
--- a/.changeset/smart-shirts-tickle.md
+++ b/.changeset/smart-shirts-tickle.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+fix component types for `data-color` and `data-size` to behave the same on components as globally

--- a/.changeset/smart-shirts-tickle.md
+++ b/.changeset/smart-shirts-tickle.md
@@ -2,4 +2,4 @@
 "@digdir/designsystemet-react": patch
 ---
 
-fix component types for `data-color` and `data-size` to behave the same on components as globally
+fix component types for `data-color` and `data-size` to behave the same on components as globally

--- a/packages/react/react-types.d.ts
+++ b/packages/react/react-types.d.ts
@@ -4,22 +4,20 @@ declare global {
   namespace React {
     interface HTMLAttributes<T> {
       /**
-       * Represents the recommended size options for the Designsystemet variables.
-       * - `'sm'`: Use the small size.
-       * - `'md'`: Use the medium size.
-       * - `'lg'`: Use the large size.
+       * Use `data-size` to change the size for descendant Designsystemet components and variables.
+       *
+       * Select from predefined sizes or define your own size.
        */
       'data-size'?: Size | (string & {});
       /**
-       * Represents the available color options for the Designsystemet variables.
+       * Use `data-color` to change the color for descendant Designsystemet components and variables.
        *
-       * These are augmented based on your theme configuration.
-       *
+       * Select from predefined colors and colors defined using theme.designsystemet.no.
        * @link https://theme.designsystemet.no
        */
       'data-color'?: Color | (string & {});
       /**
-       * Represents the available color scheme options for the Designsystemet variables.
+       * Use `data-color-scheme` to change the color scheme for descendant Designsystemet components. Select from predefined color schemes.
        * - `'light'`: Use the light color scheme.
        * - `'dark'`: Use the dark color scheme.
        * - `'auto'`: Automatically select the color scheme based on system preferences.

--- a/packages/react/react-types.d.ts
+++ b/packages/react/react-types.d.ts
@@ -1,4 +1,5 @@
-import type { Color, ColorScheme, Size } from '@digdir/designsystemet-types';
+import type { ColorScheme } from '@digdir/designsystemet-types';
+import type { DefaultProps } from './types';
 
 declare global {
   namespace React {
@@ -8,14 +9,14 @@ declare global {
        *
        * Select from predefined sizes or define your own size.
        */
-      'data-size'?: Size | (string & {});
+      'data-size'?: DefaultProps['data-size'];
       /**
        * Use `data-color` to change the color for descendant Designsystemet components and variables.
        *
        * Select from predefined colors and colors defined using theme.designsystemet.no.
        * @link https://theme.designsystemet.no
        */
-      'data-color'?: Color | (string & {});
+      'data-color'?: DefaultProps['data-color'];
       /**
        * Use `data-color-scheme` to change the color scheme for descendant Designsystemet components. Select from predefined color schemes.
        * - `'light'`: Use the light color scheme.

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -7,14 +7,18 @@ export type Placement = FloatingUIPlacement | 'none';
 
 export type DefaultProps = {
   /**
-   * Changes size for descendant Designsystemet components. Select from predefined sizes.
+   * Use `data-size` to change the size for descendant Designsystemet components and variables.
+   *
+   * Select from predefined sizes or define your own size.
    */
-  'data-size'?: Size;
+  'data-size'?: Size | (string & {});
   /**
-   * Changes color for descendant Designsystemet components.
+   * Use `data-color` to change the color for descendant Designsystemet components and variables.
+   *
    * Select from predefined colors and colors defined using theme.designsystemet.no.
+   * @link https://theme.designsystemet.no
    */
-  'data-color'?: Color | SeverityColors;
+  'data-color'?: Color | SeverityColors | (string & {});
 };
 
 export type LabelRequired =


### PR DESCRIPTION
Fix types for data-size and data-color to behave the same on components as it does globally. 

Updated also description to be more descriptive.