### PR TITLE
fix: close four CodeQL alerts in the twin merge script

### DIFF
--- a/scripts/merge-authored-twins.mjs
+++ b/scripts/merge-authored-twins.mjs
@@ -21,7 +21,7 @@
  *
  *   node scripts/merge-authored-twins.mjs [--out <registry-dir>] [--verify]
  */
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -74,12 +74,20 @@ async function pageText(url) {
   try {
     const res = await fetch(url);
     if (!res.ok) return '';
-    const html = (await res.text())
-      .replace(/<script[\s\S]*?<\/script>|<style[\s\S]*?<\/style>/g, '')
+    // Strip <script>/<style> blocks before flattening the rest of the markup.
+    // Case-insensitive so <SCRIPT> is caught too, and repeated until the text
+    // stops changing so a stripped block cannot reveal another one.
+    let html = await res.text();
+    let previous;
+    do {
+      previous = html;
+      html = html.replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, '');
+    } while (html !== previous);
+    const text = html
       .replace(/<[^>]+>/g, ' ')
       .replace(/&#(\d+);/g, (_, n) => String.fromCodePoint(Number(n)))
       .replace(/&([a-z]+);/g, (m, e) => ENTITIES[e] ?? m);
-    return normalise(html);
+    return normalise(text);
   } catch {
     return '';
   }
@@ -92,7 +100,13 @@ let reviewed = 0;
 for (const [slug, entry] of Object.entries(AUTHORED)) {
   const { name, reviewedAgainst, ...fields } = entry;
   const twinPath = join(REGISTRY, `${name}.json`);
-  if (!existsSync(twinPath)) {
+  // Read straight away rather than checking existence first: a separate check
+  // would be a check-then-use race, and this reads the file once instead of twice.
+  let twin;
+  try {
+    twin = JSON.parse(readFileSync(twinPath, 'utf8'));
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
     console.warn(
       `  skip ${name}: no generated twin (run generate-twins.mjs first)`,
     );
@@ -129,7 +143,6 @@ for (const [slug, entry] of Object.entries(AUTHORED)) {
     }
   }
 
-  const twin = JSON.parse(readFileSync(twinPath, 'utf8'));
   const method =
     allVerified && reviewedAgainst
       ? `quote-verified against the cited page; human-reviewed against ${reviewedAgainst}`
@@ -164,7 +177,7 @@ if (VERIFY) {
           '|---|---|---|---|',
           ...reviewRows.map(
             (r) =>
-              `| ${r.map((c) => String(c).replace(/\|/g, '\\|').slice(0, 160)).join(' | ')} |`,
+              `| ${r.map((c) => String(c).replace(/\\/g, '\\\\').replace(/\|/g, '\\|').slice(0, 160)).join(' | ')} |`,
           ),
         ]
       : [


### PR DESCRIPTION
Closes the four CodeQL alerts on `scripts/merge-authored-twins.mjs`. All four are in the build-time verification script, not in shipped site code.

### What each alert was, and the fix

| Alert | Fix |
|---|---|
| `js/bad-tag-filter` · `js/incomplete-multi-character-sanitization` | The `<script>`/`<style>` strip was case-sensitive, so `<SCRIPT>` passed through. Now case-insensitive, tolerant of attributes, and repeated until the text stops changing |
| `js/file-system-race` | `existsSync` → `readFileSync` was a check-then-use race. The twin is now read directly and `ENOENT` handled, which also removes a double read |
| `js/incomplete-sanitization` | Review-sheet cells escaped pipes but not backslashes; backslashes are now escaped first |

### On severity

Worth stating plainly for reviewers: these were flagged as sanitizer bugs because CodeQL recognises "strips `<script>` from HTML" as the pattern you use before *rendering* HTML. That is not what happens here — the next line strips all remaining tags and the result is flattened to lowercase plain text, used only to check whether a documentation quote still appears on its cited page. It is never rendered and never reaches a DOM, so there was no exploit path. The fixes are still worth making: the case-sensitivity gap could have let script text leak into the haystack and produce a wrong quote-verification result.

### Verification

- `generate:twins` + `merge:twins` produce a **byte-identical** registry before and after (44 components merged, 40 reviewed, 4 pending — unchanged)
- Case-handling checked directly: `<SCRIPT>`, `<Script>` and `<STYLE>` blocks leaked before and are stripped now
- Biome clean
