### PR TITLE
feat: 🚧 publish llms.txt and the twin registry on designsystemet.no

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ apps/storybook/debug-storybook.log
 CLAUDE.md
 .claude/settings.local.json
 registry
+apps/www/public/twins
+apps/www/public/llms.txt

--- a/apps/www/app/root.tsx
+++ b/apps/www/app/root.tsx
@@ -141,6 +141,9 @@ function Document({ children }: DocumentProps) {
       <head>
         <meta charSet='utf-8' />
         <meta name='viewport' content='width=device-width, initial-scale=1' />
+        {/* Machine-readable documentation index for AI agents, see /llms.txt */}
+        <link rel='alternate' type='text/plain' href='/llms.txt' />
+        <meta name='llms-txt' content='/llms.txt' />
         <Links />
         <Meta />
       </head>

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "react-router typegen && react-router build",
+    "build": "pnpm twins && react-router typegen && react-router build",
+    "twins": "node ../../scripts/generate-twins.mjs --out apps/www/public/twins --link-prefix twins/ --index apps/www/public/llms.txt && node ../../scripts/merge-authored-twins.mjs --out apps/www/public/twins",
     "dev": "cross-env NODE_ENV=development node server.js",
     "start": "node server.js",
     "types": "react-router typegen && tsc"

--- a/scripts/generate-twins.mjs
+++ b/scripts/generate-twins.mjs
@@ -33,12 +33,17 @@ const CSS_SRC = join(ROOT, 'packages/css/src');
 const PKG = JSON.parse(
   readFileSync(join(ROOT, 'packages/react/package.json'), 'utf8'),
 );
-const OUT = resolve(
-  ROOT,
-  process.argv.includes('--out')
-    ? process.argv[process.argv.indexOf('--out') + 1]
-    : 'registry',
-);
+const arg = (flag, fallback) =>
+  process.argv.includes(flag)
+    ? process.argv[process.argv.indexOf(flag) + 1]
+    : fallback;
+
+const OUT = resolve(ROOT, arg('--out', 'registry'));
+/* Where the llms.txt index is written, and the path prefix its links carry.
+ * Serving the registry at a site's /twins/ needs the index at the site root
+ * (/llms.txt per the convention) with links pointing into twins/. */
+const INDEX = arg('--index', null);
+const LINK_PREFIX = arg('--link-prefix', '');
 
 /* Docs links carry /en/: export names and the code agents write are English. */
 const docsUrl = (slug, page) =>
@@ -205,7 +210,7 @@ for (const p of patterns) {
  * commands inside fetched files as prompt injection and refuse them.
  */
 writeFileSync(
-  join(OUT, 'llms.txt'),
+  INDEX ? resolve(ROOT, INDEX) : join(OUT, 'llms.txt'),
   [
     '# Designsystemet — machine-readable index',
     '',
@@ -221,12 +226,14 @@ writeFileSync(
     '',
     ...patterns.map(
       (p) =>
-        `- [${p.name}](patterns/${p.slug}.json)${p.links?.docs ? `: ${p.links.docs}` : ''}`,
+        `- [${p.name}](${LINK_PREFIX}patterns/${p.slug}.json)${p.links?.docs ? `: ${p.links.docs}` : ''}`,
     ),
     '',
     '## Components',
     '',
-    ...written.sort().map((n) => `- [${n}](components/${n}.json)`),
+    ...written
+      .sort()
+      .map((n) => `- [${n}](${LINK_PREFIX}components/${n}.json)`),
     '',
     '## Human documentation',
     '',

--- a/scripts/merge-authored-twins.mjs
+++ b/scripts/merge-authored-twins.mjs
@@ -1,33 +1,40 @@
 /**
- * Merge the authored layer into the generated twins, verifying every quote.
+ * Merge the authored layer into the generated twins.
  *
  * The authored layer (scripts/twins-authored.json) carries the rules that exist
  * only as prose on designsystemet.no: accessibility requirements, relations
  * ("use Radio instead"), and composition rules. Each rule cites a verbatim
- * quote from the documentation. This script fetches the cited pages and checks
- * that every quote still appears there, then writes the rules into the twins
- * that `generate-twins.mjs` produced.
+ * quote from the documentation, and carries the result of its last
+ * verification. `reviewedAgainst` records the package version a human
+ * sign-off was made against.
  *
- * Two guards keep a wrong rule out of a twin:
- *   1. mechanical: a quote that no longer appears on the page marks the rule
- *      unverified, the component loses its reviewed status, and the rule lands
- *      on the review sheet (registry/REVIEW.md). This is how documentation
- *      changes surface within a day instead of silently going stale.
- *   2. human: the machine proves the sentence is on the page; it cannot prove
- *      the rule follows from the sentence. `reviewedAgainst` in the data file
- *      records the package version a human sign-off was made against.
+ * Default run is offline and deterministic (safe for site builds): it merges
+ * the rules and their stored verification state into the twins produced by
+ * generate-twins.mjs.
  *
- *   node scripts/merge-authored-twins.mjs   (run after generate-twins.mjs)
+ * `--verify` is the maintenance mode: it fetches every cited docs page,
+ * rechecks that each quote still appears there, and writes the result back
+ * into the data file. A quote that no longer verifies drops the component's
+ * reviewed status and lands on the review sheet (registry/REVIEW.md), so a
+ * documentation change surfaces on the next verify run instead of going
+ * silently stale.
+ *
+ *   node scripts/merge-authored-twins.mjs [--out <registry-dir>] [--verify]
  */
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-const REGISTRY = join(ROOT, 'registry/components');
-const AUTHORED = JSON.parse(
-  readFileSync(join(ROOT, 'scripts/twins-authored.json'), 'utf8'),
-);
+const arg = (flag, fallback) =>
+  process.argv.includes(flag)
+    ? process.argv[process.argv.indexOf(flag) + 1]
+    : fallback;
+const REGISTRY = join(ROOT, arg('--out', 'registry'), 'components');
+const VERIFY = process.argv.includes('--verify');
+
+const DATA_PATH = join(ROOT, 'scripts/twins-authored.json');
+const AUTHORED = JSON.parse(readFileSync(DATA_PATH, 'utf8'));
 
 const SUBPAGES = ['overview', 'code', 'accessibility'];
 const docsUrl = (slug, page) =>
@@ -46,9 +53,9 @@ const ENTITIES = {
 };
 
 /**
- * Both the page text and the quotes go through the same normalisation, or a
- * quote containing any transformed character could never match: typographic
- * quotes become ASCII, markdown/formatting characters are stripped, whitespace
+ * The page text and the quotes go through the same normalisation, or a quote
+ * containing any transformed character could never match: typographic quotes
+ * become ASCII, markdown/formatting characters are stripped, whitespace
  * collapses, and the space that tag-stripping strands before punctuation is
  * removed.
  */
@@ -92,33 +99,37 @@ for (const [slug, entry] of Object.entries(AUTHORED)) {
     continue;
   }
 
-  const pages = {};
-  for (const sub of SUBPAGES) pages[sub] = await pageText(docsUrl(slug, sub));
-
-  const twin = JSON.parse(readFileSync(twinPath, 'utf8'));
-  let allVerified = true;
-
-  for (const key of ['a11y', 'relations', 'composition']) {
-    for (const rule of fields[key] ?? []) {
-      const quotes = [rule.quote, rule.quote2].filter(Boolean).map(normalise);
-      const found = SUBPAGES.find((sub) =>
-        quotes.every((q) => pages[sub].includes(q)),
-      );
-      rule.verified = found !== undefined;
-      rule.sourcePage = found ? docsUrl(slug, found) : null;
-      if (!rule.verified) {
-        allVerified = false;
-        reviewRows.push([
-          name,
-          key,
-          rule.rule ?? `${rule.component}: ${rule.note ?? ''}`,
-          rule.quote ?? '',
-        ]);
+  if (VERIFY) {
+    const pages = {};
+    for (const sub of SUBPAGES) pages[sub] = await pageText(docsUrl(slug, sub));
+    for (const key of ['a11y', 'relations', 'composition']) {
+      for (const rule of fields[key] ?? []) {
+        const quotes = [rule.quote, rule.quote2].filter(Boolean).map(normalise);
+        const found = SUBPAGES.find((sub) =>
+          quotes.every((q) => pages[sub].includes(q)),
+        );
+        rule.verified = found !== undefined;
+        rule.sourcePage = found ? docsUrl(slug, found) : null;
       }
     }
   }
 
-  // Stamp after verification, so no field can claim a review the twin loses later.
+  const rules = ['a11y', 'relations', 'composition'].flatMap((k) =>
+    (fields[k] ?? []).map((r) => [k, r]),
+  );
+  const allVerified = rules.every(([, r]) => r.verified === true);
+  for (const [key, rule] of rules) {
+    if (!rule.verified) {
+      reviewRows.push([
+        name,
+        key,
+        rule.rule ?? `${rule.component}: ${rule.note ?? ''}`,
+        rule.quote ?? '',
+      ]);
+    }
+  }
+
+  const twin = JSON.parse(readFileSync(twinPath, 'utf8'));
   const method =
     allVerified && reviewedAgainst
       ? `quote-verified against the cited page; human-reviewed against ${reviewedAgainst}`
@@ -132,37 +143,39 @@ for (const [slug, entry] of Object.entries(AUTHORED)) {
       value: fields[key],
     };
   }
-
   twin.reviewedAgainst = allVerified ? (reviewedAgainst ?? null) : null;
   twin.needsReview = !(allVerified && reviewedAgainst);
   if (!twin.needsReview) reviewed += 1;
   writeFileSync(twinPath, `${JSON.stringify(twin, null, 2)}\n`, 'utf8');
   merged += 1;
-  console.log(`  merged ${name}${twin.needsReview ? '  [needs review]' : ''}`);
 }
 
-const sheet = [
-  '# Authored-layer review sheet',
-  '',
-  'Rules whose quote no longer verifies against the cited documentation page.',
-  'For each row, the question is: does the current documentation still support the rule?',
-  '',
-  ...(reviewRows.length
-    ? [
-        '| Component | Field | Rule | Quote |',
-        '|---|---|---|---|',
-        ...reviewRows.map(
-          (r) =>
-            `| ${r.map((c) => String(c).replace(/\|/g, '\\|').slice(0, 160)).join(' | ')} |`,
-        ),
-      ]
-    : [
-        'Nothing pending: every quote verifies and every component is human-reviewed.',
-      ]),
-  '',
-];
-writeFileSync(join(ROOT, 'registry/REVIEW.md'), sheet.join('\n'));
+if (VERIFY) {
+  writeFileSync(DATA_PATH, `${JSON.stringify(AUTHORED, null, 2)}\n`, 'utf8');
+  const sheet = [
+    '# Authored-layer review sheet',
+    '',
+    'Rules whose quote no longer verifies against the cited documentation page.',
+    'For each row, the question is: does the current documentation still support the rule?',
+    '',
+    ...(reviewRows.length
+      ? [
+          '| Component | Field | Rule | Quote |',
+          '|---|---|---|---|',
+          ...reviewRows.map(
+            (r) =>
+              `| ${r.map((c) => String(c).replace(/\|/g, '\\|').slice(0, 160)).join(' | ')} |`,
+          ),
+        ]
+      : [
+          'Nothing pending: every quote verifies and every component is human-reviewed.',
+        ]),
+    '',
+  ];
+  writeFileSync(join(ROOT, 'registry/REVIEW.md'), sheet.join('\n'));
+}
 
 console.log(
-  `merged ${merged} components: ${reviewed} reviewed, ${reviewRows.length} rules pending review`,
+  `merged ${merged} components: ${reviewed} reviewed, ${reviewRows.length} rules pending review` +
+    (VERIFY ? ' (verification state written back to twins-authored.json)' : ''),
 );

--- a/scripts/twins-authored.json
+++ b/scripts/twins-authored.json
@@ -7,25 +7,33 @@
         "rule": "Use role='alert' for critical messages that require immediate attention; use role='status' for less critical messages",
         "wcag": null,
         "quote": "Use `role=\"alert\"` for critical messages that require immediate attention.",
-        "quote2": "Use `role=\"status\"` for less critical messages."
+        "quote2": "Use `role=\"status\"` for less critical messages.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/alert/code"
       }
     ],
     "relations": [
       {
         "component": "ValidationMessage",
         "note": "Use for a single form field error instead of Alert",
-        "quote": "you need to notify the user about an error in a single form field, use the component's own error message"
+        "quote": "you need to notify the user about an error in a single form field, use the component's own error message",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/alert/overview"
       },
       {
         "component": "ErrorSummary",
         "note": "Use to summarise multiple errors instead of Alert",
-        "quote": "to summarise multiple errors"
+        "quote": "to summarise multiple errors",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/alert/overview"
       }
     ],
     "composition": [
       {
         "rule": "Avoid multiple alerts on the same page",
-        "quote": "Avoid multiple alerts on the same page, as it can confuse the user and make it difficult to understand what is important."
+        "quote": "Avoid multiple alerts on the same page, as it can confuse the user and make it difficult to understand what is important.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/alert/overview"
       }
     ]
   },
@@ -36,91 +44,129 @@
       {
         "rule": "Informative avatars must have an accessible name (e.g. via aria-label); if multiple avatars appear together, each name must be unique.",
         "wcag": "1.3.1",
-        "quote": "Informative avatar must have an accessible name. The accessible name can be provided using aria-label . If multiple avatars are displayed together, each name must be unique."
+        "quote": "Informative avatar must have an accessible name. The accessible name can be provided using aria-label . If multiple avatars are displayed together, each name must be unique.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar/accessibility"
       },
       {
         "rule": "Decorative avatars must be hidden from screen readers when purely decorative and not conveying information.",
         "wcag": "1.1.1",
-        "quote": "Decorative avatar must be hidden from screen readers. This applies when the avatar is purely decorative and does not convey information."
+        "quote": "Decorative avatar must be hidden from screen readers. This applies when the avatar is purely decorative and does not convey information.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar/accessibility"
       },
       {
         "rule": "A decorative avatar can be hidden when it appears alongside text that already identifies the person, e.g. inside a button.",
         "wcag": "1.1.1",
-        "quote": "Example: If an avatar is shown inside a button with the text “Ola Nordmann”, the avatar can be hidden because the name already identifies the person."
+        "quote": "Example: If an avatar is shown inside a button with the text “Ola Nordmann”, the avatar can be hidden because the name already identifies the person.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar/accessibility"
       },
       {
         "rule": "Clickable avatars must have an accessible name; avoid using just initials or the word \"Avatar\".",
         "wcag": "4.1.2",
-        "quote": "Clickable avatar must have an accessible name. The accessible name can be provided using aria-label . Example: “Profile for Ola Nordmann”. Avoid: just initials or “Avatar”."
+        "quote": "Clickable avatar must have an accessible name. The accessible name can be provided using aria-label . Example: “Profile for Ola Nordmann”. Avoid: just initials or “Avatar”.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar/accessibility"
       },
       {
         "rule": "The avatar must have an accessible name.",
         "wcag": null,
-        "quote": "Ensure the avatar has an accessible name ."
+        "quote": "Ensure the avatar has an accessible name .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar/code"
       },
       {
         "rule": "If you add an image or icon as content inside the avatar, set aria-hidden=\"true\" to avoid duplicate information.",
         "wcag": null,
-        "quote": "If you add an image or icon as content inside the avatar, make sure to set aria-hidden=\"true\" to avoid duplicate information."
+        "quote": "If you add an image or icon as content inside the avatar, make sure to set aria-hidden=\"true\" to avoid duplicate information.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar/code"
       },
       {
         "rule": "You must add an aria-label to the avatar yourself to explain who or what it represents.",
         "wcag": null,
-        "quote": "You must add an aria-label to the avatar yourself to explain who or what the avatar represents."
+        "quote": "You must add an aria-label to the avatar yourself to explain who or what the avatar represents.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar/code"
       },
       {
         "rule": "Non-text children (like an image or icon) added inside Avatar automatically receive aria-hidden=\"true\" to avoid duplicate information.",
         "wcag": null,
-        "quote": "If you add anything other than text as a child inside <Avatar> (like an image or icon), it will automatically receive aria-hidden=\"true\" to avoid duplicate information."
+        "quote": "If you add anything other than text as a child inside <Avatar> (like an image or icon), it will automatically receive aria-hidden=\"true\" to avoid duplicate information.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar/code"
       }
     ],
     "relations": [
       {
         "component": "Icon",
         "note": "Use icons or other visual symbols instead of avatar when representing anything other than a person or an entity, such as a document.",
-        "quote": "Avoid avatar when representing anything other than a person or an entity, such as a document. Use icons or other visual symbols instead"
+        "quote": "Avoid avatar when representing anything other than a person or an entity, such as a document. Use icons or other visual symbols instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar/overview"
       }
     ],
     "composition": [
       {
         "rule": "Use avatar when representing a person or an entity.",
-        "quote": "Use avatar when representing a person or an entity"
+        "quote": "Use avatar when representing a person or an entity",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar/overview"
       },
       {
         "rule": "Avoid avatar when it is used purely for decoration without function or meaning.",
-        "quote": "it is used purely for decoration without function or meaning"
+        "quote": "it is used purely for decoration without function or meaning",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar/overview"
       },
       {
         "rule": "Avatar can be round or square; use the chosen shape consistently throughout the solution.",
-        "quote": "Avatar can be round or square. Use them consistently throughout your solution."
+        "quote": "Avatar can be round or square. Use them consistently throughout your solution.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar/overview"
       },
       {
         "rule": "Avatar should help make the user interface more recognisable and easier to navigate without distracting or taking up unnecessary space.",
-        "quote": "Avatar should help make the user interface more recognisable and easier to navigate without distracting or taking up unnecessary space."
+        "quote": "Avatar should help make the user interface more recognisable and easier to navigate without distracting or taking up unnecessary space.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar/overview"
       },
       {
         "rule": "Use the same avatar shape consistently throughout the solution.",
-        "quote": "Use the same avatar shape consistently throughout the solution."
+        "quote": "Use the same avatar shape consistently throughout the solution.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar/overview"
       },
       {
         "rule": "Avatar should usually be combined with text, unless it is entirely clear who or what it represents.",
-        "quote": "The avatar should usually be combined with text, unless it is entirely clear who or what it represents."
+        "quote": "The avatar should usually be combined with text, unless it is entirely clear who or what it represents.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar/overview"
       },
       {
         "rule": "Only use an avatar when it actually adds value to the user experience, e.g. to show who authored something or who is responsible.",
-        "quote": "Only use an avatar when it actually adds value to the user experience, for example to show who authored something or who is responsible."
+        "quote": "Only use an avatar when it actually adds value to the user experience, for example to show who authored something or who is responsible.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar/overview"
       },
       {
         "rule": "Avatar should not contain text inside the component, except when using initials.",
-        "quote": "Avatar should not contain text inside the component, except when using initials."
+        "quote": "Avatar should not contain text inside the component, except when using initials.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar/overview"
       },
       {
         "rule": "Other text, such as full names, roles or organisations, should be placed outside the avatar to ensure good readability.",
-        "quote": "Other text, such as full names, roles or organisations, should be placed outside the avatar to ensure good readability."
+        "quote": "Other text, such as full names, roles or organisations, should be placed outside the avatar to ensure good readability.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar/overview"
       },
       {
         "rule": "The Avatar component should be able to be composed into other components.",
-        "quote": "The component should be able to be composed into other components."
+        "quote": "The component should be able to be composed into other components.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar/code"
       }
     ]
   },
@@ -131,35 +177,49 @@
       {
         "rule": "aria-label or aria-description can be used on the avatar stack to give screen readers context about what the stack represents",
         "wcag": null,
-        "quote": "aria-label or aria-description can be used on avatar stack to provide context to screen readers about what the stack represents."
+        "quote": "aria-label or aria-description can be used on avatar stack to provide context to screen readers about what the stack represents.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar-stack/code"
       },
       {
         "rule": "Avatars in an avatar stack can have tooltips and be links, but accessibility considerations must be kept in mind",
         "wcag": null,
-        "quote": "Avatars in avatar stack can have tooltips and be links, but be aware of accessibility considerations."
+        "quote": "Avatars in avatar stack can have tooltips and be links, but be aware of accessibility considerations.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar-stack/overview"
       },
       {
         "rule": "tabindex=\"0\" should be added to an expandable avatar stack (done automatically in React)",
         "wcag": null,
-        "quote": "tabindex=\"0\" should be added, this is automatically added with expandable in React."
+        "quote": "tabindex=\"0\" should be added, this is automatically added with expandable in React.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar-stack/code"
       }
     ],
     "composition": [
       {
         "rule": "In plain HTML, build an avatar stack with the ds-avatar-stack class on a span, containing elements with the ds-avatar class",
-        "quote": "To create an avatar stack in plain HTML, use the ds-avatar-stack class on a <span> . Inside this, place elements with the ds-avatar class."
+        "quote": "To create an avatar stack in plain HTML, use the ds-avatar-stack class on a <span> . Inside this, place elements with the ds-avatar class.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar-stack/code"
       },
       {
         "rule": "An avatar stack supports round and square avatar variants, but only one variant should be used per stack",
-        "quote": "Avatar stack supports both round and square variants, but only one variant per stack."
+        "quote": "Avatar stack supports both round and square variants, but only one variant per stack.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar-stack/overview"
       },
       {
         "rule": "An avatar stack does not support wrapping across multiple lines",
-        "quote": "Avatar stack does not support wrapping across multiple lines."
+        "quote": "Avatar stack does not support wrapping across multiple lines.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar-stack/code"
       },
       {
         "rule": "When there are more avatars than fit in the stack, a suffix can be used to show the count as text to the right of the stack",
-        "quote": "If there are more avatars than can fit in the stack, you can use suffix to indicate this as text to the right of the stack."
+        "quote": "If there are more avatars than can fit in the stack, you can use suffix to indicate this as text to the right of the stack.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/avatar-stack/code"
       }
     ]
   },
@@ -170,49 +230,67 @@
       {
         "rule": "Badge used without text inside it must have accompanying text next to it",
         "wcag": null,
-        "quote": "Badge can be used without text inside it, but it must then have accompanying text next to it."
+        "quote": "Badge can be used without text inside it, but it must then have accompanying text next to it.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/badge/overview"
       },
       {
         "rule": "Information should not be communicated through colour or shape alone",
         "wcag": null,
-        "quote": "Information should not be communicated through colour or shape alone."
+        "quote": "Information should not be communicated through colour or shape alone.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/badge/overview"
       },
       {
         "rule": "A badge showing important information must be included in the interactive element's accessible name",
         "wcag": "1.3.1",
-        "quote": "Badge that shows important information must be included in the interactive element’s accessible name."
+        "quote": "Badge that shows important information must be included in the interactive element’s accessible name.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/badge/accessibility"
       },
       {
         "rule": "A badge that changes value must be announced to screen readers",
         "wcag": "4.1.3",
-        "quote": "Badge that changes value (for example 1 → 2) must be announced to screen readers"
+        "quote": "Badge that changes value (for example 1 → 2) must be announced to screen readers",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/badge/accessibility"
       }
     ],
     "relations": [
       {
         "component": "Chip",
         "note": "Avoid Badge when interactive actions are required; use Chip instead",
-        "quote": "interactive actions are required, use chip or button instead"
+        "quote": "interactive actions are required, use chip or button instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/badge/overview"
       },
       {
         "component": "Button",
         "note": "Avoid Badge when interactive actions are required; use Button instead",
-        "quote": "interactive actions are required, use chip or button instead"
+        "quote": "interactive actions are required, use chip or button instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/badge/overview"
       },
       {
         "component": "Tag",
         "note": "Badge is not intended for text; use Tag to display words or short phrases",
-        "quote": "This component is not intended for text. If you need to display words or short phrases, use Tag instead."
+        "quote": "This component is not intended for text. If you need to display words or short phrases, use Tag instead.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/badge/overview"
       }
     ],
     "composition": [
       {
         "rule": "Badge can be placed next to other text or components",
-        "quote": "Badge can be placed next to other text or components."
+        "quote": "Badge can be placed next to other text or components.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/badge/overview"
       },
       {
         "rule": "To float a badge, the ds-badge--position class must be used on a wrapper around the element the badge is placed over",
-        "quote": "If you want it to be floating, the class ds-badge--position must be used on a wrapper around the element that the badge is to be placed over."
+        "quote": "If you want it to be floating, the class ds-badge--position must be used on a wrapper around the element that the badge is to be placed over.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/badge/code"
       }
     ]
   },
@@ -227,74 +305,106 @@
       {
         "rule": "Breadcrumbs must be handled so that the trail does not become too long on small screens; if it becomes too long, it should be replaced with a back link.",
         "wcag": "1.4.10",
-        "quote": "Breadcrumbs must be handled so that it does not become too long on small screens. Check that the breadcrumb trail does not extend beyond the visible area at a narrow viewport or high zoom. If the trail becomes too long, it should be replaced with a back link."
+        "quote": "Breadcrumbs must be handled so that it does not become too long on small screens. Check that the breadcrumb trail does not extend beyond the visible area at a narrow viewport or high zoom. If the trail becomes too long, it should be replaced with a back link.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/breadcrumbs/accessibility"
       },
       {
         "rule": "Skip link must bypass breadcrumbs and go directly to the main content, so users can skip repeated content without navigating through the breadcrumbs.",
         "wcag": "2.4.1",
-        "quote": "Skip link must bypass breadcrumbs and go directly to the main content. Users should be able to skip repeated content without navigating through the breadcrumbs."
+        "quote": "Skip link must bypass breadcrumbs and go directly to the main content. Users should be able to skip repeated content without navigating through the breadcrumbs.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/breadcrumbs/accessibility"
       },
       {
         "rule": "Link text in breadcrumbs must be understandable; avoid generic names or unclear abbreviations.",
         "wcag": "2.4.4",
-        "quote": "The link text in breadcrumbs must be understandable. Avoid generic names or unclear abbreviations."
+        "quote": "The link text in breadcrumbs must be understandable. Avoid generic names or unclear abbreviations.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/breadcrumbs/accessibility"
       },
       {
         "rule": "Breadcrumbs must be consistently placed and structured across pages, appearing in the same location and following the same order everywhere they are used.",
         "wcag": "3.2.3",
-        "quote": "Breadcrumbs must be consistently placed and structured across pages. The breadcrumb trail should appear in the same location and follow the same order on all pages where it is used."
+        "quote": "Breadcrumbs must be consistently placed and structured across pages. The breadcrumb trail should appear in the same location and follow the same order on all pages where it is used.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/breadcrumbs/accessibility"
       },
       {
         "rule": "Breadcrumbs must not be the only way to navigate; users should have multiple ways to navigate to content.",
         "wcag": "2.4.5",
-        "quote": "Breadcrumbs must not be the only way to navigate. Users should have multiple ways to navigate to content."
+        "quote": "Breadcrumbs must not be the only way to navigate. Users should have multiple ways to navigate to content.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/breadcrumbs/accessibility"
       },
       {
         "rule": "The last link should correspond to the current page and be coded as a link with aria-current=\"page\" so screen readers get correct information without other users mistaking it for a clickable link.",
         "wcag": null,
-        "quote": "The last link should correspond to the current page. It looks like regular text, but is coded as a link with aria-current=\"page\" . This way, screen readers get the correct information about which page the user is on, without other users mistakenly perceiving it as a clickable link."
+        "quote": "The last link should correspond to the current page. It looks like regular text, but is coded as a link with aria-current=\"page\" . This way, screen readers get the correct information about which page the user is on, without other users mistakenly perceiving it as a clickable link.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/breadcrumbs/accessibility"
       }
     ],
     "composition": [
       {
         "rule": "Use breadcrumbs when users may want to navigate back to previous levels.",
-        "quote": "Use breadcrumbs when users may want to navigate back to previous levels"
+        "quote": "Use breadcrumbs when users may want to navigate back to previous levels",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/breadcrumbs/overview"
       },
       {
         "rule": "Use breadcrumbs when users need help understanding where they are in the structure.",
-        "quote": "users need help understanding where they are in the structure"
+        "quote": "users need help understanding where they are in the structure",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/breadcrumbs/overview"
       },
       {
         "rule": "Avoid breadcrumbs when the navigation is linear, for example across steps in a workflow or a form.",
-        "quote": "Avoid breadcrumbs when the navigation is linear, for example across steps in a workflow or a form"
+        "quote": "Avoid breadcrumbs when the navigation is linear, for example across steps in a workflow or a form",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/breadcrumbs/overview"
       },
       {
         "rule": "On mobile or with a long trail, show only a link to the nearest parent page",
-        "quote": "On mobile, or when the breadcrumb trail becomes long, you can show only a link to the nearest parent page."
+        "quote": "On mobile, or when the breadcrumb trail becomes long, you can show only a link to the nearest parent page.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/breadcrumbs/overview"
       },
       {
         "rule": "Be consistent: use either the back-link variant or the full breadcrumb trail, not both",
-        "quote": "Be consistent in your approach, and use either this variant or the full breadcrumb trail, not both."
+        "quote": "Be consistent in your approach, and use either this variant or the full breadcrumb trail, not both.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/breadcrumbs/overview"
       },
       {
         "rule": "Breadcrumbs are only needed when there are three or more levels on a website.",
-        "quote": "Breadcrumbs are only needed when there are three or more levels on a website."
+        "quote": "Breadcrumbs are only needed when there are three or more levels on a website.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/breadcrumbs/overview"
       },
       {
         "rule": "Breadcrumbs should always be placed at the top left of the page when using left-to-right text.",
-        "quote": "Breadcrumbs should always be placed at the top left of the page when using left-to-right text."
+        "quote": "Breadcrumbs should always be placed at the top left of the page when using left-to-right text.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/breadcrumbs/overview"
       },
       {
         "rule": "Breadcrumbs should appear below the menu and main navigation, but above the page title.",
-        "quote": "They should appear below the menu and main navigation, but above the page title."
+        "quote": "They should appear below the menu and main navigation, but above the page title.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/breadcrumbs/overview"
       },
       {
         "rule": "For deep navigation, the component can be configured to show only the first and last parts of the trail on mobile, automatically on screens narrower than 650px.",
-        "quote": "For deep navigation, you can configure the component to show only the first and last parts of the trail on mobile. This can happen automatically on screens narrower than 650px, where only the link one level down is shown."
+        "quote": "For deep navigation, you can configure the component to show only the first and last parts of the trail on mobile. This can happen automatically on screens narrower than 650px, where only the link one level down is shown.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/breadcrumbs/overview"
       },
       {
         "rule": "The text should match the page headings or navigation labels so that each level is easy to recognise.",
-        "quote": "The text should match the page headings or navigation labels so that each level is easy to recognise."
+        "quote": "The text should match the page headings or navigation labels so that each level is easy to recognise.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/breadcrumbs/overview"
       }
     ]
   },
@@ -305,25 +415,33 @@
       {
         "rule": "An icon-only button needs an accessible label",
         "wcag": null,
-        "quote": "When the button has no text, you must add an accessible label describing what it does."
+        "quote": "When the button has no text, you must add an accessible label describing what it does.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/button/overview"
       },
       {
         "rule": "An icon next to text must be hidden from screen readers",
         "wcag": null,
-        "quote": "When using an icon together with text, the icon should have `aria-hidden` so screen readers don't read unnecessary content."
+        "quote": "When using an icon together with text, the icon should have `aria-hidden` so screen readers don't read unnecessary content.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/button/overview"
       }
     ],
     "relations": [
       {
         "component": "Link",
         "note": "Use Link for navigation",
-        "quote": "navigating to other pages or out of the service, use Link instead"
+        "quote": "navigating to other pages or out of the service, use Link instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/button/overview"
       }
     ],
     "composition": [
       {
         "rule": "Only one primary button per page",
-        "quote": "There should be only one primary button per page."
+        "quote": "There should be only one primary button per page.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/button/overview"
       }
     ]
   },
@@ -334,72 +452,100 @@
       {
         "rule": "Link text in a card must clearly describe where the link goes; avoid generic text like 'Read more'",
         "wcag": "2.4.4",
-        "quote": "Link text in card must clearly describe where the link goes. Use a clear title or link text that explains the destination. Avoid generic text such as “Read more” or “Click here”."
+        "quote": "Link text in card must clearly describe where the link goes. Use a clear title or link text that explains the destination. Avoid generic text such as “Read more” or “Click here”.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/card/accessibility"
       },
       {
         "rule": "The accessible name must match the visible text, even if overridden with aria-label or similar",
         "wcag": "2.5.3",
-        "quote": "The accessible name must match the visible text. If you use aria-label or other techniques that override the accessible name, it must still match the visible text."
+        "quote": "The accessible name must match the visible text. If you use aria-label or other techniques that override the accessible name, it must still match the visible text.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/card/accessibility"
       },
       {
         "rule": "Images in link cards must be decorative, with an empty alt attribute",
         "wcag": "1.1.1",
-        "quote": "Images in link cards must be decorative. If the entire card is a link with an image, the image must not be informative and should have an empty alt attribute."
+        "quote": "Images in link cards must be decorative. If the entire card is a link with an image, the image must not be informative and should have an empty alt attribute.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/card/accessibility"
       },
       {
         "rule": "Headings in a card must use the correct level relative to the rest of the page; do not skip heading levels",
         "wcag": "1.3.1",
-        "quote": "Headings in card must use the correct level relative to the rest of the page. Do not skip heading levels (for example from h1 to h3 )."
+        "quote": "Headings in card must use the correct level relative to the rest of the page. Do not skip heading levels (for example from h1 to h3 ).",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/card/accessibility"
       },
       {
         "rule": "When Card renders as a button, its content loses all semantics, so this must be used carefully",
         "wcag": null,
-        "quote": "When the card is a button, the content inside loses all semantics, so use this carefully."
+        "quote": "When the card is a button, the content inside loses all semantics, so use this carefully.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/card/overview"
       },
       {
         "rule": "Use <a> as the outermost element so screen readers read the whole card as one continuous link",
         "wcag": null,
-        "quote": "The entire card can be used as a link by using <a> as the outermost element. This is useful when you want all text and content in Card to be read by screen readers as one continuous link."
+        "quote": "The entire card can be used as a link by using <a> as the outermost element. This is useful when you want all text and content in Card to be read by screen readers as one continuous link.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/card/code"
       },
       {
         "rule": "Use data-clickdelegatefor to make a card with multiple interactive elements fully clickable while retaining the semantics of those elements",
         "wcag": null,
-        "quote": "If you have a card with multiple interactive elements, such as links or buttons, you can use data-clickdelegatefor to make the entire card clickable while retaining the semantics of the interactive elements."
+        "quote": "If you have a card with multiple interactive elements, such as links or buttons, you can use data-clickdelegatefor to make the entire card clickable while retaining the semantics of the interactive elements.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/card/code"
       },
       {
         "rule": "Prefer placing a link in the card's title over making the whole card a link, since screen reader users get a better experience",
         "wcag": null,
-        "quote": "If the card should link to another page, you can place a link in the card's title. The entire card then becomes clickable, but screen reader users get a better experience than if the whole card were a link (adrianroselli.com) ."
+        "quote": "If the card should link to another page, you can place a link in the card's title. The entire card then becomes clickable, but screen reader users get a better experience than if the whole card were a link (adrianroselli.com) .",
+        "verified": false,
+        "sourcePage": null
       },
       {
         "rule": "The keyboard focus ring should surround only the link text, not the entire card, so it matches the focus area for assistive technology users",
         "wcag": null,
-        "quote": "Note that with keyboard navigation, the focus ring only surrounds the text in the link, not the entire card. This is because link cards can also contain multiple clickable elements (secondary actions), and it is less confusing for users of assistive technology, such as voice control or screen readers, if the link text matches the focus area."
+        "quote": "Note that with keyboard navigation, the focus ring only surrounds the text in the link, not the entire card. This is because link cards can also contain multiple clickable elements (secondary actions), and it is less confusing for users of assistive technology, such as voice control or screen readers, if the link text matches the focus area.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/card/code"
       }
     ],
     "relations": [
       {
         "component": "Alert",
         "note": "Use Alert instead of Card for presenting important messages",
-        "quote": "important messages should be presented as alerts (use Alert instead)"
+        "quote": "important messages should be presented as alerts (use Alert instead)",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/card/overview"
       }
     ],
     "composition": [
       {
         "rule": "Card can be divided into sections separated by dividers, which may include images or video extending to the edge",
-        "quote": "You can divide the card into sections. These get dividers between them and may include images or video that extend to the edge."
+        "quote": "You can divide the card into sections. These get dividers between them and may include images or video that extend to the edge.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/card/overview"
       },
       {
         "rule": "When using ds-card__block to create sections, all content must be placed inside block elements rather than directly in Card",
-        "quote": "If you need sections in the card, use ds-card__block if you want to divide the card with dividers or add images or video that extend to the edge. Note that when you use ds-card__block , all content must be placed inside elements with ds-card__block - not placed directly in Card ."
+        "quote": "If you need sections in the card, use ds-card__block if you want to divide the card with dividers or add images or video that extend to the edge. Note that when you use ds-card__block , all content must be placed inside elements with ds-card__block - not placed directly in Card .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/card/code"
       },
       {
         "rule": "Card blocks can be arranged horizontally by switching to flex or grid display",
-        "quote": "You can switch between display: flex and display: grid to place Card.Block next to each other:"
+        "quote": "You can switch between display: flex and display: grid to place Card.Block next to each other:",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/card/code"
       },
       {
         "rule": "data-clickdelegatefor is automatically added when Card finds a link inside its heading, for cards with text or media that navigate to another page",
-        "quote": "When Card finds an <a> inside the heading element, data-clickdelegatefor will automatically be added to the card. This is useful when Card contains text or media and should navigate to another page."
+        "quote": "When Card finds an <a> inside the heading element, data-clickdelegatefor will automatically be added to the card. This is useful when Card contains text or media and should navigate to another page.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/card/code"
       }
     ]
   },
@@ -410,122 +556,172 @@
       {
         "rule": "Users must be able to move focus to Checkbox with Tab",
         "wcag": null,
-        "quote": "It must be possible to move focus to the Checkbox by pressing Tab on the keyboard."
+        "quote": "It must be possible to move focus to the Checkbox by pressing Tab on the keyboard.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/accessibility"
       },
       {
         "rule": "Users must be able to check and uncheck Checkbox with Space",
         "wcag": null,
-        "quote": "It must also be possible to check and uncheck it by pressing Space ."
+        "quote": "It must also be possible to check and uncheck it by pressing Space .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/accessibility"
       },
       {
         "rule": "A Checkbox must always have an accessible name",
         "wcag": null,
-        "quote": "A Checkbox must always have an accessible name."
+        "quote": "A Checkbox must always have an accessible name.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/accessibility"
       },
       {
         "rule": "In special cases, aria-label or aria-labelledby may be used instead of a visible label",
         "wcag": null,
-        "quote": "In special cases, it may make sense to omit the <label> and instead use aria-label or aria-labelledby ."
+        "quote": "In special cases, it may make sense to omit the <label> and instead use aria-label or aria-labelledby .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/accessibility"
       },
       {
         "rule": "Avoid using the disabled attribute where possible, for accessibility reasons",
         "wcag": null,
-        "quote": "Avoid using if possible for accessibility purposes"
+        "quote": "Avoid using if possible for accessibility purposes",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/code"
       },
       {
         "rule": "Should avoid disabling checkbox because the disabled state can be hard to perceive and some users won't understand why an option isn't clickable",
         "wcag": null,
-        "quote": "We should avoid disabling ( disabled ) checkbox, because it can be difficult to perceive. Some users will not understand what the option means or why it is not clickable."
+        "quote": "We should avoid disabling ( disabled ) checkbox, because it can be difficult to perceive. Some users will not understand what the option means or why it is not clickable.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/overview"
       },
       {
         "rule": "Better to remove irrelevant checkbox options than to disable them",
         "wcag": null,
-        "quote": "If a checkbox or group of checkbox options is not relevant, it is usually better to remove them rather than disable them."
+        "quote": "If a checkbox or group of checkbox options is not relevant, it is usually better to remove them rather than disable them.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/overview"
       },
       {
         "rule": "If possible, explain to users why options are unavailable",
         "wcag": null,
-        "quote": "If possible, give users an explanation of why options are unavailable."
+        "quote": "If possible, give users an explanation of why options are unavailable.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/overview"
       },
       {
         "rule": "Avoid using readOnly whenever possible because read-only fields can confuse users who don't understand why they can't change the content",
         "wcag": null,
-        "quote": "We avoid using readOnly whenever possible because such fields can be confusing. Not all users will understand why they cannot change the content."
+        "quote": "We avoid using readOnly whenever possible because such fields can be confusing. Not all users will understand why they cannot change the content.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/overview"
       },
       {
         "rule": "Read-only checkbox fields remain part of the tab order and their value is still included when the form is submitted",
         "wcag": null,
-        "quote": "Although they cannot be changed, fields with readOnly are still part of the tab order, and the information is included when the form is submitted."
+        "quote": "Although they cannot be changed, fields with readOnly are still part of the tab order, and the information is included when the form is submitted.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/overview"
       },
       {
         "rule": "A read-only checkbox stops onClick and onChange but remains focusable",
         "wcag": null,
-        "quote": "If you set readonly on checkbox we ensure that it behaves as if it has read-only access by stopping onClick and onChange . The user will still be able to focus on the element."
+        "quote": "If you set readonly on checkbox we ensure that it behaves as if it has read-only access by stopping onClick and onChange . The user will still be able to focus on the element.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/code"
       },
       {
         "rule": "Horizontal checkbox lists can be challenging for users who need to enlarge text",
         "wcag": null,
-        "quote": "For users who need to enlarge the text, horizontal lists can be challenging."
+        "quote": "For users who need to enlarge the text, horizontal lists can be challenging.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/overview"
       }
     ],
     "relations": [
       {
         "component": "Radio",
         "note": "Use Radio instead of Checkbox when the user should choose only one option",
-        "quote": "the user should choose only one option; use a radio instead"
+        "quote": "the user should choose only one option; use a radio instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/overview"
       },
       {
         "component": "Select",
         "note": "Use Select (or Suggestion) instead of Checkbox when the user must choose from more than seven options",
-        "quote": "the user must choose from more than seven options; use a select or suggestion instead"
+        "quote": "the user must choose from more than seven options; use a select or suggestion instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/overview"
       },
       {
         "component": "Suggestion",
         "note": "Use Suggestion (or Select) instead of Checkbox when the user must choose from more than seven options",
-        "quote": "the user must choose from more than seven options; use a select or suggestion instead"
+        "quote": "the user must choose from more than seven options; use a select or suggestion instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/overview"
       },
       {
         "component": "Switch",
         "note": "Use Switch instead of Checkbox when something should be turned on or off",
-        "quote": "something should be turned on or off; use a switch instead"
+        "quote": "something should be turned on or off; use a switch instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/overview"
       }
     ],
     "composition": [
       {
         "rule": "A consent checkbox must always require an active action and must never be preselected, to ensure consent is voluntary",
-        "quote": "A checkbox for consent must always require an active action, and you should never preselect the box. This ensures that the consent is given voluntarily."
+        "quote": "A checkbox for consent must always require an active action, and you should never preselect the box. This ensures that the consent is given voluntarily.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/overview"
       },
       {
         "rule": "Checkbox is most often used in groups where the user can select more than one option",
-        "quote": "Most of the time, checkbox is used in groups where the user can select more than one option."
+        "quote": "Most of the time, checkbox is used in groups where the user can select more than one option.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/overview"
       },
       {
         "rule": "When checkboxes are grouped, the error message should be shown collectively for the whole group",
-        "quote": "When checkboxes are used in groups, the error message should be shown collectively for the entire group."
+        "quote": "When checkboxes are used in groups, the error message should be shown collectively for the entire group.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/overview"
       },
       {
         "rule": "It may be appropriate to emphasise options with a larger click area (outline) around the checkbox in some cases",
-        "quote": "In some cases, it may be appropriate to emphasise options by using a larger click area around the checkbox."
+        "quote": "In some cases, it may be appropriate to emphasise options by using a larger click area around the checkbox.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/overview"
       },
       {
         "rule": "Use fieldset for grouping multiple checkbox choices",
-        "quote": "Use fieldset for grouping multiple choices."
+        "quote": "Use fieldset for grouping multiple choices.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/code"
       },
       {
         "rule": "Checkbox is a composite component built from field, label, validation message, and input",
-        "quote": "Checkbox is a composite component that uses field , label , validation message , and input to create a checkbox."
+        "quote": "Checkbox is a composite component that uses field , label , validation message , and input to create a checkbox.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/code"
       },
       {
         "rule": "Use useCheckboxGroup to create a parent checkbox that can select or clear all options in the group",
-        "quote": "Use useCheckboxGroup to create a parent checkbox that can select or clear all options in the group."
+        "quote": "Use useCheckboxGroup to create a parent checkbox that can select or clear all options in the group.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/code"
       },
       {
         "rule": "Sort answer options alphabetically unless there is a good reason to do otherwise",
-        "quote": "Sort the answer options alphabetically unless there is a good reason to do otherwise."
+        "quote": "Sort the answer options alphabetically unless there is a good reason to do otherwise.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/overview"
       },
       {
         "rule": "Response options should preferably be placed vertically for easier scanning and reading",
-        "quote": "Preferably place the response options vertically. This makes it easier to scan the list and read the options."
+        "quote": "Preferably place the response options vertically. This makes it easier to scan the list and read the options.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/checkbox/overview"
       }
     ]
   },
@@ -540,100 +736,142 @@
       {
         "rule": "Details is based on the native HTML <details> element, which provides good accessibility and semantics without extra JavaScript.",
         "wcag": null,
-        "quote": "The name comes from the built-in HTML <details> element, which provides good accessibility and semantics without additional JavaScript."
+        "quote": "The name comes from the built-in HTML <details> element, which provides good accessibility and semantics without additional JavaScript.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/details/overview"
       },
       {
         "rule": "Large amounts of text can be demanding for users, so details lets them decide what is relevant to read.",
         "wcag": null,
-        "quote": "Large amounts of text can be demanding for many users. Details allows users to decide for themselves what is relevant to read."
+        "quote": "Large amounts of text can be demanding for many users. Details allows users to decide for themselves what is relevant to read.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/details/overview"
       },
       {
         "rule": "Hidden content risks going unnoticed by users entirely.",
         "wcag": null,
-        "quote": "When content is hidden, there is a risk that users will not notice it at all."
+        "quote": "When content is hidden, there is a risk that users will not notice it at all.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/details/overview"
       },
       {
         "rule": "Nesting details makes it hard for users to understand what is open and closed.",
         "wcag": null,
-        "quote": "Nested lists can make it difficult for users to understand what is open and what is closed, especially when several levels can be expanded at once."
+        "quote": "Nested lists can make it difficult for users to understand what is open and what is closed, especially when several levels can be expanded at once.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/details/overview"
       },
       {
         "rule": "Headings strongly affect whether users find, read, and can access the content.",
         "wcag": null,
-        "quote": "Headings can strongly influence whether users find what they need, whether the content is read, and whether it is considered accessible to all."
+        "quote": "Headings can strongly influence whether users find what they need, whether the content is read, and whether it is considered accessible to all.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/details/overview"
       },
       {
         "rule": "Details is implemented as a native <details> element.",
         "wcag": null,
-        "quote": "Details is a native <details> element."
+        "quote": "Details is a native <details> element.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/details/code"
       },
       {
         "rule": "A Firefox/Android Talkback bug is polyfilled so state and role are announced correctly.",
         "wcag": null,
-        "quote": "We polyfill a bug in Firefox when used with Android Talkback screen reader to announce state and role correctly."
+        "quote": "We polyfill a bug in Firefox when used with Android Talkback screen reader to announce state and role correctly.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/details/code"
       },
       {
         "rule": "The component builds on the semantic HTML elements <details> and <summary>.",
         "wcag": null,
-        "quote": "For the Details component, we use u-details (github.io) , which builds on the semantic HTML elements <details> and <summary> ."
+        "quote": "For the Details component, we use u-details (github.io) , which builds on the semantic HTML elements <details> and <summary> .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/details/accessibility"
       },
       {
         "rule": "Space or Enter opens or closes the Details.",
         "wcag": null,
-        "quote": "Press Space or Enter to open or close the Details."
+        "quote": "Press Space or Enter to open or close the Details.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/details/accessibility"
       }
     ],
     "relations": [
       {
         "component": "ErrorSummary",
         "note": "Use error summary instead of details when you need to summarise error messages.",
-        "quote": "Avoid details when you need to show important content that everyone should see you need to display an action button you need to summarise error messages, use error summary instead"
+        "quote": "Avoid details when you need to show important content that everyone should see you need to display an action button you need to summarise error messages, use error summary instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/details/overview"
       }
     ],
     "composition": [
       {
         "rule": "Use details for information relevant only to some users, for examples/FAQs, and where reading is optional.",
-        "quote": "Use details when you want to provide information that is only relevant to some users you want to give examples or answer frequently asked questions it should be up to the user whether they choose to read the content"
+        "quote": "Use details when you want to provide information that is only relevant to some users you want to give examples or answer frequently asked questions it should be up to the user whether they choose to read the content",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/details/overview"
       },
       {
         "rule": "Details can be placed inside a card to give the content a framed appearance.",
-        "quote": "You can use details inside a card to give the content a framed appearance."
+        "quote": "You can use details inside a card to give the content a framed appearance.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/details/overview"
       },
       {
         "rule": "Details inside a card gives the content a framed appearance; works well when it doesn't span the full page width or holds a single line",
-        "quote": "You can use details inside a card to give the content a framed appearance. This works well when details does not span the full width of the page, or when it contains only a single line."
+        "quote": "You can use details inside a card to give the content a framed appearance. This works well when details does not span the full width of the page, or when it contains only a single line.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/details/overview"
       },
       {
         "rule": "Avoid using details just to make a page look tidier.",
-        "quote": "However, you should not use details to hide content just to make the page look tidier."
+        "quote": "However, you should not use details to hide content just to make the page look tidier.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/details/overview"
       },
       {
         "rule": "Do not nest one details inside another.",
-        "quote": "Do not place one details inside another."
+        "quote": "Do not place one details inside another.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/details/overview"
       },
       {
         "rule": "The heading must clearly describe what the details contains.",
-        "quote": "Make sure the heading clearly describes what the details contains."
+        "quote": "Make sure the heading clearly describes what the details contains.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/details/overview"
       },
       {
         "rule": "Vague headings like \"Show more\" or \"Read more here\" are not good enough.",
-        "quote": "“Show more” or “Read more here” are not good enough headings."
+        "quote": "“Show more” or “Read more here” are not good enough headings.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/details/overview"
       },
       {
         "rule": "When there are many expandable sections, add a main or thematic heading above the whole list.",
-        "quote": "If you have many expandable sections, consider adding a main heading or thematic heading above the entire list."
+        "quote": "If you have many expandable sections, consider adding a main heading or thematic heading above the entire list.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/details/overview"
       },
       {
         "rule": "Keep the content inside details short so it relates easily to the heading.",
-        "quote": "Keep the content inside details short so it is easy to relate to the heading."
+        "quote": "Keep the content inside details short so it is easy to relate to the heading.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/details/overview"
       },
       {
         "rule": "If content is too long, split it into several details.",
-        "quote": "If the content is too long, divide it into several details."
+        "quote": "If the content is too long, divide it into several details.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/details/overview"
       },
       {
         "rule": "For very large amounts of content, prefer separate pages over details.",
-        "quote": "For very large amounts of content, it may be better to create separate pages."
+        "quote": "For very large amounts of content, it may be better to create separate pages.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/details/overview"
       }
     ]
   },
@@ -644,85 +882,119 @@
       {
         "rule": "Make sure elements receiving focus are not hidden behind the dialog",
         "wcag": null,
-        "quote": "Note: Make sure that elements receiving focus are not hidden behind the dialog ."
+        "quote": "Note: Make sure that elements receiving focus are not hidden behind the dialog .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dialog/overview"
       },
       {
         "rule": "Add aria-haspopup=\"dialog\" to the element that opens the dialog so screen reader users know it will open a dialog",
         "wcag": null,
-        "quote": "The attribute aria-haspopup=\"dialog\" should be added to the element that opens the dialog to make it clear to screen reader users that it will open a dialog."
+        "quote": "The attribute aria-haspopup=\"dialog\" should be added to the element that opens the dialog to make it clear to screen reader users that it will open a dialog.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dialog/code"
       },
       {
         "rule": "Always provide a visible and simple way to close a dialog",
         "wcag": null,
-        "quote": "Always ensure that users have a visible and simple way to close a dialog."
+        "quote": "Always ensure that users have a visible and simple way to close a dialog.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dialog/overview"
       },
       {
         "rule": "The close button (X) should stay visible even when the dialog's content requires scrolling",
         "wcag": null,
-        "quote": "The most common approach is a close button (X) in the top right corner. It should remain visible even when the dialog contains a lot of content and the user needs to scroll."
+        "quote": "The most common approach is a close button (X) in the top right corner. It should remain visible even when the dialog contains a lot of content and the user needs to scroll.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dialog/overview"
       },
       {
         "rule": "In non-modal dialogs, elements receiving keyboard focus must not end up hidden behind the dialog",
         "wcag": "2.4.11",
-        "quote": "When using non-modal dialogs, you must ensure that elements receiving focus through keyboard navigation do not end up behind the dialog and become hidden. See criteria 2.4.11 (w3.org) (AA) and 2.4.12 (w3.org) (AAA)."
+        "quote": "When using non-modal dialogs, you must ensure that elements receiving focus through keyboard navigation do not end up behind the dialog and become hidden. See criteria 2.4.11 (w3.org) (AA) and 2.4.12 (w3.org) (AAA).",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dialog/accessibility"
       },
       {
         "rule": "Focusable elements must never be completely covered by the dialog during Tab navigation",
         "wcag": null,
-        "quote": "Ensure that focusable elements are never completely covered by the dialog when users navigate the page using the Tab key."
+        "quote": "Ensure that focusable elements are never completely covered by the dialog when users navigate the page using the Tab key.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dialog/accessibility"
       },
       {
         "rule": "Focus order must be logical and focus must always be visible",
         "wcag": null,
-        "quote": "Ensure that the focus order is logical and that focus is always visible, so users navigating with a keyboard or screen reader can understand where focus is located."
+        "quote": "Ensure that the focus order is logical and that focus is always visible, so users navigating with a keyboard or screen reader can understand where focus is located.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dialog/accessibility"
       },
       {
         "rule": "Esc closes the dialog and returns focus to the trigger",
         "wcag": null,
-        "quote": "Esc closes the dialog (focus returns to the trigger)"
+        "quote": "Esc closes the dialog (focus returns to the trigger)",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dialog/accessibility"
       }
     ],
     "relations": [
       {
         "component": "Alert",
         "note": "Use alert instead of a modal dialog when notifying users of something that does not require action",
-        "quote": "you need to notify users about something that does not require action. Use alert or a non-modal dialog instead"
+        "quote": "you need to notify users about something that does not require action. Use alert or a non-modal dialog instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dialog/overview"
       },
       {
         "component": "Popover",
         "note": "Use popover instead of a modal dialog for short, optional information",
-        "quote": "you want to provide short, optional information, use popover"
+        "quote": "you want to provide short, optional information, use popover",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dialog/overview"
       },
       {
         "component": "System notifications pattern",
         "note": "Consult the system notifications pattern for guidance on when a modal dialog should be used",
-        "quote": "See also the system notifications pattern for more guidance on when a modal dialog should be used."
+        "quote": "See also the system notifications pattern for more guidance on when a modal dialog should be used.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dialog/overview"
       }
     ],
     "composition": [
       {
         "rule": "Using the placement prop, a dialog can behave like a drawer positioned from a given side",
-        "quote": "Using placement , dialog can behave like a so-called “drawer” from the position you specify."
+        "quote": "Using placement , dialog can behave like a so-called “drawer” from the position you specify.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dialog/overview"
       },
       {
         "rule": "Use multiple ds-dialog__block elements to divide the dialog with dividers into separate areas",
-        "quote": "Use multiple ds-dialog__block if you want to divide the dialog with dividers into, for example, a top and bottom area."
+        "quote": "Use multiple ds-dialog__block if you want to divide the dialog with dividers into, for example, a top and bottom area.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dialog/code"
       },
       {
         "rule": "Content cannot be placed directly in the dialog if ds-dialog__block is used; all content must then be inside a block",
-        "quote": "Note that content cannot be placed directly in dialog if you use ds-dialog__block ; then all content should be inside one of the dialog's ds-dialog__block sections."
+        "quote": "Note that content cannot be placed directly in dialog if you use ds-dialog__block ; then all content should be inside one of the dialog's ds-dialog__block sections.",
+        "verified": false,
+        "sourcePage": null
       },
       {
         "rule": "A close button that is the dialog's first direct child floats to the top right",
-        "quote": "If the button is a direct child of the dialog and the first element, it will float to the top right."
+        "quote": "If the button is a direct child of the dialog and the first element, it will float to the top right.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dialog/code"
       },
       {
         "rule": "Use Dialog.TriggerContext together with Dialog.Trigger so the dialog and trigger can communicate without id/commandfor",
-        "quote": "Use Dialog.TriggerContext and Dialog.Trigger together, so Dialog can communicate without having to use id and commandfor ."
+        "quote": "Use Dialog.TriggerContext and Dialog.Trigger together, so Dialog can communicate without having to use id and commandfor .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dialog/code"
       },
       {
         "rule": "Use buttons in the dialog to give users a clear path forward",
-        "quote": "Use buttons to give users a clear path forward."
+        "quote": "Use buttons to give users a clear path forward.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dialog/overview"
       }
     ]
   },
@@ -733,48 +1005,68 @@
       {
         "rule": "Apply aria-hidden=\"true\" to the divider to avoid noise for screen reader users.",
         "wcag": null,
-        "quote": "Apply aria-hidden=\"true\" to avoid noise in screen readers."
+        "quote": "Apply aria-hidden=\"true\" to avoid noise in screen readers.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/divider/code"
       },
       {
         "rule": "Divider is a purely visual element and is not announced by screen readers.",
         "wcag": null,
-        "quote": "Divider is a purely visual element, and it is not announced by screen readers."
+        "quote": "Divider is a purely visual element, and it is not announced by screen readers.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/divider/accessibility"
       },
       {
         "rule": "Avoid using a divider solely for visual effect without functional meaning.",
         "wcag": null,
-        "quote": "However, avoid using a divider solely for visual effect without functional meaning."
+        "quote": "However, avoid using a divider solely for visual effect without functional meaning.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/divider/accessibility"
       },
       {
         "rule": "Since a divider represents a thematic separation, you must also use elements a screen reader can interpret to communicate that separation accessibly.",
         "wcag": null,
-        "quote": "A divider represents a thematic separation of content. To communicate this separation in an accessible way, you must also use elements that a screen reader can interpret."
+        "quote": "A divider represents a thematic separation of content. To communicate this separation in an accessible way, you must also use elements that a screen reader can interpret.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/divider/accessibility"
       }
     ],
     "composition": [
       {
         "rule": "Use divider when you want a clear separation between sections of content and whitespace alone does not provide sufficient separation.",
-        "quote": "Use divider when you want to create a clear separation between sections of content whitespace alone does not provide sufficient separation"
+        "quote": "Use divider when you want to create a clear separation between sections of content whitespace alone does not provide sufficient separation",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/divider/overview"
       },
       {
         "rule": "Avoid divider when natural spacing or other visual elements already provide enough separation, since too many dividers create visual clutter.",
-        "quote": "Avoid divider when natural spacing or other visual elements provide enough separation too many divider elements create a cluttered visual appearance"
+        "quote": "Avoid divider when natural spacing or other visual elements provide enough separation too many divider elements create a cluttered visual appearance",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/divider/overview"
       },
       {
         "rule": "Divider is used to break content into smaller sections for readability, and can also separate related content that still benefits from visual distinction.",
-        "quote": "Divider is used to break content into smaller sections, making it easier to read and understand. It can also be used to separate content that is related but still benefits from a visual distinction."
+        "quote": "Divider is used to break content into smaller sections, making it easier to read and understand. It can also be used to separate content that is related but still benefits from a visual distinction.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/divider/overview"
       },
       {
         "rule": "Use divider to mark a boundary between content that is not logically connected, such as different sections in an article or different functional areas on a page.",
-        "quote": "Use the component to mark a boundary between content that is not logically connected, such as different sections in an article or different functional areas on a page."
+        "quote": "Use the component to mark a boundary between content that is not logically connected, such as different sections in an article or different functional areas on a page.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/divider/accessibility"
       },
       {
         "rule": "Use divider to visually clarify structure, not simply to fill empty space or decorate the page.",
-        "quote": "Use it to visually clarify the structure, not simply to fill empty space or “decorate” the page."
+        "quote": "Use it to visually clarify the structure, not simply to fill empty space or “decorate” the page.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/divider/accessibility"
       },
       {
         "rule": "The accessible structural elements to pair with a divider can include a heading, a list, <section> elements, or elements with role=\"group\".",
-        "quote": "This can include a heading , a list , <section> elements , or elements with role=\"group\" ."
+        "quote": "This can include a heading , a list , <section> elements , or elements with role=\"group\" .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/divider/accessibility"
       }
     ]
   },
@@ -785,66 +1077,92 @@
       {
         "rule": "Dropdown does not create a semantic menu itself; it provides the foundation for building one yourself",
         "wcag": null,
-        "quote": "Dropdown does not create a semantic menu, but provides the foundation for building one yourself."
+        "quote": "Dropdown does not create a semantic menu, but provides the foundation for building one yourself.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dropdown/overview"
       },
       {
         "rule": "The Popover API gives built-in accessibility for open/closed state and keyboard navigation.",
         "wcag": null,
-        "quote": "There is built-in accessibility in the Popover API for open and closed state, as well as keyboard navigation."
+        "quote": "There is built-in accessibility in the Popover API for open and closed state, as well as keyboard navigation.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dropdown/accessibility"
       },
       {
         "rule": "Enter or Space opens or closes the menu.",
         "wcag": null,
-        "quote": "Enter or Space opens or closes the menu"
+        "quote": "Enter or Space opens or closes the menu",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dropdown/accessibility"
       },
       {
         "rule": "Enter or Space selects the highlighted item.",
         "wcag": null,
-        "quote": "Enter or Space selects the highlighted item"
+        "quote": "Enter or Space selects the highlighted item",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dropdown/accessibility"
       },
       {
         "rule": "Esc closes the menu.",
         "wcag": null,
-        "quote": "Esc closes the menu"
+        "quote": "Esc closes the menu",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dropdown/accessibility"
       },
       {
         "rule": "When building a menu on Dropdown, follow the W3C Menu and Menubar Pattern",
         "wcag": null,
-        "quote": "Read the \"Menu and Menubar Pattern\" on w3.org for more information on how to create accessible menus."
+        "quote": "Read the \"Menu and Menubar Pattern\" on w3.org for more information on how to create accessible menus.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dropdown/overview"
       },
       {
         "rule": "Combine Dropdown with focusgroup to enable arrow-key navigation between items",
         "wcag": null,
-        "quote": "You can combine Dropdown with focusgroup to enable arrow navigation between items."
+        "quote": "You can combine Dropdown with focusgroup to enable arrow navigation between items.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dropdown/code"
       }
     ],
     "relations": [
       {
         "component": "Button",
         "note": "Use a visible Button instead of Dropdown when the action is primary or frequently used.",
-        "quote": "Avoid dropdown when an action is primary or frequently used; use a visible button instead"
+        "quote": "Avoid dropdown when an action is primary or frequently used; use a visible button instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dropdown/overview"
       }
     ],
     "composition": [
       {
         "rule": "Use Dropdown to offer multiple secondary options compactly, that should still remain easily accessible.",
-        "quote": "Use dropdown when you want to offer multiple options without taking up much space in the interface the options are secondary but should still be easily accessible"
+        "quote": "Use dropdown when you want to offer multiple options without taking up much space in the interface the options are secondary but should still be easily accessible",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dropdown/overview"
       },
       {
         "rule": "Use Dropdown for actions or navigation that do not need to be visible at all times.",
-        "quote": "Use Dropdown for actions or navigation that do not need to be visible at all times"
+        "quote": "Use Dropdown for actions or navigation that do not need to be visible at all times",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dropdown/overview"
       },
       {
         "rule": "Keep the number of items in a dropdown manageable.",
-        "quote": "Keep the number of items manageable"
+        "quote": "Keep the number of items manageable",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dropdown/overview"
       },
       {
         "rule": "Use headings to group related items in a dropdown.",
-        "quote": "Use headings to group related items"
+        "quote": "Use headings to group related items",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dropdown/overview"
       },
       {
         "rule": "Avoid nesting multiple levels of dropdowns (nested menus).",
-        "quote": "Avoid multiple levels of dropdowns (nested menus)"
+        "quote": "Avoid multiple levels of dropdowns (nested menus)",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/dropdown/overview"
       }
     ]
   },
@@ -855,33 +1173,45 @@
       {
         "rule": "The summary takes focus when it appears or its content changes",
         "wcag": null,
-        "quote": "The summary automatically receives focus when it becomes visible and when its content changes."
+        "quote": "The summary automatically receives focus when it becomes visible and when its content changes.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/error-summary/overview"
       },
       {
         "rule": "Every error message must link directly to its field",
         "wcag": null,
-        "quote": "Error messages must link directly to the relevant field."
+        "quote": "Error messages must link directly to the relevant field.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/error-summary/overview"
       }
     ],
     "relations": [
       {
         "component": "Alert",
         "note": "Use Alert for system-level messages instead",
-        "quote": "you need to display system-level messages; use alert instead"
+        "quote": "you need to display system-level messages; use alert instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/error-summary/overview"
       }
     ],
     "composition": [
       {
         "rule": "The summary should contain every error message present on the page",
-        "quote": "Error summary should contain all error messages present on the page"
+        "quote": "Error summary should contain all error messages present on the page",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/error-summary/overview"
       },
       {
         "rule": "Summary messages should be phrased exactly the same as the field-level messages",
-        "quote": "error messages in the summary should be phrased exactly the same as the error messages displayed at the relevant fields"
+        "quote": "error messages in the summary should be phrased exactly the same as the error messages displayed at the relevant fields",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/error-summary/overview"
       },
       {
         "rule": "Where one error covers several fields, link to the first",
-        "quote": "If the error applies to several fields, for example when two fields are validated together, link to the first instance of the error."
+        "quote": "If the error applies to several fields, for example when two fields are validated together, link to the first instance of the error.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/error-summary/overview"
       }
     ]
   },
@@ -892,14 +1222,18 @@
       {
         "rule": "Field links label, description, validation message and counter so assistive technology reads them as one unit",
         "wcag": null,
-        "quote": "It automatically links label, description, validation message and character count to the relevant field, so that assistive technology like screen readers reads them as one unit"
+        "quote": "It automatically links label, description, validation message and character count to the relevant field, so that assistive technology like screen readers reads them as one unit",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/field/overview"
       }
     ],
     "relations": [
       {
         "component": "Fieldset",
         "note": "Use Fieldset to group multiple fields",
-        "quote": "use fieldset instead"
+        "quote": "use fieldset instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/field/overview"
       }
     ]
   },
@@ -914,20 +1248,26 @@
       {
         "rule": "Avoid repeating the same text in both label and legend",
         "wcag": null,
-        "quote": "Avoid using the same text in both `<label>` and `<legend>`"
+        "quote": "Avoid using the same text in both `<label>` and `<legend>`",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/fieldset/overview"
       }
     ],
     "relations": [
       {
         "component": "Radio",
         "note": "Groups radio or checkbox components, even a group of one",
-        "quote": "you have a group or list of multiple radio or checkbox components"
+        "quote": "you have a group or list of multiple radio or checkbox components",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/fieldset/overview"
       }
     ],
     "composition": [
       {
         "rule": "Start with a legend explaining what the fields below relate to",
-        "quote": "start with a `<legend>` that explains what the fields below relate to"
+        "quote": "start with a `<legend>` that explains what the fields below relate to",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/fieldset/overview"
       }
     ]
   },
@@ -938,22 +1278,30 @@
       {
         "rule": "FileUpload must have a visible label associated with it via ds-field so screen readers can announce what should be uploaded.",
         "wcag": null,
-        "quote": "File upload must always have a visible <label> associated with it through <ds-field> , so that screen readers can communicate what should be uploaded."
+        "quote": "File upload must always have a visible <label> associated with it through <ds-field> , so that screen readers can communicate what should be uploaded.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/file-upload/accessibility"
       },
       {
         "rule": "Use the description field to state allowed file formats and sizes before the user uploads.",
         "wcag": null,
-        "quote": "Use <p data-field=\"description\"> to describe allowed file formats and sizes, so the user receives this information before uploading."
+        "quote": "Use <p data-field=\"description\"> to describe allowed file formats and sizes, so the user receives this information before uploading.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/file-upload/accessibility"
       }
     ],
     "composition": [
       {
         "rule": "Place FileUpload inside a Field with a Label so the upload area gets an accessible label.",
-        "quote": "Place File upload inside a field with a label so the upload area gets an accessible label."
+        "quote": "Place File upload inside a field with a label so the upload area gets an accessible label.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/file-upload/code"
       },
       {
         "rule": "For advanced file handling with per-file upload status, build this functionality yourself around the component.",
-        "quote": "If you need advanced file handling with per-file upload status, you must build this yourself around the component."
+        "quote": "If you need advanced file handling with per-file upload status, you must build this yourself around the component.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/file-upload/overview"
       }
     ]
   },
@@ -964,76 +1312,106 @@
       {
         "rule": "Use correct heading levels (h1-h6) for proper semantic structure",
         "wcag": null,
-        "quote": "Make sure to use correct heading levels (h1-h6) to ensure proper semantic structure."
+        "quote": "Make sure to use correct heading levels (h1-h6) to ensure proper semantic structure.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/heading/overview"
       },
       {
         "rule": "Starting headings with keywords makes scanning and locating information easier",
         "wcag": null,
-        "quote": "Starting headings with keywords makes it easier for everyone to scan the page and locate relevant information."
+        "quote": "Starting headings with keywords makes it easier for everyone to scan the page and locate relevant information.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/heading/overview"
       },
       {
         "rule": "The h1 must describe the entire page; subheadings must be unique and indicate their section's content",
         "wcag": null,
-        "quote": "The main page heading — the <h1> element — must describe the entire page, while each subheading should be unique and clearly indicate what the following section contains."
+        "quote": "The main page heading — the <h1> element — must describe the entire page, while each subheading should be unique and clearly indicate what the following section contains.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/heading/overview"
       },
       {
         "rule": "Use headings in the correct order (h1-h6) for a clear, predictable structure",
         "wcag": null,
-        "quote": "Use headings in the correct order ( h1 - h6 ) to create a clear and predictable structure."
+        "quote": "Use headings in the correct order ( h1 - h6 ) to create a clear and predictable structure.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/heading/accessibility"
       },
       {
         "rule": "Coherent, logical heading hierarchy is essential since many users navigate by skimming headings",
         "wcag": null,
-        "quote": "Many users navigate by skimming the headings, and it is therefore essential that the hierarchy is coherent and provides a logical division of the content."
+        "quote": "Many users navigate by skimming the headings, and it is therefore essential that the hierarchy is coherent and provides a logical division of the content.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/heading/accessibility"
       },
       {
         "rule": "A tidy heading structure helps assistive technologies present the page correctly",
         "wcag": null,
-        "quote": "A tidy heading structure also makes it easier for assistive technologies to present the page correctly."
+        "quote": "A tidy heading structure also makes it easier for assistive technologies to present the page correctly.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/heading/accessibility"
       },
       {
         "rule": "Avoid skipping heading levels in the hierarchy",
         "wcag": null,
-        "quote": "Avoid skipping levels in the hierarchy."
+        "quote": "Avoid skipping levels in the hierarchy.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/heading/accessibility"
       },
       {
         "rule": "Jumping heading levels (e.g. h2 to h4) makes content organisation harder to understand, unlike natural progressions (e.g. h2 to h3)",
         "wcag": null,
-        "quote": "Moving from <h2> to <h3> is natural, while jumping from <h2> to <h4> can make it harder to understand how the content is organised."
+        "quote": "Moving from <h2> to <h3> is natural, while jumping from <h2> to <h4> can make it harder to understand how the content is organised.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/heading/accessibility"
       },
       {
         "rule": "Be consistent with heading structure across pages and sections in your solution",
         "wcag": null,
-        "quote": "Be consistent across pages and sections in your solution."
+        "quote": "Be consistent across pages and sections in your solution.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/heading/accessibility"
       },
       {
         "rule": "A given heading level's structure (e.g. table of contents at h2) should apply everywhere",
         "wcag": null,
-        "quote": "If a table of contents uses <h2> in one place, the same structure should apply everywhere."
+        "quote": "If a table of contents uses <h2> in one place, the same structure should apply everywhere.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/heading/accessibility"
       },
       {
         "rule": "Visual style and semantic HTML should match for the corresponding heading level",
         "wcag": null,
-        "quote": "Both the visual style and the semantic HTML should be the same for the corresponding heading level."
+        "quote": "Both the visual style and the semantic HTML should be the same for the corresponding heading level.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/heading/accessibility"
       },
       {
         "rule": "Consistent heading structure helps users build a stable mental model of content organisation",
         "wcag": null,
-        "quote": "This helps users build a stable mental model of how the content is organised."
+        "quote": "This helps users build a stable mental model of how the content is organised.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/heading/accessibility"
       }
     ],
     "composition": [
       {
         "rule": "Heading is used to establish structure and hierarchy in content",
-        "quote": "Heading is used to establish structure and hierarchy in content."
+        "quote": "Heading is used to establish structure and hierarchy in content.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/heading/overview"
       },
       {
         "rule": "Use headings to divide information into clear, logical sections",
-        "quote": "Use headings to divide information into clear, logical sections."
+        "quote": "Use headings to divide information into clear, logical sections.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/heading/overview"
       },
       {
         "rule": "Headings and subheadings should be short and clear, giving readers an accurate idea of the content they introduce",
-        "quote": "Headings and subheadings should be short and clear, giving readers an accurate idea of the content they introduce."
+        "quote": "Headings and subheadings should be short and clear, giving readers an accurate idea of the content they introduce.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/heading/overview"
       }
     ]
   },
@@ -1044,52 +1422,72 @@
       {
         "rule": "Avoid using the disabled state where possible; use readOnly instead",
         "wcag": null,
-        "quote": "Avoid using disabled where possible. Consider using readOnly instead."
+        "quote": "Avoid using disabled where possible. Consider using readOnly instead.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/input/overview"
       },
       {
         "rule": "The disabled prop should be avoided if possible for accessibility purposes",
         "wcag": null,
-        "quote": "@note Avoid using if possible for accessibility purposes"
+        "quote": "@note Avoid using if possible for accessibility purposes",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/input/code"
       },
       {
         "rule": "Even when visually hidden, the label must still be written meaningfully since it is announced by screen readers, via aria-label or aria-labelledby",
         "wcag": null,
-        "quote": "Even when the label is visually hidden, it must still be written in a meaningful way, as it will be announced by screen readers. This can be done using aria-label or aria-labelledby ."
+        "quote": "Even when the label is visually hidden, it must still be written in a meaningful way, as it will be announced by screen readers. This can be done using aria-label or aria-labelledby .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/input/overview"
       }
     ],
     "relations": [
       {
         "component": "Textfield",
         "note": "Use Textfield instead of Input when you need a complete form field with label, description and validation message",
-        "quote": "Avoid input when you need a complete form field with label, description and validation message, use textfield instead the field requires additional logic already provided by higher-level components such as textfield"
+        "quote": "Avoid input when you need a complete form field with label, description and validation message, use textfield instead the field requires additional logic already provided by higher-level components such as textfield",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/input/overview"
       },
       {
         "component": "Textfield",
         "note": "Refer to Textfield's guidelines for general usage guidance on Input",
-        "quote": "See the guidelines for textfield ."
+        "quote": "See the guidelines for textfield .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/input/overview"
       },
       {
         "component": "Textfield",
         "note": "Refer to Textfield for accessibility best practice",
-        "quote": "For best practice, see Textfield ."
+        "quote": "For best practice, see Textfield .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/input/accessibility"
       }
     ],
     "composition": [
       {
         "rule": "The label and any description should always be placed above the text field, so they remain visible on small screens and aren't hidden by validation messages",
-        "quote": "The label and any description should always be placed above the text field. This makes them easier to see on small screens and prevents them from being hidden by validation messages."
+        "quote": "The label and any description should always be placed above the text field. This makes them easier to see on small screens and prevents them from being hidden by validation messages.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/input/overview"
       },
       {
         "rule": "The label may be visually hidden in special cases, such as tables where the field receives its label from the table header",
-        "quote": "In special cases, the label may be visually hidden by not using label. This may be appropriate in tables, for example, when the field receives its label from the table header."
+        "quote": "In special cases, the label may be visually hidden by not using label. This may be appropriate in tables, for example, when the field receives its label from the table header.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/input/overview"
       },
       {
         "rule": "Input is used as a building block for other components, such as Textfield",
-        "quote": "This component is used as a building block for other components, such as textfield."
+        "quote": "This component is used as a building block for other components, such as textfield.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/input/overview"
       },
       {
         "rule": "For a valid form element, use ds-field together with a label",
-        "quote": "For a valid form element, we recommend using <ds-field> together with a <label> ."
+        "quote": "For a valid form element, we recommend using <ds-field> together with a <label> .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/input/code"
       }
     ]
   },
@@ -1100,13 +1498,17 @@
       {
         "rule": "The label must be clearly connected to its field",
         "wcag": null,
-        "quote": "Label must be clearly connected to the associated field so that both visual users and users of assistive technologies understand the relationship."
+        "quote": "Label must be clearly connected to the associated field so that both visual users and users of assistive technologies understand the relationship.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/label/overview"
       }
     ],
     "composition": [
       {
         "rule": "Write in plain language; avoid abbreviations and internal terminology",
-        "quote": "Write in plain language so that all users immediately know what to enter or select. Avoid abbreviations and internal terminology"
+        "quote": "Write in plain language so that all users immediately know what to enter or select. Avoid abbreviations and internal terminology",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/label/overview"
       }
     ]
   },
@@ -1117,62 +1519,86 @@
       {
         "rule": "Put trigger words early in link text; vague phrases must not be the entire link text",
         "wcag": null,
-        "quote": "Use the important words (trigger words) early in the link text. “Go to”, “Click here”, “Link to” or “Read more” should never be the entire link text."
+        "quote": "Use the important words (trigger words) early in the link text. “Go to”, “Click here”, “Link to” or “Read more” should never be the entire link text.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/link/overview"
       },
       {
         "rule": "All links on the same page must have unique link text",
         "wcag": null,
-        "quote": "All links on the same page must have unique link text."
+        "quote": "All links on the same page must have unique link text.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/link/overview"
       },
       {
         "rule": "A verb should appear early in the link text",
         "wcag": null,
-        "quote": "A verb should appear early in the link text."
+        "quote": "A verb should appear early in the link text.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/link/overview"
       },
       {
         "rule": "Use text, not an icon, to explain where a link leads, since text is clear for both sighted users and screen reader users",
         "wcag": null,
-        "quote": "Instead, we always recommend using text to explain where the link leads. This makes the function clear both for users and for screen readers."
+        "quote": "Instead, we always recommend using text to explain where the link leads. This makes the function clear both for users and for screen readers.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/link/overview"
       },
       {
         "rule": "Link text must make sense on its own when read aloud by a screen reader, regardless of surrounding context",
         "wcag": null,
-        "quote": "When writing link text, imagine it being read aloud by a screen reader. The text must make sense on its own, whether it appears in a sentence, menu or list."
+        "quote": "When writing link text, imagine it being read aloud by a screen reader. The text must make sense on its own, whether it appears in a sentence, menu or list.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/link/overview"
       }
     ],
     "relations": [
       {
         "component": "Button",
         "note": "Use a button instead of a link when the user should perform an action on the same page, e.g. \"Save\" or \"Submit\"",
-        "quote": "Avoid link when the user should perform an action on the same page, for example “Save” or “Submit”, use a button instead"
+        "quote": "Avoid link when the user should perform an action on the same page, for example “Save” or “Submit”, use a button instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/link/overview"
       },
       {
         "component": "Button",
         "note": "Use a button instead of a link when the action changes the state of the solution, such as opening a dialog, starting a process or saving data",
-        "quote": "the action changes the state of the solution, such as opening a dialog, starting a process or saving data, use a button instead"
+        "quote": "the action changes the state of the solution, such as opening a dialog, starting a process or saving data, use a button instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/link/overview"
       },
       {
         "component": "Button",
         "note": "Use a button, not a link, when the action itself performs the operation (e.g. \"Log in\" that submits a login form) rather than navigating to a URL",
-        "quote": "Use a button when “Log in” actually logs the user in, for example by submitting a login form."
+        "quote": "Use a button when “Log in” actually logs the user in, for example by submitting a login form.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/link/overview"
       }
     ],
     "composition": [
       {
         "rule": "A link is often used inline as part of a text",
-        "quote": "A link is often used as part of a text."
+        "quote": "A link is often used as part of a text.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/link/overview"
       },
       {
         "rule": "An icon in a link can be placed left or right of the text; left is recommended",
-        "quote": "Links can have an icon placed either to the left or the right of the text. As a general rule, we recommend placing the icon on the left."
+        "quote": "Links can have an icon placed either to the left or the right of the text. As a general rule, we recommend placing the icon on the left.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/link/overview"
       },
       {
         "rule": "Neutral-coloured links are useful when placed in an area that has its own background colour",
-        "quote": "This can be useful when the link is placed in an area with its own background colour."
+        "quote": "This can be useful when the link is placed in an area with its own background colour.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/link/overview"
       },
       {
         "rule": "Avoid overusing links on a page, as this makes it harder for users to find their way forward",
-        "quote": "It is important not to overuse links, as this can make it harder for users to find their way forward."
+        "quote": "It is important not to overuse links, as this can make it harder for users to find their way forward.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/link/overview"
       }
     ]
   },
@@ -1186,27 +1612,39 @@
     "composition": [
       {
         "rule": "Use pagination when content must be divided across multiple pages, users need to know their position within the set, and loading everything at once would hurt performance",
-        "quote": "Use pagination when search results or large amounts of data need to be divided across multiple pages users need to understand where they are within a larger set of content loading the entire dataset at once would be too heavy or result in poor performance"
+        "quote": "Use pagination when search results or large amounts of data need to be divided across multiple pages users need to understand where they are within a larger set of content loading the entire dataset at once would be too heavy or result in poor performance",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/pagination/overview"
       },
       {
         "rule": "Avoid pagination when content fits on a single page, when paging a form, or when progress needs to be shown",
-        "quote": "Avoid pagination when the total amount of content is small enough to fit on a single page you want to divide a form into several pages progress needs to be displayed"
+        "quote": "Avoid pagination when the total amount of content is small enough to fit on a single page you want to divide a form into several pages progress needs to be displayed",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/pagination/overview"
       },
       {
         "rule": "On mobile, show fewer page buttons and drop the previous/next text labels",
-        "quote": "On mobile devices, you can show fewer pages and remove the text for previous/next."
+        "quote": "On mobile devices, you can show fewer pages and remove the text for previous/next.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/pagination/overview"
       },
       {
         "rule": "Use pagination when content is too large for one page and users need to navigate back and forth",
-        "quote": "Use pagination when content is too large for a single page, such as search results or long lists, and the user needs to navigate back and forth."
+        "quote": "Use pagination when content is too large for a single page, such as search results or long lists, and the user needs to navigate back and forth.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/pagination/overview"
       },
       {
         "rule": "Only split content across multiple pages if doing so improves loading time or usability",
-        "quote": "Content should only be split across multiple pages if it improves loading time or usability."
+        "quote": "Content should only be split across multiple pages if it improves loading time or usability.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/pagination/overview"
       },
       {
         "rule": "Use the fixed text pattern \"Previous\"/\"Next\"; avoid alternate wordings like \"Previous page\", \"Go back\", \"Continue\"",
-        "quote": "We use a fixed pattern for pagination with the words “Previous” and “Next”. Avoid “Previous page”, “Next page”, “Go back”, “Go forward”, “Continue” and “Back”."
+        "quote": "We use a fixed pattern for pagination with the words “Previous” and “Next”. Avoid “Previous page”, “Next page”, “Go back”, “Go forward”, “Continue” and “Back”.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/pagination/overview"
       }
     ]
   },
@@ -1216,27 +1654,39 @@
     "composition": [
       {
         "rule": "Keep paragraphs focused and well structured, breaking up long blocks of text into smaller sections for scannability",
-        "quote": "Keep paragraphs focused and well structured, and break up long blocks of text into smaller sections to make the content easier to scan and understand."
+        "quote": "Keep paragraphs focused and well structured, and break up long blocks of text into smaller sections to make the content easier to scan and understand.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/paragraph/overview"
       },
       {
         "rule": "Line length and spacing should support good readability",
-        "quote": "Ensure that line length and spacing support good readability."
+        "quote": "Ensure that line length and spacing support good readability.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/paragraph/overview"
       },
       {
         "rule": "Body text should be clear, concise, and written in plain language",
-        "quote": "Body text should be clear, concise, and written in plain language."
+        "quote": "Body text should be clear, concise, and written in plain language.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/paragraph/overview"
       },
       {
         "rule": "Start with the most important information so users can quickly understand the context",
-        "quote": "Start with the most important information so users can quickly understand the context."
+        "quote": "Start with the most important information so users can quickly understand the context.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/paragraph/overview"
       },
       {
         "rule": "Each paragraph should cover one topic or idea at a time",
-        "quote": "Each paragraph should cover one topic or idea at a time."
+        "quote": "Each paragraph should cover one topic or idea at a time.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/paragraph/overview"
       },
       {
         "rule": "Complex information should be divided into several paragraphs to avoid cognitive overload",
-        "quote": "When explaining complex information, divide it into several paragraphs to avoid cognitive overload and make the content easier for everyone to follow."
+        "quote": "When explaining complex information, divide it into several paragraphs to avoid cognitive overload and make the content easier for everyone to follow.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/paragraph/overview"
       }
     ]
   },
@@ -1247,73 +1697,103 @@
       {
         "rule": "Popover has built-in accessibility support for open/closed states and keyboard navigation via the native Popover API",
         "wcag": null,
-        "quote": "There is built-in accessibility in the Popover API (mozilla.org) for open and closed states and for keyboard navigation."
+        "quote": "There is built-in accessibility in the Popover API (mozilla.org) for open and closed states and for keyboard navigation.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/popover/accessibility"
       },
       {
         "rule": "Enter or Space opens or closes the popover",
         "wcag": null,
-        "quote": "Enter or Space opens or closes"
+        "quote": "Enter or Space opens or closes",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/popover/accessibility"
       },
       {
         "rule": "Esc closes the popover",
         "wcag": null,
-        "quote": "Esc closes"
+        "quote": "Esc closes",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/popover/accessibility"
       }
     ],
     "relations": [
       {
         "component": "Tooltip",
         "note": "Popover should be used instead of tooltip when the explanation needs more space than a short tooltip provides, e.g. definitions or detailed instructions",
-        "quote": "you need to provide additional explanations that require more space than a short tooltip , such as definitions or detailed instructions"
+        "quote": "you need to provide additional explanations that require more space than a short tooltip , such as definitions or detailed instructions",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/popover/overview"
       },
       {
         "component": "Tooltip",
         "note": "Avoid popover to describe a symbol or keyboard shortcut; use tooltip instead",
-        "quote": "you need to describe a symbol or keyboard shortcut; use tooltip instead"
+        "quote": "you need to describe a symbol or keyboard shortcut; use tooltip instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/popover/overview"
       },
       {
         "component": "Dropdown",
         "note": "Avoid popover when the purpose is navigation or choosing between options; use dropdown instead",
-        "quote": "the purpose is navigation or choosing between options; use dropdown instead"
+        "quote": "the purpose is navigation or choosing between options; use dropdown instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/popover/overview"
       },
       {
         "component": "Tooltip",
         "note": "Popover can be used as an extended solution when tooltip is not sufficient for the content",
-        "quote": "It can be used as an extended solution when a tooltip is not sufficient."
+        "quote": "It can be used as an extended solution when a tooltip is not sufficient.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/popover/overview"
       }
     ],
     "composition": [
       {
         "rule": "Popover is opened through an intentional user click and may contain text, links and simple form elements",
-        "quote": "Popover is opened through an intentional user click and may contain text, links and simple form elements."
+        "quote": "Popover is opened through an intentional user click and may contain text, links and simple form elements.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/popover/overview"
       },
       {
         "rule": "Popover content should be short, relevant, and not critical for completing the task",
-        "quote": "The content should be short, relevant, and not critical for completing the task."
+        "quote": "The content should be short, relevant, and not critical for completing the task.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/popover/overview"
       },
       {
         "rule": "Popover may contain buttons and other interactive elements",
-        "quote": "Popover may contain buttons and other interactive elements."
+        "quote": "Popover may contain buttons and other interactive elements.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/popover/overview"
       },
       {
         "rule": "Popover can be used inline within text, marked with a dotted underline, e.g. to explain a term",
-        "quote": "You can use popover inline within text, marked with a dotted underline, for example when explaining a term."
+        "quote": "You can use popover inline within text, marked with a dotted underline, for example when explaining a term.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/popover/overview"
       },
       {
         "rule": "Popover displays more detailed or interactive supplementary information without taking the user out of context",
-        "quote": "Popover is used to display more detailed or interactive supplementary information without taking the user out of context."
+        "quote": "Popover is used to display more detailed or interactive supplementary information without taking the user out of context.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/popover/overview"
       },
       {
         "rule": "Popover placement is automatic and stays within the visible browser area",
-        "quote": "Popover can be placed as needed, and will automatically stay within the visible browser area."
+        "quote": "Popover can be placed as needed, and will automatically stay within the visible browser area.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/popover/overview"
       },
       {
         "rule": "Automatic placement behaviour can be disabled using autoPlacement",
-        "quote": "This behaviour can be disabled using autoPlacement ."
+        "quote": "This behaviour can be disabled using autoPlacement .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/popover/overview"
       },
       {
         "rule": "Avoid long texts and complex explanations in a popover; link to another page for more detailed information instead",
-        "quote": "Avoid long texts and complex explanations. In some cases, it may be better to link to another page with more detailed information on the topic."
+        "quote": "Avoid long texts and complex explanations. In some cases, it may be better to link to another page with more detailed information on the topic.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/popover/overview"
       }
     ]
   },
@@ -1324,118 +1804,168 @@
       {
         "rule": "Ensure enough spacing around each radio button so it is easy to select, including on touch devices",
         "wcag": null,
-        "quote": "Make sure there is enough spacing around each radio button so that it is easy to select, including on touch devices."
+        "quote": "Make sure there is enough spacing around each radio button so that it is easy to select, including on touch devices.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/accessibility"
       },
       {
         "rule": "Avoid placing radio buttons next to each other, as it makes them harder to read and problematic for users who need to zoom",
         "wcag": null,
-        "quote": "Avoid placing radio buttons next to each other. This makes them harder to read and creates problems for users who need to zoom a webpage or app to see clearly."
+        "quote": "Avoid placing radio buttons next to each other. This makes them harder to read and creates problems for users who need to zoom a webpage or app to see clearly.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/accessibility"
       },
       {
         "rule": "Avoid disabled states if possible due to low colour contrast",
         "wcag": null,
-        "quote": "Avoid disabled states if possible. They have low colour contrast, which can be problematic for some users."
+        "quote": "Avoid disabled states if possible. They have low colour contrast, which can be problematic for some users.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/accessibility"
       },
       {
         "rule": "Disabled radios cannot meet contrast requirements without causing confusion about interactivity",
         "wcag": null,
-        "quote": "disabled cannot meet contrast requirements, because if the contrast were higher, users might think the element is active, try to select it, and not understand why nothing happens."
+        "quote": "disabled cannot meet contrast requirements, because if the contrast were higher, users might think the element is active, try to select it, and not understand why nothing happens.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/accessibility"
       },
       {
         "rule": "Radio uses arrow keys (not Tab) to move between options within a group",
         "wcag": null,
-        "quote": "Note that we use the arrow keys to select options in the Radio component, not the Tab key."
+        "quote": "Note that we use the arrow keys to select options in the Radio component, not the Tab key.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/accessibility"
       },
       {
         "rule": "A group of radio options should always have a legend and option labels",
         "wcag": null,
-        "quote": "A group with multiple options should always have a legend and option labels ."
+        "quote": "A group with multiple options should always have a legend and option labels .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/overview"
       },
       {
         "rule": "In horizontal layouts, it must be clear which text belongs to which button",
         "wcag": null,
-        "quote": "When using a horizontal layout, it must be clear which text belongs to which button."
+        "quote": "When using a horizontal layout, it must be clear which text belongs to which button.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/overview"
       }
     ],
     "relations": [
       {
         "component": "Checkbox",
         "note": "Use checkbox instead of radio when the user should be able to choose more than one option",
-        "quote": "Avoid radio when the user should be able to choose more than one option, use checkbox instead"
+        "quote": "Avoid radio when the user should be able to choose more than one option, use checkbox instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/overview"
       },
       {
         "component": "Fieldset",
         "note": "Use fieldset to group multiple radio choices together",
-        "quote": "Use fieldset for grouping multiple choices."
+        "quote": "Use fieldset for grouping multiple choices.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/code"
       },
       {
         "component": "Suggestion",
         "note": "Consider suggestion instead of radio when users need more choices than a radio group comfortably supports",
-        "quote": "If users need more choices, consider using suggestion or select ."
+        "quote": "If users need more choices, consider using suggestion or select .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/overview"
       },
       {
         "component": "Select",
         "note": "Consider select instead of radio when users need more choices than a radio group comfortably supports",
-        "quote": "If users need more choices, consider using suggestion or select ."
+        "quote": "If users need more choices, consider using suggestion or select .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/overview"
       },
       {
         "component": "Switch",
         "note": "A switch may be more suitable than radio when there is only a single choice to make",
-        "quote": "If there is only one choice to make, a switch or a checkbox may be more suitable."
+        "quote": "If there is only one choice to make, a switch or a checkbox may be more suitable.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/overview"
       }
     ],
     "composition": [
       {
         "rule": "There should not be more than seven options in one radio group",
-        "quote": "There should not be more than seven options in one group."
+        "quote": "There should not be more than seven options in one group.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/overview"
       },
       {
         "rule": "Sort options alphabetically unless there is a clear reason not to",
-        "quote": "Sort options alphabetically unless there is a clear reason not to."
+        "quote": "Sort options alphabetically unless there is a clear reason not to.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/overview"
       },
       {
         "rule": "Be careful about placing the most common option first when the question is personal or value-based",
-        "quote": "Be careful about placing the most common option first if the question is personal or value-based, such as sexual orientation or political affiliation."
+        "quote": "Be careful about placing the most common option first if the question is personal or value-based, such as sexual orientation or political affiliation.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/overview"
       },
       {
         "rule": "Place radio buttons vertically whenever possible to make the list easier to scan and read",
-        "quote": "Place radio buttons vertically whenever possible. This makes the list easier to scan and the options easier to read."
+        "quote": "Place radio buttons vertically whenever possible. This makes the list easier to scan and the options easier to read.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/overview"
       },
       {
         "rule": "Horizontal layout is acceptable only for two short-label options or rating scales",
-        "quote": "You can use a horizontal layout when there are only two options with short labels, such as “Yes” and “No”, or in a rating scale ranging from “strongly disagree” to “strongly agree”."
+        "quote": "You can use a horizontal layout when there are only two options with short labels, such as “Yes” and “No”, or in a rating scale ranging from “strongly disagree” to “strongly agree”.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/overview"
       },
       {
         "rule": "Radio can be positioned horizontally with flex, but should generally be placed vertically",
-        "quote": "Radio can be positioned horizontally with flex , but should generally be placed vertically ."
+        "quote": "Radio can be positioned horizontally with flex , but should generally be placed vertically .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/code"
       },
       {
         "rule": "Consider whether a preselected option is appropriate for the context",
-        "quote": "Consider whether a preselected option is appropriate for the context."
+        "quote": "Consider whether a preselected option is appropriate for the context.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/overview"
       },
       {
         "rule": "A preselected option can influence informed choice and may be perceived as manipulative or discriminatory",
-        "quote": "A preselected option can influence the user's ability to make an informed choice, and some users may experience it as manipulative or discriminatory."
+        "quote": "A preselected option can influence the user's ability to make an informed choice, and some users may experience it as manipulative or discriminatory.",
+        "verified": false,
+        "sourcePage": null
       },
       {
         "rule": "Place a description meant to inform the choice directly after the legend",
-        "quote": "When the description is intended to help users understand the question and provide necessary information before they make a choice, it should be placed directly after the legend."
+        "quote": "When the description is intended to help users understand the question and provide necessary information before they make a choice, it should be placed directly after the legend.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/overview"
       },
       {
         "rule": "Answer options should be as short as possible and follow the same linguistic form",
-        "quote": "Answer options should be as short as possible, and each option should follow the same linguistic form."
+        "quote": "Answer options should be as short as possible, and each option should follow the same linguistic form.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/overview"
       },
       {
         "rule": "An error message for an unanswered required group should apply to the entire group of options",
-        "quote": "If the user attempts to continue without answering a required question, the error message should apply to the entire group of options."
+        "quote": "If the user attempts to continue without answering a required question, the error message should apply to the entire group of options.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/overview"
       },
       {
         "rule": "For a valid form element, use ds-field together with a label",
-        "quote": "For a valid form element, we recommend using <ds-field> together with a <label> ."
+        "quote": "For a valid form element, we recommend using <ds-field> together with a <label> .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/code"
       },
       {
         "rule": "Radio is a composite component built from field, label, validation message, and input",
-        "quote": "Radio is a composite component that uses field , label , validation message , and input to create a radio."
+        "quote": "Radio is a composite component that uses field , label , validation message , and input to create a radio.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/radio/code"
       }
     ]
   },
@@ -1446,64 +1976,90 @@
       {
         "rule": "Placeholder text should be used cautiously since it disappears once typing starts and can confuse users",
         "wcag": null,
-        "quote": "Placeholder text should be used with caution, as it disappears when users start typing and may cause confusion."
+        "quote": "Placeholder text should be used with caution, as it disappears when users start typing and may cause confusion.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/search/overview"
       },
       {
         "rule": "Placeholder text must meet accessibility contrast requirements, which can make it hard to distinguish from entered text",
         "wcag": null,
-        "quote": "It must also meet accessibility contrast requirements, which may make it difficult to distinguish from entered text."
+        "quote": "It must also meet accessibility contrast requirements, which may make it difficult to distinguish from entered text.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/search/overview"
       },
       {
         "rule": "Screen readers handle placeholder text inconsistently, so information should be given via a label or description instead",
         "wcag": null,
-        "quote": "Screen readers handle placeholder text inconsistently, so information should instead be provided through a label or description."
+        "quote": "Screen readers handle placeholder text inconsistently, so information should instead be provided through a label or description.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/search/overview"
       },
       {
         "rule": "Use a visible label above the search field when the search purpose isn't obvious or when it's part of a form",
         "wcag": null,
-        "quote": "You should use a label above the search field when it is not obvious what users are expected to search for, or when the search field is part of a form."
+        "quote": "You should use a label above the search field when it is not obvious what users are expected to search for, or when the search field is part of a form.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/search/overview"
       },
       {
         "rule": "Pressing Esc clears the search field for a consistent cross-browser experience",
         "wcag": null,
-        "quote": "Pressing Esc clears the search field to provide a consistent experience across browsers."
+        "quote": "Pressing Esc clears the search field to provide a consistent experience across browsers.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/search/accessibility"
       },
       {
         "rule": "Tab navigation moves focus between the input field, clear button and search button",
         "wcag": null,
-        "quote": "Tab navigation allows users to move between the input field, the clear button and the search button."
+        "quote": "Tab navigation allows users to move between the input field, the clear button and the search button.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/search/accessibility"
       },
       {
         "rule": "Enter submits the search when the input field has focus",
         "wcag": null,
-        "quote": "Enter submits the search when the input field has focus."
+        "quote": "Enter submits the search when the input field has focus.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/search/accessibility"
       },
       {
         "rule": "Placeholder text must not be the only description, since screen readers handle it differently and it can confuse users",
         "wcag": null,
-        "quote": "Placeholder text should not be used as the only description, as screen readers handle it differently and it can create confusion."
+        "quote": "Placeholder text should not be used as the only description, as screen readers handle it differently and it can create confusion.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/search/accessibility"
       }
     ],
     "composition": [
       {
         "rule": "Search should complement navigation, not replace it, and should be avoided when content is easy to navigate without it",
-        "quote": "Avoid search when the content is easy to navigate without search it replaces good navigation — search should complement navigation, not be the only method"
+        "quote": "Avoid search when the content is easy to navigate without search it replaces good navigation — search should complement navigation, not be the only method",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/search/overview"
       },
       {
         "rule": "The width of the search field should reflect the typical length of search terms users enter",
-        "quote": "The width of the search field should reflect the length of the search terms users typically enter."
+        "quote": "The width of the search field should reflect the length of the search terms users typically enter.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/search/overview"
       },
       {
         "rule": "A main site search field should be wider so users can see several words at once",
-        "quote": "A main search field for a website should be wider so users can see several words at once."
+        "quote": "A main search field for a website should be wider so users can see several words at once.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/search/overview"
       },
       {
         "rule": "The field should not be so short that entered text becomes hidden, to avoid forcing scrolling within the field",
-        "quote": "To avoid forcing users to scroll within the field, ensure it is not so short that parts of the text become hidden."
+        "quote": "To avoid forcing users to scroll within the field, ensure it is not so short that parts of the text become hidden.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/search/overview"
       },
       {
         "rule": "Connect a label to Search.Input when a labeled search field is needed",
-        "quote": "If you want a label on the search field, add a label that you connect with Search.Input ."
+        "quote": "If you want a label on the search field, add a label that you connect with Search.Input .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/search/code"
       }
     ]
   },
@@ -1514,60 +2070,82 @@
       {
         "rule": "Avoid disabling the select; it can be unclear to users why the field is unusable",
         "wcag": null,
-        "quote": "Avoid disabling select if you can. It may be difficult for users to understand why the field cannot be used."
+        "quote": "Avoid disabling select if you can. It may be difficult for users to understand why the field cannot be used.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/select/overview"
       },
       {
         "rule": "Select should always have a label",
         "wcag": null,
-        "quote": "Select should always have a label."
+        "quote": "Select should always have a label.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/select/overview"
       },
       {
         "rule": "If the label comes from a table header and is visually hidden, it must still make sense since screen readers will read it aloud",
         "wcag": null,
-        "quote": "If select is inside a table and gets its label from the table header, the label can be hidden. However, make sure the label still makes sense, since it will still be read aloud by screen readers."
+        "quote": "If select is inside a table and gets its label from the table header, the label can be hidden. However, make sure the label still makes sense, since it will still be read aloud by screen readers.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/select/overview"
       },
       {
         "rule": "Avoid the disabled state; consider not showing the field, showing plain text, or using readOnly instead",
         "wcag": null,
-        "quote": "Avoid using the disabled ( disabled ) state. Consider instead whether you need to show the field at all, or whether you can present the information as plain text or use readOnly ."
+        "quote": "Avoid using the disabled ( disabled ) state. Consider instead whether you need to show the field at all, or whether you can present the information as plain text or use readOnly .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/select/accessibility"
       }
     ],
     "relations": [
       {
         "component": "Radio",
         "note": "Use radio instead of select when there are only a few options and enough space",
-        "quote": "Avoid select when you have only a few options and enough space — use radio instead"
+        "quote": "Avoid select when you have only a few options and enough space — use radio instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/select/overview"
       },
       {
         "component": "Checkbox",
         "note": "Recommended over select's multiple attribute when the user must select multiple options, for clarity and accessibility",
-        "quote": "the user must select multiple options. Although HTML select supports this through the multiple attribute, it is not user-friendly, especially on mobile. We recommend checkbox or suggestion for a clearer and more accessible solution."
+        "quote": "the user must select multiple options. Although HTML select supports this through the multiple attribute, it is not user-friendly, especially on mobile. We recommend checkbox or suggestion for a clearer and more accessible solution.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/select/overview"
       },
       {
         "component": "Suggestion",
         "note": "Recommended over select's multiple attribute when the user must select multiple options, for clarity and accessibility",
-        "quote": "the user must select multiple options. Although HTML select supports this through the multiple attribute, it is not user-friendly, especially on mobile. We recommend checkbox or suggestion for a clearer and more accessible solution."
+        "quote": "the user must select multiple options. Although HTML select supports this through the multiple attribute, it is not user-friendly, especially on mobile. We recommend checkbox or suggestion for a clearer and more accessible solution.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/select/overview"
       },
       {
         "component": "Radio",
         "note": "Radio buttons are often easier for users when there are fewer than 7 options",
-        "quote": "For fewer options, radio buttons (radio) are often easier for users."
+        "quote": "For fewer options, radio buttons (radio) are often easier for users.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/select/overview"
       },
       {
         "component": "Suggestion",
         "note": "Use suggestion instead when the user needs to select multiple options or filter the list",
-        "quote": "If the user needs to select multiple options or filter the list, you should consider using suggestion ."
+        "quote": "If the user needs to select multiple options or filter the list, you should consider using suggestion .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/select/overview"
       },
       {
         "component": "Radio",
         "note": "Radio buttons can be a better choice if the right preceding questions reduce the option count",
-        "quote": "If you ask the right questions first, radio buttons (radio) can be a better choice."
+        "quote": "If you ask the right questions first, radio buttons (radio) can be a better choice.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/select/overview"
       }
     ],
     "composition": [
       {
         "rule": "Place the label and description above the select field for visibility on small screens and to avoid error-message issues",
-        "quote": "We place the label and description above the field to ensure good visibility on small screens and to avoid issues with error messages."
+        "quote": "We place the label and description above the field to ensure good visibility on small screens and to avoid issues with error messages.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/select/overview"
       }
     ]
   },
@@ -1578,34 +2156,46 @@
       {
         "rule": "When prefers-reduced-motion is set to reduce, skeleton still animates (at a slower 1.6s duration) rather than disabling the animation, since it is not decorative.",
         "wcag": null,
-        "quote": "When the user has prefers-reduced-motion set to reduce , the skeleton will use a 1.6-second animation. The animation is not decorative, so we do not disable it."
+        "quote": "When the user has prefers-reduced-motion set to reduce , the skeleton will use a 1.6-second animation. The animation is not decorative, so we do not disable it.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/skeleton/accessibility"
       },
       {
         "rule": "The skeleton element should be marked aria-hidden=\"true\" so it is hidden from assistive technology.",
         "wcag": null,
-        "quote": "Add the class name ds-skeleton to a <span> with aria-hidden=\"true\" ."
+        "quote": "Add the class name ds-skeleton to a <span> with aria-hidden=\"true\" .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/skeleton/code"
       }
     ],
     "relations": [
       {
         "component": "Spinner",
         "note": "Use spinner instead of skeleton when indicating the system is working on a task the user must wait for.",
-        "quote": "Avoid skeleton when you need to indicate that the system is working on a task the user must wait for, use a spinner instead"
+        "quote": "Avoid skeleton when you need to indicate that the system is working on a task the user must wait for, use a spinner instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/skeleton/overview"
       },
       {
         "component": "Spinner",
         "note": "Skeleton is an alternative to spinner for indicating loading, giving a preview of the content's eventual shape.",
-        "quote": "Skeleton is an alternative to spinner when you want to indicate that content is loading."
+        "quote": "Skeleton is an alternative to spinner when you want to indicate that content is loading.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/skeleton/overview"
       }
     ],
     "composition": [
       {
         "rule": "Choose the skeleton variant based on the type of content being loaded, such as headings, text blocks or images.",
-        "quote": "Choose the skeleton variant based on the type of content being loaded, such as headings, text blocks or images."
+        "quote": "Choose the skeleton variant based on the type of content being loaded, such as headings, text blocks or images.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/skeleton/overview"
       },
       {
         "rule": "Skeletons should mimic the structure of the actual content so the transition to the fully loaded content feels smooth.",
-        "quote": "Try to mimic the structure of the actual content to make the transition to the fully loaded content feel smooth."
+        "quote": "Try to mimic the structure of the actual content to make the transition to the fully loaded content feel smooth.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/skeleton/overview"
       }
     ]
   },
@@ -1616,55 +2206,77 @@
       {
         "rule": "Users must be able to skip repeated content such as menus, links, and page headers when navigating by keyboard",
         "wcag": null,
-        "quote": "When navigating with a keyboard, users must be able to skip content that appears on multiple pages, such as menus, links, and the page header."
+        "quote": "When navigating with a keyboard, users must be able to skip content that appears on multiple pages, such as menus, links, and the page header.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/skip-link/overview"
       },
       {
         "rule": "The skip link should visually stand out from the rest of the content when focused",
         "wcag": null,
-        "quote": "The skip link should visually stand out from the rest of the content when focused, so users who can see but navigate with a keyboard can easily recognise it before moving on."
+        "quote": "The skip link should visually stand out from the rest of the content when focused, so users who can see but navigate with a keyboard can easily recognise it before moving on.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/skip-link/overview"
       },
       {
         "rule": "Skip link text should clearly describe what the shortcut does, using simple direct wording",
         "wcag": null,
-        "quote": "Make sure the text clearly describes what the shortcut does. Use simple and direct wording, such as “Skip to main content”."
+        "quote": "Make sure the text clearly describes what the shortcut does. Use simple and direct wording, such as “Skip to main content”.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/skip-link/overview"
       },
       {
         "rule": "Avoid adding a skip link when there are only a few tab stops before the main content, as it may add unnecessary focusable elements",
         "wcag": null,
-        "quote": "If there are only a few tab stops before the main content — for example, if the page only contains a single “Home” link at the top — adding a skip link may be unnecessary. In such cases, it could introduce more focusable elements than needed."
+        "quote": "If there are only a few tab stops before the main content — for example, if the page only contains a single “Home” link at the top — adding a skip link may be unnecessary. In such cases, it could introduce more focusable elements than needed.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/skip-link/overview"
       },
       {
         "rule": "It is safe to ignore automated accessibility test warnings that a skip link is missing from a landmark like <nav>",
         "wcag": null,
-        "quote": "Be aware that some automated accessibility tests may warn that a skip link is missing from a landmark, such as a <nav> . This warning does not apply to skip links, so you can safely ignore it."
+        "quote": "Be aware that some automated accessibility tests may warn that a skip link is missing from a landmark, such as a <nav> . This warning does not apply to skip links, so you can safely ignore it.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/skip-link/accessibility"
       },
       {
         "rule": "The skip link must behave predictably, moving focus to the start of the content rather than to the first paragraph under the heading",
         "wcag": null,
-        "quote": "Make sure that the skip link behaves predictably. A skip link with the text “Skip to content” should move the user’s focus to the start of the content, not to the beginning of the first paragraph under the heading."
+        "quote": "Make sure that the skip link behaves predictably. A skip link with the text “Skip to content” should move the user’s focus to the start of the content, not to the beginning of the first paragraph under the heading.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/skip-link/accessibility"
       },
       {
         "rule": "Pressing Enter on the skip link follows it and jumps to the target",
         "wcag": null,
-        "quote": "Enter follows the link and jumps to the target"
+        "quote": "Enter follows the link and jumps to the target",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/skip-link/accessibility"
       }
     ],
     "composition": [
       {
         "rule": "A skip link should be one of the first elements the keyboard focus reaches when navigating with the keyboard",
-        "quote": "A skip link should be one of the first elements the keyboard focus reaches when navigating with the keyboard."
+        "quote": "A skip link should be one of the first elements the keyboard focus reaches when navigating with the keyboard.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/skip-link/overview"
       },
       {
         "rule": "Place the skip link as the first focusable element on the page",
-        "quote": "Place the skip link as the first focusable element on the page."
+        "quote": "Place the skip link as the first focusable element on the page.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/skip-link/overview"
       },
       {
         "rule": "If the page includes a cookie banner or similar message, the skip link should be placed immediately after that element in the code",
-        "quote": "If the page includes a cookie banner or similar message, place the skip link immediately after that element in the code."
+        "quote": "If the page includes a cookie banner or similar message, place the skip link immediately after that element in the code.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/skip-link/overview"
       },
       {
         "rule": "Add the class ds-skip-link to an <a> tag pointing to the main content, and the target should be focusable via tabindex=\"-1\"",
-        "quote": "Add the class name ds-skip-link to an <a> tag that points to the main content of the page. The target should be able to receive focus with tabindex=\"-1\" ."
+        "quote": "Add the class name ds-skip-link to an <a> tag that points to the main content of the page. The target should be able to receive focus with tabindex=\"-1\" .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/skip-link/code"
       }
     ]
   },
@@ -1675,34 +2287,46 @@
       {
         "rule": "The spinner should be combined with text or have an aria-label so assistive technology users know loading is in progress",
         "wcag": null,
-        "quote": "To ensure a good user experience, the spinner should be combined with text or have an aria-label , so that users of assistive technologies are informed that loading is in progress."
+        "quote": "To ensure a good user experience, the spinner should be combined with text or have an aria-label , so that users of assistive technologies are informed that loading is in progress.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/spinner/accessibility"
       },
       {
         "rule": "When loading text is shown together with a spinner, the spinner must be hidden with aria-hidden=\"true\" to prevent duplicate announcements",
         "wcag": null,
-        "quote": "When you display text indicating loading together with a spinner, you must hide the spinner using aria-hidden=\"true\" to prevent “loading” from being announced multiple times."
+        "quote": "When you display text indicating loading together with a spinner, you must hide the spinner using aria-hidden=\"true\" to prevent “loading” from being announced multiple times.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/spinner/accessibility"
       },
       {
         "rule": "If no text is included, the spinner should instead have an aria-label",
         "wcag": null,
-        "quote": "If you do not include text, the spinner should instead have an aria-label ."
+        "quote": "If you do not include text, the spinner should instead have an aria-label .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/spinner/accessibility"
       }
     ],
     "relations": [
       {
         "component": "Skeleton",
         "note": "Avoid spinner when only specific parts of the page are loading; use skeleton instead",
-        "quote": "Avoid spinner when only specific parts of the page are loading — consider using skeleton instead"
+        "quote": "Avoid spinner when only specific parts of the page are loading — consider using skeleton instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/spinner/overview"
       }
     ],
     "composition": [
       {
         "rule": "Spinner can be used inside a button, a field, or another defined area where the user is waiting for something like saving or updating content",
-        "quote": "It can be used in a button, a field, or another defined area where the user is waiting for something to happen, such as saving or updating content."
+        "quote": "It can be used in a button, a field, or another defined area where the user is waiting for something to happen, such as saving or updating content.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/spinner/overview"
       },
       {
         "rule": "Explanatory text can be shown alongside the spinner to describe why the user has to wait",
-        "quote": "In some cases, it may improve the user experience to show explanatory text alongside the spinner, describing why the user has to wait."
+        "quote": "In some cases, it may improve the user experience to show explanatory text alongside the spinner, describing why the user has to wait.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/spinner/overview"
       }
     ]
   },
@@ -1713,13 +2337,17 @@
       {
         "component": "Radio",
         "note": "Use Radio or Checkbox when there are only a few options",
-        "quote": "users need to choose between only a few options"
+        "quote": "users need to choose between only a few options",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/suggestion/overview"
       }
     ],
     "composition": [
       {
         "rule": "Keep each option short",
-        "quote": "Each option should be short"
+        "quote": "Each option should be short",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/suggestion/overview"
       }
     ]
   },
@@ -1730,71 +2358,99 @@
       {
         "rule": "Use role=\"switch\" so screen readers identify the toggle switch and its on/off state.",
         "wcag": null,
-        "quote": "We use role=\"switch\" to inform screen readers that this is a toggle switch."
+        "quote": "We use role=\"switch\" to inform screen readers that this is a toggle switch.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/switch/accessibility"
       },
       {
         "rule": "This role tells screen reader users that the control is a switch that can be turned on and off.",
         "wcag": null,
-        "quote": "This allows screen readers to tell the user that it is a switch and that it can be turned on and off."
+        "quote": "This allows screen readers to tell the user that it is a switch and that it can be turned on and off.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/switch/accessibility"
       },
       {
         "rule": "Do not add aria-checked, since it is unnecessary on a switch built as a checkbox input.",
         "wcag": null,
-        "quote": "We do not add aria-checked because it is not necessary when the switch is an input with type=\"checkbox\" ."
+        "quote": "We do not add aria-checked because it is not necessary when the switch is an input with type=\"checkbox\" .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/switch/accessibility"
       },
       {
         "rule": "Space toggles the switch on and off via keyboard.",
         "wcag": null,
-        "quote": "Space toggles the switch on and off"
+        "quote": "Space toggles the switch on and off",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/switch/accessibility"
       },
       {
         "rule": "Label text should make sense when read aloud with an on/off switch announced at the end (for screen reader users).",
         "wcag": null,
-        "quote": "The text should make sense when you read it aloud and add an on/off switch at the end."
+        "quote": "The text should make sense when you read it aloud and add an on/off switch at the end.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/switch/overview"
       }
     ],
     "relations": [
       {
         "component": "Radio",
         "note": "When users are answering questions in a form, use radio instead of switch.",
-        "quote": "users are answering questions in forms, use radio or checkbox instead"
+        "quote": "users are answering questions in forms, use radio or checkbox instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/switch/overview"
       },
       {
         "component": "Checkbox",
         "note": "When users are answering questions in a form, use checkbox instead of switch.",
-        "quote": "users are answering questions in forms, use radio or checkbox instead"
+        "quote": "users are answering questions in forms, use radio or checkbox instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/switch/overview"
       },
       {
         "component": "Toggle group",
         "note": "When users are switching between different content views (e.g. list vs graph), use toggleGroup instead of switch.",
-        "quote": "users are switching between different content views, such as list and graph, use toggleGroup instead"
+        "quote": "users are switching between different content views, such as list and graph, use toggleGroup instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/switch/overview"
       },
       {
         "component": "Chip",
         "note": "When content needs to be filtered, use chip instead of switch.",
-        "quote": "content needs to be filtered, use chip instead"
+        "quote": "content needs to be filtered, use chip instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/switch/overview"
       }
     ],
     "composition": [
       {
         "rule": "Use fieldset to group multiple switch components together.",
-        "quote": "Use fieldset to group multiple switch components together."
+        "quote": "Use fieldset to group multiple switch components together.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/switch/overview"
       },
       {
         "rule": "By default, the switch is placed on the left and its label on the right.",
-        "quote": "As a rule, the switch is placed on the left and the label on the right."
+        "quote": "As a rule, the switch is placed on the left and the label on the right.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/switch/overview"
       },
       {
         "rule": "When switches are fixed on the right side of the interface, place the label on the left so switches align neatly on the right.",
-        "quote": "In some cases, switches are fixed on the right side of the interface. In those situations, it is best to place the label on the left, so all switches align neatly on the right."
+        "quote": "In some cases, switches are fixed on the right side of the interface. In those situations, it is best to place the label on the left, so all switches align neatly on the right.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/switch/overview"
       },
       {
         "rule": "Build the switch using the ds-input classname on an input with type=\"checkbox\" and role=\"switch\".",
-        "quote": "Use the classname ds-input on <input> along with type=\"checkbox\" and role=\"switch\" ."
+        "quote": "Use the classname ds-input on <input> along with type=\"checkbox\" and role=\"switch\" .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/switch/code"
       },
       {
         "rule": "For a valid form element, use ds-field together with a label.",
-        "quote": "For a valid form element, we recommend using <ds-field> together with a <label> ."
+        "quote": "For a valid form element, we recommend using <ds-field> together with a <label> .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/switch/code"
       }
     ]
   },
@@ -1805,105 +2461,149 @@
       {
         "rule": "Table cells must not be merged, and each cell should contain only one interactive element",
         "wcag": null,
-        "quote": "Table cells should not be merged, and each cell should contain only one interactive element."
+        "quote": "Table cells should not be merged, and each cell should contain only one interactive element.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/table/accessibility"
       },
       {
         "rule": "Use row and/or column headers so screen reader users can navigate the table",
         "wcag": null,
-        "quote": "For screen reader users to navigate the content, it is important to use row and/or column headers ( <Table.HeaderCell> )."
+        "quote": "For screen reader users to navigate the content, it is important to use row and/or column headers ( <Table.HeaderCell> ).",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/table/accessibility"
       },
       {
         "rule": "Mark headers with scope=\"row\" or scope=\"col\" to indicate what they apply to",
         "wcag": null,
-        "quote": "Use scope=\"row\" and scope=\"col\" to indicate whether the header applies to a row or a column."
+        "quote": "Use scope=\"row\" and scope=\"col\" to indicate whether the header applies to a row or a column.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/table/accessibility"
       },
       {
         "rule": "Headers may be visually hidden if space is limited",
         "wcag": null,
-        "quote": "If space is limited, you may visually hide one or more headers."
+        "quote": "If space is limited, you may visually hide one or more headers.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/table/accessibility"
       },
       {
         "rule": "Tables must always include a caption describing what the table shows, since screen readers read it first",
         "wcag": null,
-        "quote": "Tables must always include a caption element that provides a brief description of what the table shows. Screen readers will read the caption, allowing users to decide whether they want to continue reading the table."
+        "quote": "Tables must always include a caption element that provides a brief description of what the table shows. Screen readers will read the caption, allowing users to decide whether they want to continue reading the table.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/table/accessibility"
       },
       {
         "rule": "Empty cells must use Table.Cell so screen readers can navigate the table correctly",
         "wcag": null,
-        "quote": "Empty cells must use Table.Cell . This is important to ensure that screen readers can navigate the table correctly."
+        "quote": "Empty cells must use Table.Cell . This is important to ensure that screen readers can navigate the table correctly.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/table/accessibility"
       },
       {
         "rule": "Make sure sorting can be changed using the keyboard",
         "wcag": null,
-        "quote": "Make sure you can change the sorting using the keyboard."
+        "quote": "Make sure you can change the sorting using the keyboard.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/table/accessibility"
       },
       {
         "rule": "Test sorting with a screen reader to confirm sortable state, sort direction, and that focus isn't lost when sorting changes",
         "wcag": null,
-        "quote": "Test with a screen reader to verify that you hear what is sortable, the sorting types, and that focus is not lost when sorting changes."
+        "quote": "Test with a screen reader to verify that you hear what is sortable, the sorting types, and that focus is not lost when sorting changes.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/table/accessibility"
       },
       {
         "rule": "Tables are challenging on mobile; common adaptations are horizontal scroll or converting to a list view",
         "wcag": null,
-        "quote": "Tables can be challenging on mobile, as there is no universal design that works well in all contexts. The most common approaches are a table that scrolls horizontally or converting the table into a list view."
+        "quote": "Tables can be challenging on mobile, as there is no universal design that works well in all contexts. The most common approaches are a table that scrolls horizontally or converting the table into a list view.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/table/accessibility"
       }
     ],
     "relations": [
       {
         "component": "List",
         "note": "Prefer a list view over a table when the content is better suited to a list",
-        "quote": "the information is better suited to a list or card view"
+        "quote": "the information is better suited to a list or card view",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/table/overview"
       },
       {
         "component": "Card",
         "note": "Prefer a card view over a table when the content is better suited to cards",
-        "quote": "the information is better suited to a list or card view"
+        "quote": "the information is better suited to a list or card view",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/table/overview"
       }
     ],
     "composition": [
       {
         "rule": "Use table to compare information, present clearly structured row/column data, or support sorting",
-        "quote": "Use table when the goal is to help users compare information easily the data needs a clear structure with rows and columns the content can benefit from sorting"
+        "quote": "Use table when the goal is to help users compare information easily the data needs a clear structure with rows and columns the content can benefit from sorting",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/table/overview"
       },
       {
         "rule": "Avoid table for page layout, when content is very limited without need for comparison, or when large data sets become hard to read on mobile",
-        "quote": "Avoid using table when the purpose is to create layout or visually organise content on a page the information is better suited to a list or card view the content is very limited, for example only one column or very few data points without a need for comparison the table becomes difficult to read on mobile because the data set is large"
+        "quote": "Avoid using table when the purpose is to create layout or visually organise content on a page the information is better suited to a list or card view the content is very limited, for example only one column or very few data points without a need for comparison the table becomes difficult to read on mobile because the data set is large",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/table/overview"
       },
       {
         "rule": "Use table to structure and present data clearly in rows and columns",
-        "quote": "Use table to structure and present data clearly in rows and columns."
+        "quote": "Use table to structure and present data clearly in rows and columns.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/table/overview"
       },
       {
         "rule": "Content should be left-aligned except numbers, which should be right-aligned for easier comparison",
-        "quote": "Content in tables should be left-aligned, except for numbers, which should be right-aligned to make comparison easier."
+        "quote": "Content in tables should be left-aligned, except for numbers, which should be right-aligned to make comparison easier.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/table/overview"
       },
       {
         "rule": "Use Table.HeaderCell (not Table.Cell) for cells that describe the content of their row or column",
-        "quote": "Use <Table.HeaderCell> for header cells, not <Table.Cell> . A cell counts as a header when it describes the content of the same row or column."
+        "quote": "Use <Table.HeaderCell> for header cells, not <Table.Cell> . A cell counts as a header when it describes the content of the same row or column.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/table/overview"
       },
       {
         "rule": "In rows with several actions, a menu can be used to save space when the actions don't need to be visible at all times",
-        "quote": "In table rows with several actions, you can use a menu to save space if the actions do not need to be visible at all times."
+        "quote": "In table rows with several actions, you can use a menu to save space if the actions do not need to be visible at all times.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/table/overview"
       },
       {
         "rule": "When numbers are meant to be compared, align them to the right within the cell",
-        "quote": "When numbers appear in a table and are meant to be compared, align them to the right within the cell."
+        "quote": "When numbers appear in a table and are meant to be compared, align them to the right within the cell.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/table/overview"
       },
       {
         "rule": "Avoid long texts in table cells; keep content short and concise so it's easy to scan across rows and columns",
-        "quote": "Avoid long texts in table cells. Keep content short and concise so it is easy to scan across rows and columns."
+        "quote": "Avoid long texts in table cells. Keep content short and concise so it is easy to scan across rows and columns.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/table/overview"
       },
       {
         "rule": "If more information is needed than fits in a cell, consider linking to a detail page",
-        "quote": "If you need to show more information, consider linking to a detail page."
+        "quote": "If you need to show more information, consider linking to a detail page.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/table/overview"
       },
       {
         "rule": "Use headers to tell users what type of content they'll find in rows and columns",
-        "quote": "Use headers to tell users what type of content they will find in the rows and columns."
+        "quote": "Use headers to tell users what type of content they will find in the rows and columns.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/table/overview"
       },
       {
         "rule": "Content in cells should generally be left-aligned; exceptions are numbers, currency, and sometimes form elements and buttons",
-        "quote": "As a general rule, content in cells should be left-aligned to make it easier to read and scan. The exception is numbers and currency and sometimes form elements and buttons."
+        "quote": "As a general rule, content in cells should be left-aligned to make it easier to read and scan. The exception is numbers and currency and sometimes form elements and buttons.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/table/overview"
       }
     ]
   },
@@ -1914,83 +2614,119 @@
       {
         "rule": "Icons used in tabs must be intuitive and have descriptive titles for screen readers.",
         "wcag": null,
-        "quote": "Ensure that the icons are intuitive and have descriptive titles for screen readers."
+        "quote": "Ensure that the icons are intuitive and have descriptive titles for screen readers.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tabs/overview"
       },
       {
         "rule": "When icons are combined with text, the icons should be decorative and marked with aria-hidden.",
         "wcag": null,
-        "quote": "Icons should be decorative and marked with aria-hidden ."
+        "quote": "Icons should be decorative and marked with aria-hidden .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tabs/overview"
       },
       {
         "rule": "Use the ds-tabs component rather than building a custom tabs implementation, to ensure good accessibility and functionality.",
         "wcag": null,
-        "quote": "We recommend using <ds-tabs> , and not building your own tabs from scratch, to ensure good accessibility and functionality."
+        "quote": "We recommend using <ds-tabs> , and not building your own tabs from scratch, to ensure good accessibility and functionality.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tabs/code"
       },
       {
         "rule": "Each tab must have a unique title.",
         "wcag": null,
-        "quote": "Each tab must have a unique title"
+        "quote": "Each tab must have a unique title",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tabs/accessibility"
       },
       {
         "rule": "Icons used in tabs must be decorative (aria-hidden) or have descriptive titles.",
         "wcag": null,
-        "quote": "When using icons, ensure they are decorative ( aria-hidden ) or have descriptive titles"
+        "quote": "When using icons, ensure they are decorative ( aria-hidden ) or have descriptive titles",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tabs/accessibility"
       },
       {
         "rule": "If a tab panel has no focusable elements, the panel itself receives focus.",
         "wcag": null,
-        "quote": "If a tab panel does not contain any focusable elements, the panel itself receives focus"
+        "quote": "If a tab panel does not contain any focusable elements, the panel itself receives focus",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tabs/accessibility"
       },
       {
         "rule": "Tabs support keyboard navigation with arrow keys.",
         "wcag": null,
-        "quote": "Tabs supports keyboard navigation with arrow keys"
+        "quote": "Tabs supports keyboard navigation with arrow keys",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tabs/accessibility"
       }
     ],
     "composition": [
       {
         "rule": "Use tabs when content needs structuring without loading a new page, when information benefits from being divided into clearly labelled sections, and when navigation becomes easier without viewing all content at once.",
-        "quote": "Use tabs when content needs to be structured without loading a new page information benefits from being divided into clearly labelled sections navigation becomes easier when users do not need to view all content at once"
+        "quote": "Use tabs when content needs to be structured without loading a new page information benefits from being divided into clearly labelled sections navigation becomes easier when users do not need to view all content at once",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tabs/overview"
       },
       {
         "rule": "Avoid tabs when an immediate overview is needed, when information must be compared across sections, for step-by-step processes where order matters, for large amounts of content, or when the content could be shown on a single page or spread across several pages.",
-        "quote": "Avoid using tabs when it is important to give an immediate overview of the content information needs to be compared across sections users must go through a step-by-step process where the order matters large amounts of content may slow down the page the content could just as well be shown on a single page or spread across several pages"
+        "quote": "Avoid using tabs when it is important to give an immediate overview of the content information needs to be compared across sections users must go through a step-by-step process where the order matters large amounts of content may slow down the page the content could just as well be shown on a single page or spread across several pages",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tabs/overview"
       },
       {
         "rule": "Before choosing tabs, consider simplifying content, distributing it across pages, keeping it on a single page with clear headings, or using a table of contents.",
-        "quote": "Before choosing tabs, consider whether it might be better to: simplify and reduce the amount of content distribute the content across several pages keep everything on a single page with clear headings use a table of contents for easier navigation"
+        "quote": "Before choosing tabs, consider whether it might be better to: simplify and reduce the amount of content distribute the content across several pages keep everything on a single page with clear headings use a table of contents for easier navigation",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tabs/overview"
       },
       {
         "rule": "Limit the number of tabs, since too many make it hard to get an overview, especially on small screens.",
-        "quote": "Limit the number of tabs - too many make it difficult to get an overview, especially on small screens"
+        "quote": "Limit the number of tabs - too many make it difficult to get an overview, especially on small screens",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tabs/overview"
       },
       {
         "rule": "Use clear, descriptive tab names since tabs hide content and it must be obvious what each section contains.",
-        "quote": "Use clear, descriptive names - tabs hide content, so it must be obvious what each section contains"
+        "quote": "Use clear, descriptive names - tabs hide content, so it must be obvious what each section contains",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tabs/overview"
       },
       {
         "rule": "Place the most important content first, organising tabs according to users' needs.",
-        "quote": "Place the most important content first - organise tabs according to users' needs"
+        "quote": "Place the most important content first - organise tabs according to users' needs",
+        "verified": false,
+        "sourcePage": null
       },
       {
         "rule": "Keep tabs on a single line, since long labels or too many tabs make navigation harder.",
-        "quote": "Keep tabs on a single line - long labels or too many tabs make navigation harder"
+        "quote": "Keep tabs on a single line - long labels or too many tabs make navigation harder",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tabs/overview"
       },
       {
         "rule": "Avoid disabled tabs; remove them or explain why they contain no content.",
-        "quote": "Avoid disabled tabs - remove them or explain why they contain no content"
+        "quote": "Avoid disabled tabs - remove them or explain why they contain no content",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tabs/overview"
       },
       {
         "rule": "Tab labels should be short and descriptive so users understand what they will find when clicking.",
-        "quote": "Tabs labels should be short and descriptive so users can easily understand what they will find when clicking."
+        "quote": "Tabs labels should be short and descriptive so users can easily understand what they will find when clicking.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tabs/overview"
       },
       {
         "rule": "Difficulty creating clear tab labels may indicate the content is not well structured.",
-        "quote": "If it is difficult to create clear labels, it may indicate that the content is not well structured."
+        "quote": "If it is difficult to create clear labels, it may indicate that the content is not well structured.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tabs/overview"
       },
       {
         "rule": "If additional context is needed, a shared heading can be placed above the tabs component.",
-        "quote": "If additional context is needed, a shared heading can be placed above the tabs component."
+        "quote": "If additional context is needed, a shared heading can be placed above the tabs component.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tabs/overview"
       }
     ]
   },
@@ -2001,47 +2737,65 @@
       {
         "rule": "Group multiple Tags in a list so assistive tech announces them as a list, not one sentence",
         "wcag": null,
-        "quote": "If you are displaying several Tag components together, we recommend using a <ul> list with one <li> per Tag . This ensures that they are announced as a list rather than as one continuous sentence, providing a better experience for users of assistive technologies."
+        "quote": "If you are displaying several Tag components together, we recommend using a <ul> list with one <li> per Tag . This ensures that they are announced as a list rather than as one continuous sentence, providing a better experience for users of assistive technologies.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tag/accessibility"
       },
       {
         "rule": "Place multiple tags in a <ul>/<li> structure so screen readers announce them as a list",
         "wcag": null,
-        "quote": "When using multiple tags together, place them in a <ul> with <li> elements so screen readers announce them as a list."
+        "quote": "When using multiple tags together, place them in a <ul> with <li> elements so screen readers announce them as a list.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tag/overview"
       }
     ],
     "relations": [
       {
         "component": "Link",
         "note": "Use Link instead of Tag when linking to another page",
-        "quote": "linking to another page, use link instead"
+        "quote": "linking to another page, use link instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tag/overview"
       },
       {
         "component": "Button",
         "note": "Use Button instead of Tag when the element triggers an action",
-        "quote": "the element triggers an action, use button instead"
+        "quote": "the element triggers an action, use button instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tag/overview"
       },
       {
         "component": "Chip",
         "note": "Use Chip instead of Tag when the user needs to filter content",
-        "quote": "the user needs to filter content, use chip instead"
+        "quote": "the user needs to filter content, use chip instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tag/overview"
       }
     ],
     "composition": [
       {
         "rule": "Tag should generally be placed after the title or name of the related element",
-        "quote": "Tag should generally be placed after the title or name of the related element."
+        "quote": "Tag should generally be placed after the title or name of the related element.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tag/overview"
       },
       {
         "rule": "Avoid placing tags next to buttons, as this can confuse users",
-        "quote": "Avoid placing tags next to buttons, as this can confuse users."
+        "quote": "Avoid placing tags next to buttons, as this can confuse users.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tag/overview"
       },
       {
         "rule": "Icons can be used inside a tag to add additional visual information",
-        "quote": "Icons can be used inside a tag to add additional visual information."
+        "quote": "Icons can be used inside a tag to add additional visual information.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tag/overview"
       },
       {
         "rule": "Keep the padding on tag equal to the icon's margin when combining icon and text",
-        "quote": "We recommend keeping the padding on tag equal to the icon’s margin ."
+        "quote": "We recommend keeping the padding on tag equal to the icon’s margin .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tag/overview"
       }
     ]
   },
@@ -2052,53 +2806,73 @@
       {
         "rule": "Avoid disabling a textarea if possible, since it can be difficult for users to understand why the field cannot be used.",
         "wcag": null,
-        "quote": "Avoid disabling a textarea if possible. It can be difficult for users to understand why the field cannot be used."
+        "quote": "Avoid disabling a textarea if possible. It can be difficult for users to understand why the field cannot be used.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/textarea/overview"
       },
       {
         "rule": "readOnly can be confusing since a text field is normally expected to be editable; use it only when truly necessary.",
         "wcag": null,
-        "quote": "Since a text field is normally expected to be editable, readOnly can be confusing. Use it only when it is truly necessary. In many cases, it is better to display the information as plain text rather than in a readOnly field."
+        "quote": "Since a text field is normally expected to be editable, readOnly can be confusing. Use it only when it is truly necessary. In many cases, it is better to display the information as plain text rather than in a readOnly field.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/textarea/overview"
       },
       {
         "rule": "If readOnly is used, you must explain to the user why the content cannot be edited.",
         "wcag": null,
-        "quote": "Important: If you choose to use readOnly , you must explain to the user why the content cannot be edited."
+        "quote": "Important: If you choose to use readOnly , you must explain to the user why the content cannot be edited.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/textarea/overview"
       },
       {
         "rule": "Fields with the readonly attribute remain part of the tab order.",
         "wcag": null,
-        "quote": "Fields with the readonly attribute remain part of the tab order."
+        "quote": "Fields with the readonly attribute remain part of the tab order.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/textarea/overview"
       }
     ],
     "relations": [
       {
         "component": "Textfield",
         "note": "Use textfield instead of textarea when short answers are expected.",
-        "quote": "Avoid using textarea when short answers are expected, use textfield instead"
+        "quote": "Avoid using textarea when short answers are expected, use textfield instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/textarea/overview"
       },
       {
         "component": "Radio",
         "note": "For structured/fixed-choice answers, break the question into smaller parts and use components like Radio instead of a free-text textarea.",
-        "quote": "Be aware that some users find free-text fields challenging. In certain cases, it may be better to break the question into smaller, more structured parts and let users answer with components such as Radio ."
+        "quote": "Be aware that some users find free-text fields challenging. In certain cases, it may be better to break the question into smaller, more structured parts and let users answer with components such as Radio .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/textarea/overview"
       },
       {
         "component": "Textfield",
         "note": "Textarea should also follow the general guidelines defined for textfield.",
-        "quote": "In addition to these recommendations, follow the general guidelines for textfield"
+        "quote": "In addition to these recommendations, follow the general guidelines for textfield",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/textarea/overview"
       }
     ],
     "composition": [
       {
         "rule": "The height of the textarea should reflect the expected amount of text.",
-        "quote": "The height of the textarea should reflect the expected amount of text."
+        "quote": "The height of the textarea should reflect the expected amount of text.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/textarea/overview"
       },
       {
         "rule": "Textarea should expand in height when users need more space.",
-        "quote": "Textarea should expand in height when users need more space."
+        "quote": "Textarea should expand in height when users need more space.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/textarea/overview"
       },
       {
         "rule": "A textarea should not be wider than 50-75 characters including spaces.",
-        "quote": "A textarea should not be wider than 50-75 characters including spaces."
+        "quote": "A textarea should not be wider than 50-75 characters including spaces.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/textarea/overview"
       }
     ]
   },
@@ -2109,35 +2883,47 @@
       {
         "rule": "A textfield must always have a label",
         "wcag": ["1.3.1"],
-        "quote": "A textfield must always have a label."
+        "quote": "A textfield must always have a label.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/textfield/overview"
       },
       {
         "rule": "Prefixes and suffixes must not be used without a label",
         "wcag": ["1.3.1"],
-        "quote": "These must **not** be used without a `<label>`, since screen readers will not announce them."
+        "quote": "These must **not** be used without a `<label>`, since screen readers will not announce them.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/textfield/overview"
       },
       {
         "rule": "Information in a prefix or suffix must also appear in the label",
         "wcag": ["1.3.1"],
-        "quote": "The information shown in the prefix or suffix must also be reflected in the label text."
+        "quote": "The information shown in the prefix or suffix must also be reflected in the label text.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/textfield/overview"
       },
       {
         "rule": "Autocomplete is required where a predefined purpose exists",
         "wcag": ["1.3.5"],
-        "quote": "Autocomplete is required in fields where a predefined purpose exists, as defined in 1.3.5"
+        "quote": "Autocomplete is required in fields where a predefined purpose exists, as defined in 1.3.5",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/textfield/overview"
       }
     ],
     "relations": [
       {
         "component": "Input",
         "note": "Use Input for a simple field without form logic",
-        "quote": "you need a simple input field without form logic, use input instead"
+        "quote": "you need a simple input field without form logic, use input instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/textfield/overview"
       }
     ],
     "composition": [
       {
         "rule": "Textfield bundles label, help text and validation message",
-        "quote": "you need a complete form field with label, help text, and validation message"
+        "quote": "you need a complete form field with label, help text, and validation message",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/textfield/overview"
       }
     ]
   },
@@ -2148,29 +2934,39 @@
       {
         "rule": "Icon-only toggles need a tooltip to convey meaning",
         "wcag": null,
-        "quote": "Use tooltip to clarify the actions when using icons alone."
+        "quote": "Use tooltip to clarify the actions when using icons alone.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/toggle-group/overview"
       }
     ],
     "relations": [
       {
         "component": "Radio",
         "note": "Use Radio when the options are answers in a form",
-        "quote": "the options represent answers in a form"
+        "quote": "the options represent answers in a form",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/toggle-group/overview"
       },
       {
         "component": "Switch",
         "note": "Use Switch for an on/off setting",
-        "quote": "the choice is an on/off setting"
+        "quote": "the choice is an on/off setting",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/toggle-group/overview"
       }
     ],
     "composition": [
       {
         "rule": "At least two options, few enough to fit on one line",
-        "quote": "A toggle group should have at least two options, but not so many that they no longer fit horizontally."
+        "quote": "A toggle group should have at least two options, but not so many that they no longer fit horizontally.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/toggle-group/overview"
       },
       {
         "rule": "The group needs a label explaining what the options refer to",
-        "quote": "Include a label for the group that explains what the options refer to."
+        "quote": "Include a label for the group that explains what the options refer to.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/toggle-group/overview"
       }
     ]
   },
@@ -2185,72 +2981,102 @@
       {
         "rule": "Tooltip must not be used as a substitute for alt text or title attributes",
         "wcag": null,
-        "quote": "Tooltip should never be used as a replacement for alt text or title ."
+        "quote": "Tooltip should never be used as a replacement for alt text or title .",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tooltip/overview"
       },
       {
         "rule": "Tooltip is less suitable on touch devices since it normally relies on hover or focus, which touch does not support",
         "wcag": null,
-        "quote": "On touch devices, Tooltip is less suitable because it is normally triggered by hover or focus , which are not supported on these devices."
+        "quote": "On touch devices, Tooltip is less suitable because it is normally triggered by hover or focus , which are not supported on these devices.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tooltip/accessibility"
       }
     ],
     "relations": [
       {
         "component": "Popover",
         "note": "Use popover instead of tooltip when the explanation is longer than four words",
-        "quote": "the explanation is longer than four words, use popover instead"
+        "quote": "the explanation is longer than four words, use popover instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tooltip/overview"
       },
       {
         "component": "Popover",
         "note": "Use popover instead of tooltip when the content contains links or other interactive elements",
-        "quote": "the content contains links or other interactive elements, use popover instead"
+        "quote": "the content contains links or other interactive elements, use popover instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tooltip/overview"
       },
       {
         "component": "Popover",
         "note": "Use popover instead of tooltip when richer content such as longer text, images, or buttons is needed",
-        "quote": "If richer content is needed - for example longer text, images, or buttons - use a popover instead."
+        "quote": "If richer content is needed - for example longer text, images, or buttons - use a popover instead.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tooltip/overview"
       },
       {
         "component": "Popover",
         "note": "The Tooltip `open` prop is deprecated for overriding open state; use Popover instead",
-        "quote": "This should not be used on Tooltip. Use a Popover instead"
+        "quote": "This should not be used on Tooltip. Use a Popover instead",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tooltip/code"
       }
     ],
     "composition": [
       {
         "rule": "Tooltip provides brief supplementary information without distracting from the main content",
-        "quote": "Tooltip provides brief supplementary information without distracting from the main content."
+        "quote": "Tooltip provides brief supplementary information without distracting from the main content.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tooltip/overview"
       },
       {
         "rule": "Tooltip is not intended for information essential to completing a task",
-        "quote": "Tooltip is not intended for information that is essential for completing a task."
+        "quote": "Tooltip is not intended for information that is essential for completing a task.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tooltip/overview"
       },
       {
         "rule": "Important content should appear as body text or help text on the page, not in a tooltip",
-        "quote": "Important content should instead appear as body text or help text on the page."
+        "quote": "Important content should instead appear as body text or help text on the page.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tooltip/overview"
       },
       {
         "rule": "Use tooltip when a symbol needs explanation, an interactive element's action needs clarifying, or keyboard shortcuts need to be shown",
-        "quote": "Use tooltip when a symbol needs a brief explanation the action of an interactive element needs to be clarified keyboard shortcuts need to be shown"
+        "quote": "Use tooltip when a symbol needs a brief explanation the action of an interactive element needs to be clarified keyboard shortcuts need to be shown",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tooltip/overview"
       },
       {
         "rule": "Avoid using tooltip when the text is already visible on the page",
-        "quote": "Avoid using tooltip when the text is already visible on the page"
+        "quote": "Avoid using tooltip when the text is already visible on the page",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tooltip/overview"
       },
       {
         "rule": "Consider whether the tooltip should be placed above, below, or beside the element",
-        "quote": "Consider whether the tooltip should be placed above, below, or beside the element."
+        "quote": "Consider whether the tooltip should be placed above, below, or beside the element.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tooltip/overview"
       },
       {
         "rule": "A tooltip should not contain more than one sentence or more than four words, to avoid obstructing other important elements on screen",
-        "quote": "A tooltip should not contain more than one sentence or more than four words, to avoid obstructing other important elements on the screen."
+        "quote": "A tooltip should not contain more than one sentence or more than four words, to avoid obstructing other important elements on the screen.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tooltip/overview"
       },
       {
         "rule": "Tooltip should not repeat text that is already present on the page",
-        "quote": "Tooltip should not repeat text that is already present on the page."
+        "quote": "Tooltip should not repeat text that is already present on the page.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tooltip/overview"
       },
       {
         "rule": "Tooltip content should provide additional help or clarification that is not immediately obvious",
-        "quote": "It should provide additional help or clarification that is not immediately obvious."
+        "quote": "It should provide additional help or clarification that is not immediately obvious.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/tooltip/overview"
       }
     ]
   },
@@ -2261,7 +3087,9 @@
       {
         "rule": "Messages should be placed close to the field they relate to",
         "wcag": ["3.3.1"],
-        "quote": "Messages should be placed close to the field they relate to, so that both visual users and users of assistive technologies can easily understand the connection."
+        "quote": "Messages should be placed close to the field they relate to, so that both visual users and users of assistive technologies can easily understand the connection.",
+        "verified": true,
+        "sourcePage": "https://designsystemet.no/en/components/docs/validation-message/overview"
       }
     ]
   }


### PR DESCRIPTION
## Summary

Third PR of the stack proposed in #5166 (AI-readiness), stacked on #5176. It adds:

- the www build generates the twin registry into `public/twins/` and the [llms.txt](https://llmstxt.org) index at the site root, so designsystemet.no serves `/llms.txt` and `/twins/components/<Name>.json`
- the document head advertises the index (`<link rel="alternate" type="text/plain" href="/llms.txt">` plus a `llms-txt` meta): in trials, discovery went from 4/8 to 7/8 agents when advertised there
- `merge:twins` is reworked for build use: the default run is offline and deterministic, merging the verification state stored in `scripts/twins-authored.json`; `--verify` is the maintenance mode that fetches the cited docs pages, rechecks every quote and writes the result back to the data file
- generated site output is gitignored, consistent with the build-time stance stated on #5167

The per-PR preview deployment should serve `/llms.txt` and the twins as soon as it builds, which makes this PR the natural place to try the whole thing in a test environment.

🚧 **Draft on purpose**: stacked on #5176 (the branch contains the earlier stack commits; the diff specific to this PR is the www wiring and the offline/verify split). Not ready for merge until the stack's shape is agreed on #5166.

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant): not relevant, no package changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
