### PR TITLE
fix(popover): support non-writable polyfilled methods

### DIFF
--- a/.changeset/calm-papayas-smile.md
+++ b/.changeset/calm-papayas-smile.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-web": patch
+---
+
+**Popover**: Support wrapping popover methods provided by polyfills

--- a/packages/web/src/popover/popover.ts
+++ b/packages/web/src/popover/popover.ts
@@ -151,45 +151,66 @@ const handleClick = (e: Event) => {
 
 onHotReload('popover', () => {
   const isFunction = (fn: unknown) => typeof fn === 'function';
+  const descriptors = Object.getOwnPropertyDescriptors(HTMLElement.prototype);
   const togglePopover = HTMLElement.prototype.togglePopover;
   const showPopover = HTMLElement.prototype.showPopover;
   const hidePopover = HTMLElement.prototype.hidePopover;
 
   // Since toggle event is not composed, we need to trigger it when programatically called inside shadow DOM
   if (isFunction(togglePopover))
-    HTMLElement.prototype.togglePopover = function (opt) {
-      const isOpen = this.matches(':popover-open');
-      const isBool = typeof opt === 'boolean';
-      const prev = isOpen ? 'open' : 'closed';
-      const next = (isBool ? opt : (opt?.force ?? !isOpen)) ? 'open' : 'closed';
-      const source = isBool ? undefined : opt?.source;
-      const result = togglePopover.call(this, opt as TogglePopoverOptions);
-      toggle(this, next, prev, source);
-      return result;
-    };
+    Object.defineProperty(HTMLElement.prototype, 'togglePopover', {
+      ...descriptors.togglePopover,
+      writable: true,
+      value: function (opt: Parameters<typeof togglePopover>[0]) {
+        const isOpen = this.matches(':popover-open');
+        const isBool = typeof opt === 'boolean';
+        const prev = isOpen ? 'open' : 'closed';
+        const next = (isBool ? opt : (opt?.force ?? !isOpen))
+          ? 'open'
+          : 'closed';
+        const source = isBool ? undefined : opt?.source;
+        const result = togglePopover.call(this, opt as TogglePopoverOptions);
+        toggle(this, next, prev, source);
+        return result;
+      },
+    });
   if (isFunction(showPopover))
-    HTMLElement.prototype.showPopover = function (opt) {
-      const prev = this.matches(':popover-open') ? 'open' : 'closed';
-      const result = showPopover.call(this, opt);
-      toggle(this, 'open', prev, opt?.source);
-      return result;
-    };
+    Object.defineProperty(HTMLElement.prototype, 'showPopover', {
+      ...descriptors.showPopover,
+      writable: true,
+      value: function (opt?: Parameters<typeof showPopover>[0]) {
+        const prev = this.matches(':popover-open') ? 'open' : 'closed';
+        const result = showPopover.call(this, opt);
+        toggle(this, 'open', prev, opt?.source);
+        return result;
+      },
+    });
   if (isFunction(hidePopover))
-    HTMLElement.prototype.hidePopover = function () {
-      const prev = this.matches(':popover-open') ? 'open' : 'closed';
-      const result = hidePopover.call(this);
-      toggle(this, 'closed', prev);
-      return result;
-    };
+    Object.defineProperty(HTMLElement.prototype, 'hidePopover', {
+      ...descriptors.hidePopover,
+      writable: true,
+      value: function () {
+        const prev = this.matches(':popover-open') ? 'open' : 'closed';
+        const result = hidePopover.call(this);
+        toggle(this, 'closed', prev);
+        return result;
+      },
+    });
 
   return [
     on(document, 'click', handleClick, QUICK_EVENT),
     on(document, 'pointerdown pointerup scroll', handleScrollbar, QUICK_EVENT),
     on(document, 'toggle ds-toggle-source', handleToggle, QUICK_EVENT), // Use capture since the toggle event does not bubble
     () => {
-      HTMLElement.prototype.togglePopover = togglePopover; // Restore original methods on hot reload
-      HTMLElement.prototype.showPopover = showPopover;
-      HTMLElement.prototype.hidePopover = hidePopover;
+      for (const name of [
+        'togglePopover',
+        'showPopover',
+        'hidePopover',
+      ] as const) {
+        const descriptor = descriptors[name];
+        if (descriptor)
+          Object.defineProperty(HTMLElement.prototype, name, descriptor); // Restore original methods on hot reload
+      }
       for (const [, off] of ROOTS) off(); // Cleanup listeners on ShadowRoots on hot reload
       ROOTS.clear();
     },

--- a/packages/web/vitest.setup.ts
+++ b/packages/web/vitest.setup.ts
@@ -1,5 +1,19 @@
 /// <reference types="@testing-library/jest-dom" />
 import '@testing-library/jest-dom/vitest';
 
-// Import all web components
-import './src/index';
+// The popover polyfill defines these methods as configurable, but not writable.
+// Mirror that descriptor shape even in browsers with native popover support.
+for (const name of ['togglePopover', 'showPopover', 'hidePopover'] as const) {
+  const descriptor = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    name,
+  );
+  if (descriptor)
+    Object.defineProperty(HTMLElement.prototype, name, {
+      ...descriptor,
+      writable: false,
+    });
+}
+
+// Import all web components after configuring the popover method descriptors
+await import('./src/index');


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

The shadow DOM support added wrappers around `HTMLElement.prototype.togglePopover`, `showPopover`, and `hidePopover` using direct assignment. That works for native browser implementations, but `@oddbird/popover-polyfill` defines these methods as configurable and non-writable. Assigning to them throws a `TypeError` while the Designsystemet module is loading.

We discovered this while upgrading Altinn from Designsystemet 1.18.0 through 1.19.0 as part of [Altinn/altinn-studio#19766](https://github.com/Altinn/altinn-studio/pull/19766). In Altinn's JSDOM/Vitest suite, importing any Designsystemet React component failed with:

```text
TypeError: Cannot assign to read only property 'togglePopover' of object '#<HTMLElement>'
```

Because the exception happened during module initialization, 118 test suites failed before collecting their tests, blocking progress on the upgrade.

This change installs the wrappers with `Object.defineProperty`, preserving the existing descriptors while explicitly making the replacement methods writable. Hot-reload cleanup now restores the complete original descriptors instead of assigning the function values back. The web test setup mirrors the non-writable descriptor shape from the polyfill so this compatibility path remains covered in browsers with native popover support.

Downstream verification in Altinn removed the import-time exception, our tests pass again.

Checks performed:

- Biome check passed for the changed TypeScript files.
- TypeScript passed for `packages/web`.
- Designsystemet types, web, CSS, and React package builds passed before the final no-behavior inlining cleanup.

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
