### PR TITLE
fix(css): missing tailwind variables in default theme

### DIFF
--- a/.changeset/olive-symbols-attend.md
+++ b/.changeset/olive-symbols-attend.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+Fix missing tailwind variables (opacity and shadow) in default theme that was introduced in #5139

--- a/.changeset/olive-symbols-attend.md
+++ b/.changeset/olive-symbols-attend.md
@@ -2,4 +2,4 @@
 "@digdir/designsystemet-css": patch
 ---
 
-Fix missing tailwind variables (opacity and shadow) in default theme that was introduced in #5139
+Fix missing tailwind variables (opacity and shadow) in default theme that was introduced in [#5139](https://github.com/digdir/designsystemet/pull/5139)

--- a/design-tokens/$designsystemet.jsonc
+++ b/design-tokens/$designsystemet.jsonc
@@ -1,4 +1,4 @@
 {
   "name": "@digdir/designsystemet",
-  "version": "1.18.0"
+  "version": "1.19.0"
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "publish-packages": "pnpm build && changeset publish",
     "chromatic": "pnpm --filter @web/storybook chromatic",
     "update:theme-digdir": "pnpm --filter @internal/digdir update:theme-digdir",
-    "update:theme": "designsystemet",
+    "update:theme": "pnpm node packages/cli/bin/designsystemet.ts tokens create --config designsystemet.config.json && pnpm --filter @digdir/designsystemet-css build:theme",
     "update:preview-tokens": "pnpm --filter @digdir/designsystemet run update:preview-tokens"
   },
   "devDependencies": {

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -49,7 +49,8 @@
     "digdir"
   ],
   "scripts": {
-    "build": "rimraf dist && postcss ./src/*.css --base . --dir ./dist && postcss ./theme/*.css --dir ./dist/theme && postcss ./src/v2/*.css --dir ./dist/src/v2"
+    "build": "rimraf dist && postcss ./src/*.css --base . --dir ./dist && postcss ./theme/*.css --dir ./dist/theme && postcss ./src/v2/*.css --dir ./dist/src/v2",
+    "build:theme": "pnpm node ../cli/bin/designsystemet.ts tokens build -t ../../design-tokens -o ./theme --experimental-tailwind"
   },
   "dependencies": {
     "@digdir/designsystemet-types": "workspace:"

--- a/packages/css/theme/colors.d.ts
+++ b/packages/css/theme/colors.d.ts
@@ -1,5 +1,5 @@
 /* This file is deprecated and will be removed in a future release. Use types.d.ts instead */
-/* build: v1.18.0 */
+/* build: v1.19.0 */
 import type {} from '@digdir/designsystemet-types';
 
 // Augment types based on theme

--- a/packages/css/theme/designsystemet.css
+++ b/packages/css/theme/designsystemet.css
@@ -1,7 +1,7 @@
 @charset "UTF-8";
 /*
-build: v1.18.0
-design-tokens: v1.18.0
+build: v1.19.0
+design-tokens: v1.19.0
 */
 
 @layer ds.theme.size-mode {

--- a/packages/css/theme/designsystemet.tailwind.css
+++ b/packages/css/theme/designsystemet.tailwind.css
@@ -151,6 +151,12 @@
   --font-weight-medium: var(--ds-font-weight-medium);
   --font-weight-regular: var(--ds-font-weight-regular);
   --font-weight-semibold: var(--ds-font-weight-semibold);
+  --opacity-disabled: var(--ds-opacity-disabled);
+  --shadow-lg: var(--ds-shadow-lg);
+  --shadow-md: var(--ds-shadow-md);
+  --shadow-sm: var(--ds-shadow-sm);
+  --shadow-xl: var(--ds-shadow-xl);
+  --shadow-xs: var(--ds-shadow-xs);
   --spacing-0: var(--ds-size-0);
   --spacing-1: var(--ds-size-1);
   --spacing-2: var(--ds-size-2);

--- a/packages/css/theme/types.d.ts
+++ b/packages/css/theme/types.d.ts
@@ -1,4 +1,4 @@
-/* build: v1.18.0 */
+/* build: v1.19.0 */
 import type {} from '@digdir/designsystemet-types';
 
 // Augment types based on theme


### PR DESCRIPTION
- Fixes broken `update:theme` script
- Fixes missing tailwind variables opacity and shadow that was introduced in #5139.

