### PR TITLE
feat(popover): don't resize overscroll on scroll

### DIFF
--- a/.changeset/famous-beers-push.md
+++ b/.changeset/famous-beers-push.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-web": patch
+---
+
+**popover**: Won't resize overscroll on scroll while open

--- a/packages/web/src/popover/popover.test.ts
+++ b/packages/web/src/popover/popover.test.ts
@@ -191,6 +191,63 @@ describe('popover scrollbar interaction guard', () => {
   });
 });
 
+describe('popover overscroll sizing', () => {
+  const renderScrollable = () =>
+    render(`
+      <button popovertarget="my-popover">Open</button>
+      <div
+        id="my-popover"
+        popover="auto"
+        style="--_ds-floating: bottom; --_ds-floating-overscroll: contain"
+      >Content</div>
+      <div style="height: 3000px"></div>
+    `);
+
+  afterEach(() => window.scrollTo(0, 0));
+
+  it('keeps the max-height calculated at open when scrolling', async () => {
+    renderScrollable();
+
+    const trigger = document.querySelector('button') as HTMLButtonElement;
+    const popover = document.getElementById('my-popover') as HTMLElement;
+
+    trigger.click();
+    await tick();
+
+    const sizeAtOpen = popover.style.maxHeight;
+    expect(sizeAtOpen).toMatch(/px$/);
+
+    // Scroll so the available height below the trigger changes, then wait
+    // for autoUpdate's recompute (arrowPseudo calls setProperty on each run)
+    const setPropertySpy = vi.spyOn(popover.style, 'setProperty');
+    window.scrollTo(0, 300);
+    await vi.waitFor(() => expect(setPropertySpy).toHaveBeenCalled());
+    await new Promise((resolve) => setTimeout(resolve, 50)); // Let the full middleware pass (including size) settle
+
+    expect(popover.style.maxHeight).toBe(sizeAtOpen);
+  });
+
+  it('recalculates the max-height when the popover is re-opened', async () => {
+    renderScrollable();
+
+    const trigger = document.querySelector('button') as HTMLButtonElement;
+    const popover = document.getElementById('my-popover') as HTMLElement;
+
+    trigger.click();
+    await tick();
+    const sizeAtFirstOpen = popover.style.maxHeight;
+
+    trigger.click(); // Close
+    await tick();
+    window.scrollTo(0, 300); // Trigger is now above the viewport, so available height below it is larger
+    trigger.click();
+    await tick();
+
+    expect(popover.style.maxHeight).toMatch(/px$/);
+    expect(popover.style.maxHeight).not.toBe(sizeAtFirstOpen);
+  });
+});
+
 describe('popover duplicate toggle guard', () => {
   it('does not run positioning twice when togglePopover() is followed synchronously by a ds-toggle-source event', async () => {
     // Mirrors React's Popover, which calls togglePopover() and then dispatches

--- a/packages/web/src/popover/popover.ts
+++ b/packages/web/src/popover/popover.ts
@@ -90,6 +90,7 @@ function toggle(
 
   if (placement === 'none') return; // No need to position
 
+  let sized = false; // Only size once per open, so scrolling does not resize the popover
   const options = {
     strategy: 'absolute',
     placement,
@@ -105,6 +106,8 @@ function toggle(
         ? [
             size({
               apply({ availableHeight }) {
+                if (sized) return;
+                sized = true;
                 if (overscroll === 'fit')
                   el.style.width = `${source.offsetWidth}px`; // Use offsetWidth to include padding, matching the width of the source element
                 el.style.maxHeight = `${Math.max(50, availableHeight - padding * 2)}px`;


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

This makes it better for the end-user, since the list does not change size while scrolling outside the popover.
See video:

https://github.com/user-attachments/assets/a2b65b80-d034-454c-99ca-0c93d61d49a1

## Checks

- [ ] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)
