### PR TITLE
fix(cli): reduce engines node version

### DIFF
--- a/.changeset/good-pears-sort.md
+++ b/.changeset/good-pears-sort.md
@@ -2,4 +2,4 @@
 "@digdir/designsystemet": patch
 ---
 
-reduce required engines version to minimum node lts version
+remove minimum `engines` for node version as its no longer needed.

--- a/.changeset/good-pears-sort.md
+++ b/.changeset/good-pears-sort.md
@@ -2,4 +2,4 @@
 "@digdir/designsystemet": patch
 ---
 
-remove minimum `engines` for node version as its no longer needed.
+Reduce minimum required node version to `>=22.0.0`.

--- a/.changeset/good-pears-sort.md
+++ b/.changeset/good-pears-sort.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet": patch
+---
+
+reduce required engines version to minimum node lts version

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,6 +3,9 @@
   "version": "1.19.1",
   "description": "CLI for Designsystemet",
   "author": "Designsystemet team",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/digdir/designsystemet.git"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,9 +3,6 @@
   "version": "1.19.1",
   "description": "CLI for Designsystemet",
   "author": "Designsystemet team",
-  "engines": {
-    "node": ">=22.23.2"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/digdir/designsystemet.git"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,7 +4,7 @@
   "description": "CLI for Designsystemet",
   "author": "Designsystemet team",
   "engines": {
-    "node": ">=24.19.0"
+    "node": ">=22.23.2"
   },
   "repository": {
     "type": "git",

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,15 @@
   "extends": ["local>digdir/renovate-config"],
   "rangeStrategy": "bump",
   "ignoreDeps": ["@floating-ui/react"],
+  "packageRules": [
+    {
+      "description": "Keep engines.node in the CLI package as the minimum supported Node version",
+      "matchFileNames": ["packages/cli/package.json"],
+      "matchDepTypes": ["engines"],
+      "matchDepNames": ["node"],
+      "enabled": false
+    }
+  ],
   "customManagers": [
     {
       "customType": "jsonata",

--- a/renovate.json
+++ b/renovate.json
@@ -3,15 +3,6 @@
   "extends": ["local>digdir/renovate-config"],
   "rangeStrategy": "bump",
   "ignoreDeps": ["@floating-ui/react"],
-  "packageRules": [
-    {
-      "description": "Keep engines.node in the CLI package as the minimum supported Node version",
-      "matchFileNames": ["packages/cli/package.json"],
-      "matchDepTypes": ["engines"],
-      "matchDepNames": ["node"],
-      "enabled": false
-    }
-  ],
   "customManagers": [
     {
       "customType": "jsonata",

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,15 @@
   "extends": ["local>digdir/renovate-config"],
   "rangeStrategy": "bump",
   "ignoreDeps": ["@floating-ui/react"],
+  "packageRules": [
+    {
+      "description": "Keep engines.node in the CLI package at the minimum required by style-dictionary dependency",
+      "matchFileNames": ["packages/cli/package.json"],
+      "matchDepTypes": ["engines"],
+      "matchDepNames": ["node"],
+      "enabled": false
+    }
+  ],
   "customManagers": [
     {
       "customType": "jsonata",


### PR DESCRIPTION
Our defined node version in `engines` also applies downstream to users. This was earlier defined due to `import type 'json'` support. Reducing it to minimum version required by our dependencies (style-dictioarny) to reduce `npm warn EBADENGINE` downstream.

https://designsystemet.slack.com/archives/C05RF86A3K7/p1786540047774989