### PR TITLE
fix(Suggestion): initialize the empty state

### DIFF
--- a/.changeset/calm-bears-hide.md
+++ b/.changeset/calm-bears-hide.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-web": patch
+---
+
+**Suggestion**: Hide the empty state when options are initially available.

--- a/packages/web/src/suggestion/suggestion.test.ts
+++ b/packages/web/src/suggestion/suggestion.test.ts
@@ -8,6 +8,7 @@ const render = () => {
     <ds-suggestion class="ds-suggestion">
       <input type="search" class="ds-input" />
       <u-datalist role="listbox">
+        <u-option data-empty>No results</u-option>
         <u-option value="option-1">Option 1</u-option>
       </u-datalist>
     </ds-suggestion>
@@ -45,5 +46,14 @@ describe('suggestion component', () => {
     suggestion.dispatchEvent(event);
 
     expect(detail).toBe(input);
+  });
+
+  it('hides the empty option initially when selectable options exist', async () => {
+    const suggestion = render();
+    const empty = suggestion.querySelector('[data-empty]') as HTMLElement;
+
+    await new Promise((resolve) => setTimeout(resolve, 0)); // Let mutation observer run
+
+    expect(empty.hidden).toBe(true);
   });
 });

--- a/packages/web/src/suggestion/suggestion.ts
+++ b/packages/web/src/suggestion/suggestion.ts
@@ -51,9 +51,10 @@ const render = (self: DSSuggestionElement) => {
     attr(datalist, 'popover', 'manual'); // Ensure popover attribute is set on the list
     attr(datalist, 'data-is-floating', 'true'); // identifier for css to toggle opacity when it is placed by floating-ui.
   }
+  handleEmpty({ currentTarget: self });
 };
 
-const handleEmpty = ({ currentTarget: self }: Event) => {
+const handleEmpty = ({ currentTarget: self }: Pick<Event, 'currentTarget'>) => {
   const { creatable, control, options } = self as DSSuggestionElement;
   if (!options) return;
 


### PR DESCRIPTION
## Summary

Initialize Suggestion's empty-state visibility when its options are rendered, instead of waiting for the first input or selection event.

## Root cause

[PR #5097](https://github.com/digdir/designsystemet/pull/5097) changed `Suggestion.Empty` from conditionally rendered React content to a persistent option whose visibility is managed by `handleEmpty`. However, `handleEmpty` was only registered for `input` and `comboboxafterselect` events.

When a Suggestion initially rendered with selectable options, neither event had occurred yet. The empty option therefore remained visible alongside the real options until the user typed or selected something.

We discovered this while validating the Designsystemet upgrade in [Altinn/altinn-studio#19766](https://github.com/Altinn/altinn-studio/pull/19766). Altinn's Dropdown ordering tests received the Norwegian “no results” message as the first option instead of the expected country. This blocks our progress validating the upgrades to Designsystemet 1.18.0 and 1.19.0.

## Fix

Run the existing `handleEmpty` synchronization from Suggestion's mutation-driven render path. This covers initial and asynchronously rendered options while retaining the existing input and selection updates.

The regression test renders an empty-state option together with a selectable option and verifies that the empty state is hidden without requiring user interaction. It failed before the fix with `empty.hidden === false`.

## Verification

- `biome check packages/web/src/suggestion/suggestion.ts packages/web/src/suggestion/suggestion.test.ts`
- Chromium Suggestion tests: 3 passed
- `pnpm build:web`
- Altinn Dropdown tests using the locally resolved Designsystemet packages: 12 passed
