### PR TITLE
fix(clickdelegatefor): allow native label activation

### DIFF
--- a/.changeset/calm-numbers-return.md
+++ b/.changeset/calm-numbers-return.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-web": patch
+---
+
+**clickdelegatefor**: Now allows native label click, avoiding duplicate input activation.

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -78,9 +78,15 @@
       <br>
 
       <h2 class="ds-heading">data-clickdelegatefor</h2>
+      <ds-field class="ds-card" data-clickdelegatefor="input-in-label">
+        <label>
+          <input id="input-in-label" class="ds-input" type="checkbox">
+          Clicking this card will toggle the checkbox
+        </label>
+      </ds-field>
       <ds-field class="ds-card" data-clickdelegatefor="target">
         <input id="target" class="ds-input" type="checkbox">
-        <label>Clicking this card will toggle the checkbox</label>
+        <label> Clicking this card will toggle the checkbox </label>
       </ds-field>
       <ds-field class="ds-card" data-clickdelegatefor="target-disabled">
         <input id="target-disabled" class="ds-input" type="checkbox" disabled>

--- a/packages/web/src/clickdelegatefor/clickdelegatefor.test.ts
+++ b/packages/web/src/clickdelegatefor/clickdelegatefor.test.ts
@@ -25,6 +25,73 @@ describe('data-clickdelegatefor', () => {
     targetSpy.mockRestore();
   });
 
+  it('should only activate an input once when clicking its label - for', () => {
+    document.body.innerHTML = `
+      <ds-field data-clickdelegatefor="target">
+        <input id="target" type="checkbox">
+        <label for="target">Label text</label>
+      </ds-field>
+    `;
+
+    const target = document.getElementById('target');
+    const label = document.querySelector('label');
+    const targetSpy = vi.fn();
+    target?.addEventListener('click', targetSpy);
+    label?.click();
+
+    expect(targetSpy).toHaveBeenCalledTimes(1);
+    expect((target as HTMLInputElement).checked).toBe(true);
+    target?.removeEventListener('click', targetSpy);
+  });
+
+  it('should only activate an input once when clicking its label - wrapped', () => {
+    document.body.innerHTML = `
+      <ds-field data-clickdelegatefor="target">
+        <label>
+          <input id="target" type="checkbox">
+          Label text
+        </label>
+      </ds-field>
+    `;
+
+    const target = document.getElementById('target');
+    const label = document.querySelector('label');
+    const targetSpy = vi.fn();
+    target?.addEventListener('click', targetSpy);
+    label?.click();
+
+    expect(targetSpy).toHaveBeenCalledTimes(1);
+    expect((target as HTMLInputElement).checked).toBe(true);
+    target?.removeEventListener('click', targetSpy);
+  });
+
+  it('should not activate an input when clicking a button inside its label', () => {
+    document.body.innerHTML = `
+      <ds-field data-clickdelegatefor="target">
+        <label>
+          <input id="target" type="checkbox">
+          Label text
+          <button type="button">Help text</button>
+        </label>
+      </ds-field>
+    `;
+
+    const target = document.getElementById('target');
+    const button = document.querySelector('button');
+    const targetSpy = vi.fn();
+    const buttonSpy = vi.fn();
+    target?.addEventListener('click', targetSpy);
+    button?.addEventListener('click', buttonSpy);
+    button?.click();
+
+    expect(targetSpy).not.toHaveBeenCalled();
+    expect(buttonSpy).toHaveBeenCalled();
+    expect((target as HTMLInputElement).checked).toBe(false);
+
+    target?.removeEventListener('click', targetSpy);
+    button?.removeEventListener('click', buttonSpy);
+  });
+
   it('should ignore interactive elements inside the delegate', () => {
     document.body.innerHTML = `
         <div data-clickdelegatefor="target">

--- a/packages/web/src/clickdelegatefor/clickdelegatefor.ts
+++ b/packages/web/src/clickdelegatefor/clickdelegatefor.ts
@@ -3,6 +3,7 @@
 // and https://github.com/openui/open-ui/issues/1104#issuecomment-3151387080
 import {
   attr,
+  getComposedPath,
   getComposedTarget,
   getRoot,
   on,
@@ -29,10 +30,13 @@ const handleClickDelegateFor = (event: MouseEvent) => {
   const delegateTarget = event.button < 2 && getDelegateTarget(event); // Only accept left or middle clicks
 
   if (!delegateTarget || delegateTarget.contains(target)) return; // Only proxy event if delegated target isn't part of the original target
+  for (const el of getComposedPath(target))
+    if ((el as HTMLLabelElement).control === delegateTarget) return; // Let labels forward click natively
+
   if (isNewTab && delegateTarget instanceof HTMLAnchorElement)
     return window.open(delegateTarget.href, undefined, delegateTarget.rel); // If middle click or cmd/ctrl click on link, open in new tab
   event.stopImmediatePropagation(); // We'll trigger a new click event anyway, so prevent actions on this one
-  if (delegateTarget.nodeName !== 'LABEL') delegateTarget.click(); // Forward click to the clickable element (labels forwards click natively though)
+  delegateTarget.click(); // Forward click to the clickable element
 };
 
 let HOVER: Element | undefined;


### PR DESCRIPTION
Replaces #5199 with also tests for label wrapping input, support for nested Shadow DOM, and clean up previous label check