### PR TITLE
fix(popover): avoid ResizeObserver feedback loops

### DIFF
--- a/.changeset/calm-taxis-resize.md
+++ b/.changeset/calm-taxis-resize.md
@@ -2,4 +2,4 @@
 '@digdir/designsystemet-web': patch
 ---
 
-**Suggestion:** Prevent ResizeObserver loop errors when positioning the option list.
+**popover:** Prevent ResizeObserver loop errors when positioning the option list.

--- a/.changeset/calm-taxis-resize.md
+++ b/.changeset/calm-taxis-resize.md
@@ -1,0 +1,5 @@
+---
+'@digdir/designsystemet-web': patch
+---
+
+**Suggestion:** Prevent ResizeObserver loop errors when positioning the option list.

--- a/packages/web/src/popover/popover.test.ts
+++ b/packages/web/src/popover/popover.test.ts
@@ -73,6 +73,37 @@ describe('popover floating behavior', () => {
     expect(popover).toHaveAttribute('data-floating', 'bottom-end');
   });
 
+  it('defers dimension changes to avoid resizing during ResizeObserver delivery', async () => {
+    const animationFrames: FrameRequestCallback[] = [];
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      animationFrames.push(callback);
+      return animationFrames.length;
+    });
+    render(`
+      <button style="width: 120px" popovertarget="my-popover">Open</button>
+      <div
+        id="my-popover"
+        popover="auto"
+        style="--_ds-floating: top; --_ds-floating-overscroll: fit"
+      >Content</div>
+    `);
+
+    document.querySelector('button')?.click();
+    await tick();
+
+    const popover = document.getElementById('my-popover') as HTMLElement;
+    expect(animationFrames.length).toBeGreaterThan(0);
+    expect(popover.style.width).toBe('');
+    expect(popover.style.maxHeight).toBe('');
+
+    animationFrames.forEach((callback) => {
+      callback(performance.now());
+    });
+
+    expect(popover.style.width).toBe('120px');
+    expect(popover.style.maxHeight).not.toBe('');
+  });
+
   it('does not position when data-placement is "none"', async () => {
     render(`
       <button popovertarget="my-popover">Open</button>

--- a/packages/web/src/popover/popover.test.ts
+++ b/packages/web/src/popover/popover.test.ts
@@ -245,6 +245,7 @@ describe('popover overscroll sizing', () => {
     trigger.click();
     await tick();
 
+    await vi.waitFor(() => expect(popover.style.maxHeight).toMatch(/px$/));
     const sizeAtOpen = popover.style.maxHeight;
     expect(sizeAtOpen).toMatch(/px$/);
 
@@ -266,6 +267,7 @@ describe('popover overscroll sizing', () => {
 
     trigger.click();
     await tick();
+    await vi.waitFor(() => expect(popover.style.maxHeight).toMatch(/px$/));
     const sizeAtFirstOpen = popover.style.maxHeight;
 
     trigger.click(); // Close
@@ -274,8 +276,10 @@ describe('popover overscroll sizing', () => {
     trigger.click();
     await tick();
 
+    await vi.waitFor(() =>
+      expect(popover.style.maxHeight).not.toBe(sizeAtFirstOpen),
+    );
     expect(popover.style.maxHeight).toMatch(/px$/);
-    expect(popover.style.maxHeight).not.toBe(sizeAtFirstOpen);
   });
 });
 

--- a/packages/web/src/popover/popover.ts
+++ b/packages/web/src/popover/popover.ts
@@ -105,9 +105,16 @@ function toggle(
         ? [
             size({
               apply({ availableHeight }) {
-                if (overscroll === 'fit')
-                  el.style.width = `${source.offsetWidth}px`; // Use offsetWidth to include padding, matching the width of the source element
-                el.style.maxHeight = `${Math.max(50, availableHeight - padding * 2)}px`;
+                const width = `${source.offsetWidth}px`; // Use offsetWidth to include padding, matching the width of the source element
+                const maxHeight = `${Math.max(50, availableHeight - padding * 2)}px`;
+
+                requestAnimationFrame(() => {
+                  // Avoid changing an observed element during ResizeObserver delivery.
+                  if (overscroll === 'fit' && el.style.width !== width)
+                    el.style.width = width;
+                  if (el.style.maxHeight !== maxHeight)
+                    el.style.maxHeight = maxHeight;
+                });
               },
             }),
           ]


### PR DESCRIPTION
## Summary

Prevent `ResizeObserver loop completed with undelivered notifications` errors when a Suggestion option list is positioned.

## Root cause

Suggestion lists opt into the shared floating-element sizing path with `--_ds-floating-overscroll: fit`. Floating UI's `autoUpdate()` observes the list with `ResizeObserver`, while the `size()` middleware synchronously writes `width` and `max-height` to that same observed element. If those writes affect its dimensions during observer delivery, the browser schedules another resize notification in the active rendering cycle and can eventually report undelivered notifications.

The issue surfaced while upgrading Designsystemet in [Altinn/altinn-studio#19766](https://github.com/Altinn/altinn-studio/pull/19766).

Designsystemet has encountered the same feedback-loop pattern before. The previous React implementations deferred Floating UI dimension writes with `requestAnimationFrame` in [#565](https://github.com/digdir/designsystemet/pull/565) for Select and [#1594](https://github.com/digdir/designsystemet/pull/1594) for Combobox. Those components have since been replaced, while the shared `@digdir/designsystemet-web` popover sizing path reintroduced synchronous writes for Suggestion lists.

## Solution

Schedule the dimension writes for the next animation frame and avoid assignments when the desired value is already applied. This keeps the existing list sizing behavior while breaking the observer feedback loop.

A browser regression test verifies that the floating size middleware does not mutate dimensions until the next animation frame.

## Verification

- Focused Chromium browser test: 12 tests passed
- Biome check passed for the changed source and test
- TypeScript check passed for `packages/web`