### PR TITLE
feat: add webmcp to www and themebuilder

### DIFF
--- a/apps/themebuilder/app/_hooks/use-webmcp-navigate.ts
+++ b/apps/themebuilder/app/_hooks/use-webmcp-navigate.ts
@@ -1,0 +1,20 @@
+import { useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router';
+import { setWebMcpNavigate } from '~/_utils/webmcp.client';
+
+/**
+ * Upgrades the WebMCP tools from full page loads to client-side navigation
+ * once the app has hydrated.
+ */
+export function useWebMcpNavigate() {
+  const navigate = useNavigate();
+  const navigateRef = useRef(navigate);
+
+  useEffect(() => {
+    navigateRef.current = navigate;
+  }, [navigate]);
+
+  useEffect(() => {
+    setWebMcpNavigate((to) => navigateRef.current(to));
+  }, []);
+}

--- a/apps/themebuilder/app/_utils/webmcp.client.ts
+++ b/apps/themebuilder/app/_utils/webmcp.client.ts
@@ -1,0 +1,441 @@
+/**
+ * WebMCP integration – exposes the themebuilder's key actions (reading and
+ * updating the theme, exporting the theme config) as tools AI agents can call
+ * through the browser's Model Context API.
+ *
+ * The whole theme state lives in the URL query params, so tools read the
+ * current theme from `location.search` and apply changes by navigating.
+ *
+ * The API surface differs between the spec draft (`document.modelContext`) and
+ * Chrome's early preview (`navigator.modelContext`), so we feature-detect both
+ * and register through `provideContext` when available, falling back to
+ * `registerTool`.
+ *
+ * @see https://webmachinelearning.github.io/webmcp/
+ * @see https://developer.chrome.com/blog/webmcp-epp
+ */
+
+import themeConfig from '../../../../designsystemet.config.json';
+
+type WebMcpToolResult = {
+  content: { type: 'text'; text: string }[];
+};
+
+type WebMcpTool = {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  annotations?: {
+    readOnlyHint?: boolean;
+  };
+  execute: (
+    input: Record<string, unknown>,
+  ) => WebMcpToolResult | Promise<WebMcpToolResult>;
+};
+
+type ModelContext = {
+  provideContext?: (context: { tools: WebMcpTool[] }) => void;
+  registerTool?: (tool: WebMcpTool) => void | Promise<void>;
+};
+
+declare global {
+  interface Navigator {
+    modelContext?: ModelContext;
+  }
+  interface Document {
+    modelContext?: ModelContext;
+  }
+}
+
+/* Full page loads also work, but SPA navigation lets the tool call resolve and
+ * return its result to the agent instead of being cut off by the unload.
+ * Upgraded to the react-router navigate function once the app has hydrated. */
+let navigateImpl: (to: string) => void = (to) => window.location.assign(to);
+
+export function setWebMcpNavigate(navigate: (to: string) => void) {
+  navigateImpl = navigate;
+}
+
+const textResult = (value: unknown): WebMcpToolResult => ({
+  content: [
+    {
+      type: 'text',
+      text: typeof value === 'string' ? value : JSON.stringify(value, null, 2),
+    },
+  ],
+});
+
+/* Duplicated from routes/themebuilder/_utils/use-themebuilder.tsx (like
+ * config-to-url.ts does) to keep the color-scheme generation code out of the
+ * entry chunk */
+const QUERY_SEPARATOR = ' ';
+
+const DEFAULT_COLORS = themeConfig.themes.designsystemet.colors;
+const SEVERITY_NAMES = ['info', 'success', 'warning', 'danger'] as const;
+const TABS = ['examples', 'colorsystem', 'variables'] as const;
+
+const HEX_PATTERN = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
+const NAME_PATTERN = /^[a-z][a-z0-9-]{0,39}$/;
+
+const currentLang = (): 'en' | 'no' =>
+  window.location.pathname.startsWith('/en') ? 'en' : 'no';
+
+/* The theme state lives in the themebuilder page's query params. On other
+ * pages (the landing page), fall back to the same defaults as the loader. */
+const currentThemeParams = (): URLSearchParams => {
+  if (window.location.pathname.endsWith('/themebuilder')) {
+    return new URLSearchParams(window.location.search);
+  }
+
+  return new URLSearchParams({
+    colors: Object.entries(DEFAULT_COLORS)
+      .map(([name, hex]) => `${name}:${hex}`)
+      .join(QUERY_SEPARATOR),
+    appearance: 'light',
+    'border-radius': '4',
+    tab: 'colorsystem',
+  });
+};
+
+const parseColorList = (
+  value: string | null,
+): { name: string; hex: string }[] =>
+  (value ?? '')
+    .split(QUERY_SEPARATOR)
+    .filter(Boolean)
+    .map((entry) => {
+      const [name, hex] = entry.split(':');
+      return { name, hex };
+    });
+
+const serializeColorList = (colors: { name: string; hex: string }[]): string =>
+  colors.map(({ name, hex }) => `${name}:${hex}`).join(QUERY_SEPARATOR);
+
+const themebuilderUrl = (params: URLSearchParams): string =>
+  `/${currentLang()}/themebuilder?${params.toString()}`;
+
+/* Mirrors parseColorOverrides in routes/themebuilder/_utils/use-themebuilder.tsx.
+ * Entries look like `<colorname>|<tokenname>|light:<hex>|dark:<hex>` */
+const parseColorOverrides = (
+  value: string | null,
+): Record<string, Record<string, { light?: string; dark?: string }>> => {
+  const result: Record<
+    string,
+    Record<string, { light?: string; dark?: string }>
+  > = {};
+
+  for (const entry of (value ?? '').split(QUERY_SEPARATOR)) {
+    const [colorName, tokenName, ...modeParts] = entry.split('|');
+    if (!colorName || !tokenName || modeParts.length === 0) continue;
+
+    result[colorName] ??= {};
+    result[colorName][tokenName] ??= {};
+
+    for (const modePart of modeParts) {
+      const [mode, hex] = modePart.split(':');
+      if (mode === 'light' || mode === 'dark') {
+        result[colorName][tokenName][mode] = hex;
+      }
+    }
+  }
+
+  return result;
+};
+
+const themeFromParams = (params: URLSearchParams) => ({
+  colors: parseColorList(params.get('colors')),
+  severity: parseColorList(params.get('severity')),
+  severityEnabled: params.get('severity-enabled') === 'true',
+  borderRadius: Number.parseInt(params.get('border-radius') || '4', 10),
+  appearance: params.get('appearance') || 'light',
+  tab: params.get('tab') || 'colorsystem',
+});
+
+const colorInputSchema = {
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string',
+      description:
+        'Color name in lowercase letters, digits and hyphens, e.g. "accent" or "brand1". "neutral" is the reserved neutral color.',
+    },
+    hex: {
+      type: 'string',
+      description: 'Hex color value, e.g. "#0062BA".',
+    },
+  },
+  required: ['name', 'hex'],
+};
+
+const buildTools = (): WebMcpTool[] => [
+  {
+    name: 'get-theme',
+    description:
+      'Get the current theme in the theme builder: main/neutral colors, severity colors, border radius, appearance (light/dark) and a shareable URL.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+    annotations: { readOnlyHint: true },
+    execute: () => {
+      const params = currentThemeParams();
+      return textResult({
+        ...themeFromParams(params),
+        url: new URL(themebuilderUrl(params), window.location.origin).href,
+      });
+    },
+  },
+  {
+    name: 'update-theme',
+    description:
+      'Update the theme in the theme builder. All inputs are optional; provided ones are applied to the current theme and the page navigates to show the result. Colors are merged by name unless "replaceColors" is true. The reserved "neutral" color is always kept.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        colors: {
+          type: 'array',
+          description: 'Colors to add or update.',
+          items: colorInputSchema,
+        },
+        removeColors: {
+          type: 'array',
+          description: 'Names of colors to remove.',
+          items: { type: 'string' },
+        },
+        replaceColors: {
+          type: 'boolean',
+          description:
+            'Replace the whole color set with "colors" instead of merging.',
+        },
+        severity: {
+          type: 'array',
+          description:
+            'Override severity colors. Valid names: info, success, warning, danger.',
+          items: colorInputSchema,
+        },
+        borderRadius: {
+          type: 'number',
+          description: 'Base border radius in pixels, 0–9999.',
+        },
+        appearance: {
+          type: 'string',
+          enum: ['light', 'dark'],
+          description: 'Color scheme to preview the theme in.',
+        },
+        tab: {
+          type: 'string',
+          enum: [...TABS],
+          description: 'Which themebuilder tab to show.',
+        },
+      },
+    },
+    execute: (input) => {
+      const params = currentThemeParams();
+      const errors: string[] = [];
+
+      const readColorArray = (
+        value: unknown,
+        allowedNames?: readonly string[],
+      ) => {
+        if (!Array.isArray(value)) return [];
+        const colors: { name: string; hex: string }[] = [];
+        for (const entry of value) {
+          const name = String(
+            (entry as Record<string, unknown>)?.name ?? '',
+          ).toLowerCase();
+          const hex = String(
+            (entry as Record<string, unknown>)?.hex ?? '',
+          ).toLowerCase();
+          if (!NAME_PATTERN.test(name)) {
+            errors.push(`Invalid color name "${name}".`);
+          } else if (allowedNames && !allowedNames.includes(name)) {
+            errors.push(
+              `Invalid severity color "${name}". Valid names: ${allowedNames.join(', ')}.`,
+            );
+          } else if (!HEX_PATTERN.test(hex)) {
+            errors.push(`Invalid hex value "${hex}" for color "${name}".`);
+          } else {
+            colors.push({ name, hex });
+          }
+        }
+        return colors;
+      };
+
+      const newColors = readColorArray(input.colors);
+      const newSeverity = readColorArray(input.severity, SEVERITY_NAMES);
+      const removeColors = Array.isArray(input.removeColors)
+        ? input.removeColors.map((name) => String(name).toLowerCase())
+        : [];
+
+      if (input.borderRadius !== undefined) {
+        const radius = Number(input.borderRadius);
+        if (!Number.isFinite(radius) || radius < 0 || radius > 9999) {
+          errors.push('"borderRadius" must be a number between 0 and 9999.');
+        } else {
+          params.set('border-radius', Math.round(radius).toString());
+        }
+      }
+
+      if (input.appearance !== undefined) {
+        if (input.appearance === 'light' || input.appearance === 'dark') {
+          params.set('appearance', input.appearance);
+        } else {
+          errors.push('"appearance" must be "light" or "dark".');
+        }
+      }
+
+      if (input.tab !== undefined) {
+        if (TABS.includes(input.tab as (typeof TABS)[number])) {
+          params.set('tab', String(input.tab));
+        } else {
+          errors.push(`"tab" must be one of: ${TABS.join(', ')}.`);
+        }
+      }
+
+      if (errors.length > 0) {
+        return textResult(`No changes applied:\n${errors.join('\n')}`);
+      }
+
+      if (newColors.length > 0 || removeColors.length > 0) {
+        const current = parseColorList(params.get('colors'));
+        let colors = input.replaceColors === true ? [] : [...current];
+
+        for (const color of newColors) {
+          const existing = colors.findIndex((c) => c.name === color.name);
+          if (existing >= 0) {
+            colors[existing] = color;
+          } else {
+            colors.push(color);
+          }
+        }
+
+        colors = colors.filter((c) => !removeColors.includes(c.name));
+
+        // A theme always needs the reserved neutral color
+        if (!colors.some((c) => c.name === 'neutral')) {
+          const neutral =
+            current.find((c) => c.name === 'neutral')?.hex ??
+            DEFAULT_COLORS.neutral;
+          colors.push({ name: 'neutral', hex: neutral });
+        }
+
+        params.set('colors', serializeColorList(colors));
+      }
+
+      if (newSeverity.length > 0) {
+        const current = parseColorList(params.get('severity'));
+        const severity = [...current];
+
+        for (const color of newSeverity) {
+          const existing = severity.findIndex((c) => c.name === color.name);
+          if (existing >= 0) {
+            severity[existing] = color;
+          } else {
+            severity.push(color);
+          }
+        }
+
+        params.set('severity', serializeColorList(severity));
+        params.set('severity-enabled', 'true');
+      }
+
+      const url = themebuilderUrl(params);
+      navigateImpl(url);
+
+      return textResult({
+        message: 'Theme updated.',
+        ...themeFromParams(params),
+        url: new URL(url, window.location.origin).href,
+      });
+    },
+  },
+  {
+    name: 'get-theme-config',
+    description:
+      'Export the current theme as a designsystemet.config.json snippet, with the CLI commands that generate design tokens and CSS variables from it.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          description:
+            'Name of the theme in the generated config. Defaults to "theme".',
+        },
+      },
+    },
+    annotations: { readOnlyHint: true },
+    execute: (input) => {
+      const rawName = String(input.name ?? 'theme').toLowerCase();
+      const name = NAME_PATTERN.test(rawName) ? rawName : 'theme';
+
+      const params = currentThemeParams();
+      const theme = themeFromParams(params);
+
+      const colors = Object.fromEntries(
+        theme.colors.map(({ name: colorName, hex }) => [colorName, hex]),
+      );
+      const severity = Object.fromEntries(
+        theme.severity.map(({ name: severityName, hex }) => [
+          severityName,
+          hex,
+        ]),
+      );
+      const colorOverrides = parseColorOverrides(params.get('color-overrides'));
+      const hasOverrides =
+        theme.severity.length > 0 || Object.keys(colorOverrides).length > 0;
+
+      const config = {
+        $schema: 'node_modules/@digdir/designsystemet/dist/config.schema.json',
+        outDir: './design-tokens',
+        themes: {
+          [name]: {
+            colors,
+            ...(hasOverrides && {
+              overrides: {
+                ...(theme.severity.length > 0 && { severity }),
+                ...(Object.keys(colorOverrides).length > 0 && {
+                  colors: colorOverrides,
+                }),
+              },
+            }),
+            borderRadius: theme.borderRadius,
+          },
+        },
+      };
+
+      const packageWithTag = `@digdir/designsystemet${
+        window.location.hostname === 'theme.designsystemet.no'
+          ? '@latest'
+          : '@next'
+      }`;
+
+      return textResult({
+        instructions:
+          'Save the config as designsystemet.config.json in your project root, then run the commands to generate design tokens and CSS variables.',
+        config,
+        commands: [
+          `npx ${packageWithTag} tokens create --config designsystemet.config.json`,
+          `npx ${packageWithTag} tokens build --config designsystemet.config.json`,
+        ],
+      });
+    },
+  },
+];
+
+let registered = false;
+
+export function registerWebMcpTools() {
+  const modelContext = navigator.modelContext ?? document.modelContext;
+  if (!modelContext || registered) return;
+  registered = true;
+
+  const tools = buildTools();
+
+  if (typeof modelContext.provideContext === 'function') {
+    modelContext.provideContext({ tools });
+  } else if (typeof modelContext.registerTool === 'function') {
+    for (const tool of tools) {
+      void modelContext.registerTool(tool);
+    }
+  }
+}

--- a/apps/themebuilder/app/entry.client.tsx
+++ b/apps/themebuilder/app/entry.client.tsx
@@ -3,9 +3,14 @@ import { StrictMode, startTransition } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
 import { HydratedRouter } from 'react-router/dom';
+import { registerWebMcpTools } from '~/_utils/webmcp.client';
 import en from '~/locales/en';
 import no from '~/locales/no';
 import i18n from './i18n';
+
+/* Expose the themebuilder's WebMCP tools to AI agents as early as possible on
+ * page load, before hydration */
+registerWebMcpTools();
 
 const url = window.location.pathname;
 const lng = url.startsWith('/no') ? 'no' : url.startsWith('/en') ? 'en' : 'no';

--- a/apps/themebuilder/app/root.tsx
+++ b/apps/themebuilder/app/root.tsx
@@ -15,6 +15,7 @@ import '@digdir/designsystemet-css';
 import './app.css';
 import { useTranslation } from 'react-i18next';
 import { useChangeLanguage } from '~/_hooks/use-change-language';
+import { useWebMcpNavigate } from '~/_hooks/use-webmcp-navigate';
 
 export const links: Route.LinksFunction = () => {
   return [
@@ -146,6 +147,7 @@ function Document({ children }: DocumentProps) {
 
 export default function App({ loaderData: { lang } }: Route.ComponentProps) {
   useChangeLanguage(lang);
+  useWebMcpNavigate();
 
   return (
     <Document>

--- a/apps/www/app/_hooks/use-webmcp-navigate.ts
+++ b/apps/www/app/_hooks/use-webmcp-navigate.ts
@@ -1,0 +1,20 @@
+import { useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router';
+import { setWebMcpNavigate } from '~/_utils/webmcp.client';
+
+/**
+ * Upgrades the WebMCP open-page tool from full page loads to client-side
+ * navigation once the app has hydrated.
+ */
+export function useWebMcpNavigate() {
+  const navigate = useNavigate();
+  const navigateRef = useRef(navigate);
+
+  useEffect(() => {
+    navigateRef.current = navigate;
+  }, [navigate]);
+
+  useEffect(() => {
+    setWebMcpNavigate((to) => navigateRef.current(to));
+  }, []);
+}

--- a/apps/www/app/_utils/webmcp.client.ts
+++ b/apps/www/app/_utils/webmcp.client.ts
@@ -1,0 +1,222 @@
+/**
+ * WebMCP integration – exposes the site's key actions (documentation search,
+ * component listing, navigation and page reading) as tools AI agents can call
+ * through the browser's Model Context API.
+ *
+ * The API surface differs between the spec draft (`document.modelContext`) and
+ * Chrome's early preview (`navigator.modelContext`), so we feature-detect both
+ * and register through `provideContext` when available, falling back to
+ * `registerTool`.
+ *
+ * @see https://webmachinelearning.github.io/webmcp/
+ * @see https://developer.chrome.com/blog/webmcp-epp
+ */
+
+type WebMcpToolResult = {
+  content: { type: 'text'; text: string }[];
+};
+
+type WebMcpTool = {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  annotations?: {
+    readOnlyHint?: boolean;
+  };
+  execute: (
+    input: Record<string, unknown>,
+  ) => WebMcpToolResult | Promise<WebMcpToolResult>;
+};
+
+type ModelContext = {
+  provideContext?: (context: { tools: WebMcpTool[] }) => void;
+  registerTool?: (tool: WebMcpTool) => void | Promise<void>;
+};
+
+declare global {
+  interface Navigator {
+    modelContext?: ModelContext;
+  }
+  interface Document {
+    modelContext?: ModelContext;
+  }
+}
+
+/* Full page loads also work, but SPA navigation lets the tool call resolve and
+ * return its result to the agent instead of being cut off by the unload.
+ * Upgraded to the react-router navigate function once the app has hydrated. */
+let navigateImpl: (to: string) => void = (to) => window.location.assign(to);
+
+export function setWebMcpNavigate(navigate: (to: string) => void) {
+  navigateImpl = navigate;
+}
+
+const textResult = (value: unknown): WebMcpToolResult => ({
+  content: [
+    {
+      type: 'text',
+      text: typeof value === 'string' ? value : JSON.stringify(value, null, 2),
+    },
+  ],
+});
+
+/* Kept in sync with the <html lang> attribute by i18next */
+const currentLang = (): 'en' | 'no' =>
+  document.documentElement.lang === 'en' ? 'en' : 'no';
+
+const langFromInput = (input: Record<string, unknown>): 'en' | 'no' =>
+  input.lang === 'en' || input.lang === 'no' ? input.lang : currentLang();
+
+const langInputSchema = {
+  type: 'string',
+  enum: ['no', 'en'],
+  description:
+    'Language of the documentation, "no" (Norwegian) or "en" (English). Defaults to the current page language.',
+};
+
+type SearchResponse = {
+  results: {
+    title: string;
+    description: string;
+    url: string;
+    type: string;
+  }[];
+};
+
+const fetchSearchResults = async (params: URLSearchParams) => {
+  const response = await fetch(`/api/search?${params}`);
+  if (!response.ok) {
+    return textResult(`Search request failed with status ${response.status}.`);
+  }
+
+  const { results } = (await response.json()) as SearchResponse;
+  if (results.length === 0) {
+    return textResult('No results found.');
+  }
+
+  return textResult(
+    results.map((result) => ({
+      title: result.title,
+      description: result.description,
+      type: result.type,
+      url: new URL(result.url, window.location.origin).href,
+    })),
+  );
+};
+
+const buildTools = (): WebMcpTool[] => [
+  {
+    name: 'search-documentation',
+    description:
+      'Search the Designsystemet documentation. Finds components, fundamentals (design tokens, theming), patterns, best practices and blog posts. Returns matching pages with title, description and URL.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description:
+            'Search terms, e.g. "button", "design tokens" or "accessibility".',
+        },
+        lang: langInputSchema,
+      },
+      required: ['query'],
+    },
+    annotations: { readOnlyHint: true },
+    execute: async (input) => {
+      const query = String(input.query ?? '').trim();
+      if (!query) {
+        return textResult('The "query" input is required.');
+      }
+
+      return fetchSearchResults(
+        new URLSearchParams({ q: query, lang: langFromInput(input) }),
+      );
+    },
+  },
+  {
+    name: 'list-components',
+    description:
+      'List all UI components in Designsystemet, each with a short description and a link to its documentation.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        lang: langInputSchema,
+      },
+    },
+    annotations: { readOnlyHint: true },
+    execute: async (input) =>
+      fetchSearchResults(
+        new URLSearchParams({ type: 'component', lang: langFromInput(input) }),
+      ),
+  },
+  {
+    name: 'open-page',
+    description:
+      'Navigate the browser to a page on this site, e.g. a URL returned by search-documentation or list-components.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: {
+          type: 'string',
+          description:
+            'Path (e.g. "/no/components/docs/button/overview") or full URL on this site.',
+        },
+      },
+      required: ['url'],
+    },
+    execute: (input) => {
+      const raw = String(input.url ?? '');
+
+      let target: URL;
+      try {
+        target = new URL(raw, window.location.origin);
+      } catch {
+        return textResult(`"${raw}" is not a valid URL.`);
+      }
+
+      if (target.origin !== window.location.origin) {
+        return textResult(
+          `Only pages on ${window.location.origin} can be opened.`,
+        );
+      }
+
+      navigateImpl(target.pathname + target.search + target.hash);
+      return textResult(`Navigated to ${target.pathname}.`);
+    },
+  },
+  {
+    name: 'get-page-content',
+    description: "Get the current page's URL, title and readable text content.",
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+    annotations: { readOnlyHint: true },
+    execute: () => {
+      const main = document.querySelector('main');
+      return textResult({
+        url: window.location.href,
+        title: document.title,
+        content: (main ?? document.body).innerText.slice(0, 8000),
+      });
+    },
+  },
+];
+
+let registered = false;
+
+export function registerWebMcpTools() {
+  const modelContext = navigator.modelContext ?? document.modelContext;
+  if (!modelContext || registered) return;
+  registered = true;
+
+  const tools = buildTools();
+
+  if (typeof modelContext.provideContext === 'function') {
+    modelContext.provideContext({ tools });
+  } else if (typeof modelContext.registerTool === 'function') {
+    for (const tool of tools) {
+      void modelContext.registerTool(tool);
+    }
+  }
+}

--- a/apps/www/app/entry.client.tsx
+++ b/apps/www/app/entry.client.tsx
@@ -3,9 +3,14 @@ import { StrictMode, startTransition } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
 import { HydratedRouter } from 'react-router/dom';
+import { registerWebMcpTools } from '~/_utils/webmcp.client';
 import en from '~/locales/en';
 import no from '~/locales/no';
 import i18n from './i18n';
+
+/* Expose the site's WebMCP tools to AI agents as early as possible on page
+ * load, before hydration */
+registerWebMcpTools();
 
 const url = window.location.pathname;
 const lng = url.startsWith('/no') ? 'no' : url.startsWith('/en') ? 'en' : 'no';

--- a/apps/www/app/root.tsx
+++ b/apps/www/app/root.tsx
@@ -16,6 +16,7 @@ import { Error404 } from '@internal/components';
 import { useTranslation } from 'react-i18next';
 import { SiteimproveScript } from './_components/siteimprove-script';
 import { useChangeLanguage } from './_hooks/use-change-language';
+import { useWebMcpNavigate } from './_hooks/use-webmcp-navigate';
 import { designsystemetRedirects } from './_utils/redirects.server';
 
 export const links = () => {
@@ -162,6 +163,7 @@ function Document({ children }: DocumentProps) {
 
 export default function App({ loaderData: { lang } }: Route.ComponentProps) {
   useChangeLanguage(lang);
+  useWebMcpNavigate();
 
   return (
     <Document>

--- a/apps/www/app/routes/search.tsx
+++ b/apps/www/app/routes/search.tsx
@@ -6,8 +6,31 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
   const url = new URL(request.url);
   const query = url.searchParams.get('q') || '';
   const lang = (url.searchParams.get('lang') as 'en' | 'no') || 'no';
+  const type = url.searchParams.get('type');
 
   if (!query.trim()) {
+    // List mode, used by the WebMCP list-components tool. The index has one
+    // entry per documentation page, so keep only each component's overview.
+    if (type === 'component') {
+      const results = getSearchIndex()
+        .filter(
+          (item) =>
+            item.lang === lang &&
+            item.type === 'component' &&
+            item.url.endsWith('/overview'),
+        )
+        .sort((a, b) => a.title.localeCompare(b.title))
+        .map((item) => ({
+          id: item.id,
+          title: item.title,
+          description: item.description,
+          url: item.url,
+          type: item.type,
+        }));
+
+      return data({ results, query: '' });
+    }
+
     return data({ results: [], query: '' });
   }
 


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

This PR was prompted from: https://isitagentready.com/designsystemet.no
This is not something we need, so we will have to talk about benefits and cost of having this.

The prompt used:
```
Goal: Support WebMCP to expose site tools to AI agents via the browser

Issue: No WebMCP tools detected on page load

Fix: Implement the WebMCP API by calling navigator.modelContext.provideContext() with tool definitions that expose your site's key actions to AI agents. Each tool needs a name, description, inputSchema (JSON Schema), and an execute callback function.

Skill: https://isitagentready.com/.well-known/agent-skills/webmcp/SKILL.md

Docs: https://webmachinelearning.github.io/webmcp/, https://developer.chrome.com/blog/webmcp-epp
```

## Checks

- [ ] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)
