### PR TITLE
docs: blog svgcolour added section

### DIFF
--- a/apps/www/app/content/blog/en/colorsvg.mdx
+++ b/apps/www/app/content/blog/en/colorsvg.mdx
@@ -68,7 +68,21 @@ The graphic can then be referenced in HTML using `<use>`:
 </svg>
 ```
 
-**Tip:** You can store multiple symbols or icons in the same SVG file by wrapping each one in its own `<symbol>` element and assigning a unique ID to each symbol.
+#### Preview SVGs with symbols in design and editing tools
+
+Many design and editing tools cannot specify which `symbol` to display when previewing an SVG file. As a result, the graphic may appear empty even though the SVG is set up correctly.
+
+To make the graphic visible, add a `use` element at the end of the SVG file:
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg">
+  <symbol id="symbol-id" viewBox="0 0 64 64">
+    <path d="..." />
+  </symbol>
+  <use href="#symbol-id">
+```
+
+**Tip:** You can include multiple symbols or icons in the same file by wrapping each one in a `symbol` element and giving it a unique ID. You can then use the technique above to choose which symbol should be displayed when previewing the file.
 
 #### Alternatively, Embed the Graphic Inline
 

--- a/apps/www/app/content/blog/en/colorsvg.mdx
+++ b/apps/www/app/content/blog/en/colorsvg.mdx
@@ -79,7 +79,7 @@ To make the graphic visible, add a `use` element at the end of the SVG file:
   <symbol id="symbol-id" viewBox="0 0 64 64">
     <path d="..." />
   </symbol>
-  <use href="#symbol-id">
+  <use href="#symbol-id" />
 </svg>
 ```
 

--- a/apps/www/app/content/blog/en/colorsvg.mdx
+++ b/apps/www/app/content/blog/en/colorsvg.mdx
@@ -80,6 +80,7 @@ To make the graphic visible, add a `use` element at the end of the SVG file:
     <path d="..." />
   </symbol>
   <use href="#symbol-id">
+</svg>
 ```
 
 **Tip:** You can include multiple symbols or icons in the same file by wrapping each one in a `symbol` element and giving it a unique ID. You can then use the technique above to choose which symbol should be displayed when previewing the file.
@@ -89,9 +90,6 @@ To make the graphic visible, add a `use` element at the end of the SVG file:
 Using `<use>` makes it possible to reuse the same SVG without duplicating the markup in multiple places. If the graphic is only used once on a page, however, embedding the SVG inline is often the simpler option. When used inline, the example above does not require a `<symbol>` element or an ID:
 ```HTML
 <svg height="1rem" width="1rem" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
-  <path d="..." />
-  <path d="..." />
-  <path d="..." />
   <path d="..." />
 </svg>
 ```

--- a/apps/www/app/content/blog/no/colorsvg.mdx
+++ b/apps/www/app/content/blog/no/colorsvg.mdx
@@ -69,7 +69,21 @@ Fila brukes deretter slik i html:
 </svg>
 ```
 
-Tips: Du kan ha flere symboler eller ikoner i samme fil når du pakker hver av dem med `<symbol>`og unike ider for hver av dem.
+#### Forhåndsvis SVG med symbol i redaktørverktøy
+
+Mange redaktørverktøy kan ikke angi hvilket `symbol` som skal vises når de forhåndsviser en SVG-fil. Resultatet er ofte at grafikken ser tom ut, selv om SVG-filen er satt opp riktig.
+
+For å gjøre grafikken synlig kan du legge til et `use`-element nederst i SVG-filen:
+```svg
+<svg xmlns="http://www.w3.org/2000/svg">
+  <symbol id="symbol-id" viewBox="0 0 64 64">
+    <path d="..." />
+  </symbol>
+  <use href="#symbol-id" />
+</svg>
+```
+
+**Tips:** Du kan ha flere symboler eller ikoner i samme fil når du pakker hver av dem med `<symbol>` og unike ider for hver av dem. Da kan du også bruke metoden ovenfor for å velge et symbol inni fila for forhåndsvisning.
 
 #### Alternativt sett inn grafikken inline
 

--- a/apps/www/app/content/blog/no/colorsvg.mdx
+++ b/apps/www/app/content/blog/no/colorsvg.mdx
@@ -76,7 +76,7 @@ Mange redaktørverktøy kan ikke angi hvilket `symbol` som skal vises når de fo
 For å gjøre grafikken synlig kan du legge til et `use`-element nederst i SVG-filen:
 ```svg
 <svg xmlns="http://www.w3.org/2000/svg">
-  <symbol id="symbol-id" viewBox="0 0 64 64">
+  <symbol id="symbol-id" viewBox="0 0 40 40">
     <path d="..." />
   </symbol>
   <use href="#symbol-id" />
@@ -90,9 +90,6 @@ For å gjøre grafikken synlig kan du legge til et `use`-element nederst i SVG-f
 Bruken av `<use>` muliggjør at en ikke trenger å gjenta samme svg-kode flere steder. Når du uansett kun skal ha grafikken på ett sted på siden din, så kan du gjerne sette den inn inline. Grafikken ovenfor når satt inn direkte inline trenger ikke `<symbol>` og id
 ```HTML
 <svg height="1rem" width="1rem" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">
-  <path d="..." />
-  <path d="..." />
-  <path d="..." />
   <path d="..." />
 </svg>
 ```


### PR DESCRIPTION
## Summary

Added short section describing what to do if the svg graphics does not show when using symbol inside, in editor tools and if trying to open the svg directly in the browser it will appear empty because the tool or browser does not know what symbol (id) to show.

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [ ] I have added a changeset (run `pnpm changeset` if relevant)
