### PR TITLE
fix(clickdelegatefor): avoid duplicate label activation

### DIFF
--- a/.changeset/bright-labels-click.md
+++ b/.changeset/bright-labels-click.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-web": patch
+---
+
+**clickdelegatefor**: Prevent label clicks from activating associated inputs twice.

--- a/packages/web/src/clickdelegatefor/clickdelegatefor.test.ts
+++ b/packages/web/src/clickdelegatefor/clickdelegatefor.test.ts
@@ -25,6 +25,53 @@ describe('data-clickdelegatefor', () => {
     targetSpy.mockRestore();
   });
 
+  it('should only activate an input once when clicking its label', () => {
+    document.body.innerHTML = `
+      <ds-field data-clickdelegatefor="target">
+        <input id="target" type="checkbox">
+        <label for="target">
+          <span>Label text</span>
+        </label>
+      </ds-field>
+    `;
+
+    const target = document.getElementById('target') as HTMLInputElement;
+    const label = document.querySelector('label') as HTMLLabelElement;
+    const targetSpy = vi.fn();
+    target.addEventListener('click', targetSpy);
+
+    label.click();
+
+    expect(targetSpy).toHaveBeenCalledTimes(1);
+    expect(target.checked).toBe(true);
+
+    target.removeEventListener('click', targetSpy);
+  });
+
+  it('should not activate an input when clicking a button inside its label', () => {
+    document.body.innerHTML = `
+      <ds-field data-clickdelegatefor="target">
+        <input id="target" type="checkbox">
+        <label for="target">
+          <span>Label text</span>
+          <button type="button">Help text</button>
+        </label>
+      </ds-field>
+    `;
+
+    const target = document.getElementById('target') as HTMLInputElement;
+    const button = document.querySelector('button') as HTMLButtonElement;
+    const targetSpy = vi.fn();
+    target.addEventListener('click', targetSpy);
+
+    button.click();
+
+    expect(targetSpy).not.toHaveBeenCalled();
+    expect(target.checked).toBe(false);
+
+    target.removeEventListener('click', targetSpy);
+  });
+
   it('should ignore interactive elements inside the delegate', () => {
     document.body.innerHTML = `
         <div data-clickdelegatefor="target">

--- a/packages/web/src/clickdelegatefor/clickdelegatefor.ts
+++ b/packages/web/src/clickdelegatefor/clickdelegatefor.ts
@@ -28,7 +28,16 @@ const handleClickDelegateFor = (event: MouseEvent) => {
   const target = getComposedTarget(event);
   const delegateTarget = event.button < 2 && getDelegateTarget(event); // Only accept left or middle clicks
 
-  if (!delegateTarget || delegateTarget.contains(target)) return; // Only proxy event if delegated target isn't part of the original target
+  if (
+    !delegateTarget ||
+    delegateTarget.contains(target) ||
+    event
+      .composedPath()
+      .some(
+        (el) => el instanceof HTMLLabelElement && el.control === delegateTarget,
+      )
+  )
+    return; // Only proxy event if delegated target isn't part of the original target or is activated by a label
   if (isNewTab && delegateTarget instanceof HTMLAnchorElement)
     return window.open(delegateTarget.href, undefined, delegateTarget.rel); // If middle click or cmd/ctrl click on link, open in new tab
   event.stopImmediatePropagation(); // We'll trigger a new click event anyway, so prevent actions on this one


### PR DESCRIPTION
## Summary

Prevent `data-clickdelegatefor` from activating an input a second time when the original click came through an associated label.

The composed-path handling introduced for shadow DOM support in #5095 maps labels to their associated controls. The click delegate consequently treated a label click as an indirect field click and called `input.click()`, after which the browser also performed the label's native activation. Checkboxes toggled twice and ended in their original state.

This was discovered in [Altinn/altinn-studio#19766](https://github.com/Altinn/altinn-studio/pull/19766) while upgrading Altinn Studio to Designsystemet 1.18.0/1.19.0. It caused both Cypress interactions and real user clicks on checkbox labels to appear to do nothing.

The fix recognizes associated labels in the composed event path and leaves their activation to the browser. Clicks on other nested interactive elements, such as help-text buttons, remain independent.

## Verification

- Added browser regression coverage asserting that a label produces exactly one input click and leaves its checkbox selected.
- Added coverage asserting that a button inside the label does not activate the input.
- Confirmed the label regression test fails when the implementation guard is removed.
- `pnpm exec biome check packages/web/src/clickdelegatefor/clickdelegatefor.ts packages/web/src/clickdelegatefor/clickdelegatefor.test.ts`
- `pnpm build:web`