### PR TITLE
fix(Suggestion): preserve controlled input value

### DIFF
--- a/.changeset/calm-suggestions-wait.md
+++ b/.changeset/calm-suggestions-wait.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+**Suggestion**: Keep the input synchronized with the controlled `selected` prop when a proposed selection is not accepted.

--- a/packages/react/src/components/suggestion/suggestion.test.tsx
+++ b/packages/react/src/components/suggestion/suggestion.test.tsx
@@ -1,0 +1,81 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { Suggestion } from './suggestion';
+import { SuggestionInput } from './suggestion-input';
+import { SuggestionList } from './suggestion-list';
+import { SuggestionOption } from './suggestion-option';
+
+const norway = { label: 'Norway', value: 'norway' };
+const sweden = { label: 'Sweden', value: 'sweden' };
+
+function ControlledSuggestion({
+  selected = norway,
+  onSelectedChange,
+}: {
+  selected?: typeof norway;
+  onSelectedChange: (item: typeof norway | null) => void;
+}) {
+  return (
+    <Suggestion
+      filter={false}
+      selected={selected}
+      onSelectedChange={onSelectedChange}
+    >
+      <SuggestionInput aria-label='Country' />
+      <SuggestionList>
+        <SuggestionOption value={norway.value}>{norway.label}</SuggestionOption>
+        <SuggestionOption value={sweden.value}>{sweden.label}</SuggestionOption>
+      </SuggestionList>
+    </Suggestion>
+  );
+}
+
+describe('Suggestion', () => {
+  it('keeps the input synchronized with the selected prop when a change is not accepted', async () => {
+    const onSelectedChange = vi.fn();
+    render(<ControlledSuggestion onSelectedChange={onSelectedChange} />);
+
+    const input = screen.getByRole<HTMLInputElement>('combobox', {
+      name: 'Country',
+    });
+    await waitFor(() => expect(input).toHaveValue(norway.label));
+
+    const suggestion = document.querySelector('ds-suggestion');
+    const proposedItem = document.createElement('data');
+    proposedItem.value = sweden.value;
+    proposedItem.textContent = sweden.label;
+
+    await act(async () =>
+      suggestion?.dispatchEvent(
+        new CustomEvent('comboboxbeforeselect', {
+          bubbles: true,
+          cancelable: true,
+          detail: proposedItem,
+        }),
+      ),
+    );
+
+    expect(onSelectedChange).toHaveBeenCalledWith(sweden);
+    expect(input).toHaveValue(norway.label);
+  });
+
+  it('synchronizes the input when the selected prop changes', async () => {
+    const onSelectedChange = vi.fn();
+    const { rerender } = render(
+      <ControlledSuggestion onSelectedChange={onSelectedChange} />,
+    );
+    const input = screen.getByRole<HTMLInputElement>('combobox', {
+      name: 'Country',
+    });
+    await waitFor(() => expect(input).toHaveValue(norway.label));
+
+    rerender(
+      <ControlledSuggestion
+        selected={sweden}
+        onSelectedChange={onSelectedChange}
+      />,
+    );
+
+    await waitFor(() => expect(input).toHaveValue(sweden.label));
+    expect(onSelectedChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/components/suggestion/suggestion.tsx
+++ b/packages/react/src/components/suggestion/suggestion.tsx
@@ -208,11 +208,9 @@ export const Suggestion = forwardRef<DSSuggestionElement, SuggestionProps>(
       const beforeChange = (event: CustomEvent<HTMLDataElement>) => {
         event.preventDefault();
         const multiple = combobox?.multiple;
-        const input = combobox?.control;
         const data = event.detail;
         const nextItem = nextItems(data, selectedItemsRef.current, multiple);
 
-        if (!multiple && input) input.value = data?.textContent || ''; // Sync input value for single selection
         onSelectedChangeRef.current?.(
           (nextItem as SuggestionItem & SuggestionItem[]) || null,
         );


### PR DESCRIPTION
## Summary

Keep a controlled Suggestion input synchronized with its accepted `selected` prop when a consumer defers or rejects a proposed selection.

The single-selection synchronization added in #5043 writes the proposed option label directly into the input before calling `onSelectedChange`. For controlled consumers, this makes the visible input disagree with `selected` until the parent accepts the change. Consumers that deliberately defer acceptance—for example, to ask for confirmation—can then receive a follow-up empty selection while the component reconciles.

This was discovered in [Altinn/altinn-studio#19766](https://github.com/Altinn/altinn-studio/pull/19766) while upgrading Altinn Studio to Designsystemet 1.18.0/1.19.0. Altinn's Dropdown waits for confirmation before updating `selected`; after confirmation, Suggestion emitted an empty change and reopened the confirmation popover with an empty option label.

The existing selected-item reconciliation already updates the input when the controlled prop changes. This removes the premature write and adds React-wrapper tests for both rejected/deferred proposals and accepted prop updates.

## Verification

- Confirmed the controlled-proposal regression test fails before the fix with `Expected: Norway`, `Received: Sweden`.
- React Suggestion browser tests: 2 passed in Chromium.
- Existing web Suggestion tests: 9 passed across Chromium, Firefox, and WebKit.
- Biome passed for the changed React source and test.
