### PR TITLE
chore: point to public schema and always provide latest

### DIFF
--- a/apps/themebuilder/app/_components/token-modal/use-token-modal.ts
+++ b/apps/themebuilder/app/_components/token-modal/use-token-modal.ts
@@ -55,7 +55,7 @@ export const useTokenModal = () => {
   const configBuildSnippet = `npx ${packageWithTag} tokens create --config designsystemet.config.json\nnpx ${packageWithTag} tokens build --config designsystemet.config.json`;
 
   const configSnippet = {
-    $schema: 'node_modules/@digdir/designsystemet/dist/config.schema.json',
+    $schema: 'https://designsystemet.no/schemas/cli/latest.json',
     outDir: './design-tokens',
     themes: {
       [theme.name]: {

--- a/apps/www/app/content/schemas/cli/latest.json
+++ b/apps/www/app/content/schemas/cli/latest.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "outDir": {
+      "default": "design-tokens",
+      "description": "Path to the output directory for the created design tokens",
+      "type": "string"
+    },
+    "themes": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string"
+      },
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "colors": {
+            "type": "object",
+            "propertyNames": {
+              "type": "string"
+            },
+            "additionalProperties": {
+              "description": "A hex color, which is used for creating a color scale.",
+              "type": "string",
+              "pattern": "^#[0-9a-fA-F]{3}|#[0-9a-fA-F]{4}|#[0-9a-fA-F]{6}|#[0-9a-fA-F]{8}$"
+            },
+            "description": "Defines the colors for this theme"
+          },
+          "typography": {
+            "default": {},
+            "type": "object",
+            "properties": {
+              "fontFamily": {
+                "default": "Inter",
+                "type": "string",
+                "description": "Sets the font-family for this theme"
+              }
+            },
+            "description": "Defines the typography for a given theme"
+          },
+          "borderRadius": {
+            "default": 4,
+            "type": "number",
+            "description": "Defines the border-radius for this theme"
+          },
+          "overrides": {
+            "type": "object",
+            "properties": {
+              "colors": {
+                "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
+                "additionalProperties": {
+                  "type": "object",
+                  "propertyNames": {
+                    "type": "string",
+                    "enum": [
+                      "background-default",
+                      "background-tinted",
+                      "surface-default",
+                      "surface-tinted",
+                      "surface-hover",
+                      "surface-active",
+                      "border-subtle",
+                      "border-default",
+                      "border-strong",
+                      "text-subtle",
+                      "text-default",
+                      "base-default",
+                      "base-hover",
+                      "base-active",
+                      "base-contrast-subtle",
+                      "base-contrast-default"
+                    ]
+                  },
+                  "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                      "light": {
+                        "description": "A hex color that overrides light mode",
+                        "type": "string",
+                        "pattern": "^#[0-9a-fA-F]{3}|#[0-9a-fA-F]{4}|#[0-9a-fA-F]{6}|#[0-9a-fA-F]{8}$"
+                      },
+                      "dark": {
+                        "description": "A hex color that overrides dark mode",
+                        "type": "string",
+                        "pattern": "^#[0-9a-fA-F]{3}|#[0-9a-fA-F]{4}|#[0-9a-fA-F]{6}|#[0-9a-fA-F]{8}$"
+                      }
+                    },
+                    "description": "Override values for semantic color tokens like \"background-subtle\", \"border-default\", etc."
+                  },
+                  "description": "The name of the color to add overrides for, e.g. \"accent\""
+                },
+                "description": "An object with color names as keys"
+              },
+              "severity": {
+                "description": "An object with severity color names as keys",
+                "type": "object",
+                "propertyNames": {
+                  "type": "string",
+                  "enum": [
+                    "info",
+                    "success",
+                    "warning",
+                    "danger"
+                  ]
+                },
+                "additionalProperties": {
+                  "description": "A hex color, which is used for creating a color scale",
+                  "type": "string",
+                  "pattern": "^#[0-9a-fA-F]{3}|#[0-9a-fA-F]{4}|#[0-9a-fA-F]{6}|#[0-9a-fA-F]{8}$"
+                }
+              },
+              "linkVisited": {
+                "type": "object",
+                "properties": {
+                  "light": {
+                    "description": "A hex color that overrides light mode",
+                    "type": "string",
+                    "pattern": "^#[0-9a-fA-F]{3}|#[0-9a-fA-F]{4}|#[0-9a-fA-F]{6}|#[0-9a-fA-F]{8}$"
+                  },
+                  "dark": {
+                    "description": "A hex color that overrides dark mode",
+                    "type": "string",
+                    "pattern": "^#[0-9a-fA-F]{3}|#[0-9a-fA-F]{4}|#[0-9a-fA-F]{6}|#[0-9a-fA-F]{8}$"
+                  }
+                },
+                "description": "Overrides for the \"link-visited\" color"
+              },
+              "focus": {
+                "type": "object",
+                "properties": {
+                  "inner": {
+                    "description": "Overrides for the \"focus-inner\" color",
+                    "type": "object",
+                    "properties": {
+                      "light": {
+                        "description": "A hex color that overrides light mode",
+                        "type": "string",
+                        "pattern": "^#[0-9a-fA-F]{3}|#[0-9a-fA-F]{4}|#[0-9a-fA-F]{6}|#[0-9a-fA-F]{8}$"
+                      },
+                      "dark": {
+                        "description": "A hex color that overrides dark mode",
+                        "type": "string",
+                        "pattern": "^#[0-9a-fA-F]{3}|#[0-9a-fA-F]{4}|#[0-9a-fA-F]{6}|#[0-9a-fA-F]{8}$"
+                      }
+                    }
+                  },
+                  "outer": {
+                    "description": "Overrides for the \"focus-outer\" color",
+                    "type": "object",
+                    "properties": {
+                      "light": {
+                        "description": "A hex color that overrides light mode",
+                        "type": "string",
+                        "pattern": "^#[0-9a-fA-F]{3}|#[0-9a-fA-F]{4}|#[0-9a-fA-F]{6}|#[0-9a-fA-F]{8}$"
+                      },
+                      "dark": {
+                        "description": "A hex color that overrides dark mode",
+                        "type": "string",
+                        "pattern": "^#[0-9a-fA-F]{3}|#[0-9a-fA-F]{4}|#[0-9a-fA-F]{6}|#[0-9a-fA-F]{8}$"
+                      }
+                    }
+                  }
+                },
+                "description": "Overrides for the focus colors"
+              }
+            },
+            "description": "Overrides for generated design tokens. Currently only supports colors defined in your theme"
+          }
+        },
+        "required": [
+          "colors"
+        ],
+        "description": "An object defining a theme. The property name holding the object becomes the theme name."
+      },
+      "description": "An object with one or more themes. Each property defines a theme, and the property name is used as the theme name."
+    },
+    "clean": {
+      "default": false,
+      "description": "Delete the output directory before building or creating tokens",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "outDir",
+    "themes"
+  ]
+}

--- a/scripts/sync-cli-schema.js
+++ b/scripts/sync-cli-schema.js
@@ -30,8 +30,11 @@ async function main() {
   }
   const src = path.join(CLI_ROOT, 'dist', schemaFile);
   const dst = path.join(SCHEMAS_DIR, `${await getCurrentVersion()}.json`);
+  const latestDst = path.join(SCHEMAS_DIR, 'latest.json');
   await fs.copyFile(src, dst);
   console.log(`Copied schema file to ${dst}`);
+  await fs.copyFile(src, latestDst);
+  console.log(`Copied schema file to ${latestDst}`);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

Makes it better known that we have schemas published. We could make this use the latest version instead of latest, but not without structural changes to how we actually get that number

## Checks

- [ ] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)
