### PR TITLE
docs: 🚧 AI-assisted development page (no/en)

### DIFF
--- a/apps/www/app/content/fundamentals/en/code/ai-assisted-development.mdx
+++ b/apps/www/app/content/fundamentals/en/code/ai-assisted-development.mdx
@@ -1,0 +1,75 @@
+---
+title: AI-assisted development
+description: Give your coding assistant the component and pattern definitions directly, instead of letting it infer them.
+date: 2026-08-13
+category: Code
+color: blue
+icon: CodeIcon
+published: true
+order: 5
+search_terms: ai, agent, plugin, mcp, claude, copilot, cursor, coding assistant
+---
+
+An increasing share of the code built on Designsystemet is written with a coding assistant.
+Assistants that read these pages as ordinary web documentation generally get the visible parts
+right and the accessibility parts wrong — most often the error handling required by WCAG 3.3.1,
+where a field enters an error state without `aria-invalid` or a linked error summary.
+
+## Before you generate any code
+
+Install the packages. Do not reproduce them by hand.
+
+```bash
+npm install @digdir/designsystemet-react @digdir/designsystemet-css
+```
+
+Then import the CSS, import a theme, and add the Inter font — all of it is on the
+[setup page](/en/fundamentals/code/setup). Skipping any of it produces markup that carries the
+right `ds-*` class names with none of the design behind it: the structure looks correct and
+the page looks nothing like Designsystemet. Hand-written custom properties also drift the
+moment the theme changes.
+
+Use the CLI rather than reimplementing what it generates:
+
+| Need | Command |
+|---|---|
+| Create a theme and tokens | `npx @digdir/designsystemet tokens create` |
+| Rebuild tokens after a config change | `npx @digdir/designsystemet tokens build` |
+| Upgrade across a breaking version | `npx @digdir/designsystemet migrate` |
+
+## The plugin (experimental)
+
+> **Note:** the plugin is an experimental proof of concept, currently distributed
+> from its author's repository while a permanent, Digdir-owned home is decided.
+> Evaluate it accordingly before installing.
+
+The plugin gives your coding assistant the component and pattern definitions directly, so it
+uses the real props, the real design tokens and the required accessibility wiring — instead of
+inferring them from rendered documentation.
+
+```bash
+claude plugin marketplace add sorensensig/ai-corner-store
+claude plugin install designsystemet@ai-corner-store
+```
+
+Works with Claude Code; the bundled MCP server works in any assistant that speaks MCP. Your code is not sent to Digdir.
+
+## What the assistant gets
+
+| | |
+|---|---|
+| `list_twins` | Every component and pattern available |
+| `get_component` | One component's contract — import name, emitted attributes, design tokens, and the accessibility requirements the component does not enforce for you |
+| `get_pattern` | A pattern — which components compose it, in what order, and the rules that apply |
+| `find_equivalent` | Maps a foreign component name to the right Designsystemet component |
+
+## Without the plugin
+
+Assistants that cannot install a plugin — in a browser rather than a coding tool, for example
+— can read the machine-readable index directly:
+
+```
+https://designsystemet.no/llms.txt
+```
+
+The index lists every component and pattern with a link to its documentation.

--- a/apps/www/app/content/fundamentals/no/code/ai-assistert-utvikling.mdx
+++ b/apps/www/app/content/fundamentals/no/code/ai-assistert-utvikling.mdx
@@ -1,0 +1,75 @@
+---
+title: KI-assistert utvikling
+description: Gje kodeassistenten din komponent- og mønsterdefinisjonane direkte, i staden for at han gjettar seg fram.
+date: 2026-08-13
+category: Kode
+color: blue
+icon: CodeIcon
+published: true
+order: 5
+search_terms: ai, ki, agent, plugin, mcp, claude, copilot, cursor, kodeassistent
+---
+
+Ein aukande del av koden som byggjer på Designsystemet blir skriven saman med ein
+kodeassistent. Assistentar som les desse sidene som vanlege nettsider får som regel dei
+synlege delane rette, men bommar på tilgjengelegheita — oftast feilhandteringa som WCAG 3.3.1
+krev, der eit felt får feilstatus utan `aria-invalid` eller ei kopla feiloppsummering.
+
+## Før du genererer kode
+
+Installer pakkane. Ikkje lag dei på nytt for hand.
+
+```bash
+npm install @digdir/designsystemet-react @digdir/designsystemet-css
+```
+
+Deretter importerer du CSS-en, importerer eit tema og legg til Inter-fonten — alt saman står på
+[oppsettsida](/no/fundamentals/code/setup). Hoppar du over noko av det, får du markup med rette
+`ds-*` klassenamn og ingenting av designet bak: strukturen ser rett ut, og sida ser ikkje ut som
+Designsystemet i det heile. Handskrivne custom properties driv dessutan frå kvarandre så snart
+temaet blir endra.
+
+Bruk CLI-en i staden for å lage det han genererer på nytt:
+
+| Behov | Kommando |
+|---|---|
+| Lage tema og token | `npx @digdir/designsystemet tokens create` |
+| Byggje token på nytt etter endring | `npx @digdir/designsystemet tokens build` |
+| Oppgradere over ein brytande versjon | `npx @digdir/designsystemet migrate` |
+
+## Pluginen (eksperimentell)
+
+> **Merk:** pluginen er eit eksperimentelt konsept og blir førebels distribuert
+> frå forfattaren sitt eige kodelager, i påvente av ein permanent heim eigd av
+> Digdir. Vurder dette før du installerer.
+
+Pluginen gjev kodeassistenten komponent- og mønsterdefinisjonane direkte, slik at han brukar
+dei verkelege prop-ane, dei verkelege designtokena og den tilgjengelegheitskoplinga som krevst
+— i staden for å utleie dei frå gjengitt dokumentasjon.
+
+```bash
+claude plugin marketplace add sorensensig/ai-corner-store
+claude plugin install designsystemet@ai-corner-store
+```
+
+Fungerer med Claude Code; MCP-serveren som følgjer med, verkar i alle assistentar som støttar MCP. Koden din blir ikkje send til Digdir.
+
+## Kva assistenten får
+
+| | |
+|---|---|
+| `list_twins` | Alle komponentar og mønster som finst |
+| `get_component` | Kontrakten for éin komponent — importnamn, emitterte attributt, design-token, og tilgjengelegheitskrava komponenten ikkje handhevar for deg |
+| `get_pattern` | Eit mønster — kva komponentar det består av, i kva rekkjefølgje, og krava som gjeld |
+| `find_equivalent` | Frå eit framandt komponentnamn til rett komponent i Designsystemet |
+
+## Utan plugin
+
+Assistentar som ikkje kan installere ein plugin — til dømes i ein nettlesar i staden for eit
+kodeverktøy — kan lese den maskinlesbare indeksen direkte:
+
+```
+https://designsystemet.no/llms.txt
+```
+
+Indeksen listar kvar komponent og kvart mønster med lenkje til dokumentasjonen.


### PR DESCRIPTION
## Summary

Fourth and final PR of the stack proposed in #5166 (AI-readiness), stacked on #5177. It adds one docs page in both languages:

- *Kode → KI-assistert utvikling* / *Code → AI-assisted development*
- what to do before generating any code: install the packages and use the CLI, never hand-write build output
- the experimental plugin and the four lookup tools it gives an assistant
- the `/llms.txt` index for assistants that cannot install a plugin (published by #5177)

The plugin install shown on the page points at its interim home; it follows the placement decision raised on #5166 (our recommendation there is a Digdir-owned home).

🚧 **Draft on purpose**: stacked on #5177 (the branch contains the earlier stack commits; the diff specific to this PR is the two content pages). Not ready for merge until the stack's shape is agreed on #5166.

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant): not relevant, content pages only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
