### PR TITLE
chore: fix color scale weakness

### DIFF
--- a/.changeset/violet-scales-return.md
+++ b/.changeset/violet-scales-return.md
@@ -1,0 +1,5 @@
+---
+'@digdir/designsystemet': minor
+---
+
+`generateColorScale` and `generateColorSchemes` now return colors as a record keyed by semantic color name instead of an array.

--- a/.changeset/violet-scales-return.md
+++ b/.changeset/violet-scales-return.md
@@ -1,5 +1,2 @@
 ---
-'@digdir/designsystemet': minor
 ---
-
-`generateColorScale` and `generateColorSchemes` now return colors as a record keyed by semantic color name instead of an array.

--- a/apps/themebuilder/app/_components/color-contrasts/color-contrasts.tsx
+++ b/apps/themebuilder/app/_components/color-contrasts/color-contrasts.tsx
@@ -1,7 +1,9 @@
 import {
   type Color,
+  type ColorScale,
   generateColorSchemes,
   getContrastFromHex,
+  type SemanticColorNames,
 } from '@digdir/designsystemet';
 import {
   Field,
@@ -97,8 +99,8 @@ const ColorContrastMapper = ({
   horizontal,
   variant,
 }: {
-  vertical: string[];
-  horizontal: string[];
+  vertical: SemanticColorNames[];
+  horizontal: SemanticColorNames[];
   variant: string;
 }) => {
   const { t } = useTranslation();
@@ -106,9 +108,7 @@ const ColorContrastMapper = ({
     useThemebuilder();
   const [selectedColor, setSelectedColor] = useState('dominant');
 
-  const getMappedTheme = () => {
-    const mappedColors: { [key: string]: Color } = {};
-
+  const getMappedTheme = (): ColorScale => {
     let colorTheme = colors?.[0]?.colors || initialTheme;
 
     if (selectedColor !== 'dominant') {
@@ -130,11 +130,7 @@ const ColorContrastMapper = ({
       }
     }
 
-    for (const [, value] of Object.entries(colorTheme[colorScheme])) {
-      mappedColors[value.name] = value;
-    }
-
-    return mappedColors;
+    return colorTheme[colorScheme];
   };
 
   const mappedTheme = getMappedTheme();

--- a/apps/themebuilder/app/_components/color-group/color-group.tsx
+++ b/apps/themebuilder/app/_components/color-group/color-group.tsx
@@ -1,9 +1,6 @@
-import {
-  type Color,
-  getSemanticColorByNumber,
-  type SemanticColorNames,
-  semanticColorSpec,
-  type ThemeInfo,
+import type {
+  SemanticColorNames,
+  ThemeInfo,
 } from '@digdir/designsystemet/color';
 import { RovingFocusItem } from '@digdir/designsystemet-react';
 import cl from 'clsx/lite';
@@ -44,13 +41,8 @@ export const ColorGroup = ({
 
       <div className={cl(classes.colors)}>
         {colorNames.map((colorName, index) => {
-          const { number, hex } =
-            colorScale[colorScheme][semanticColorSpec[colorName].number - 1];
-          const color: Color = {
-            ...getSemanticColorByNumber(number),
-            number,
-            hex,
-          };
+          const color = colorScale[colorScheme][colorName];
+          const { number, hex } = color;
           return (
             <Fragment key={index + 'fragment' + namespace}>
               <RovingFocusItem value={namespace + number} asChild>

--- a/apps/themebuilder/app/_components/sidebar/color-overrides/_components/color-details.tsx
+++ b/apps/themebuilder/app/_components/sidebar/color-overrides/_components/color-details.tsx
@@ -206,12 +206,8 @@ export default function ColorDetails({ color }: ColorDetailsProps) {
       <div className={classes.tokenList}>
         {semanticColorNames.map((colorName) => {
           // Get the actual colors from the theme to show preview
-          const lightColor = color.colors?.light?.find(
-            (c) => c.name === colorName,
-          );
-          const darkColor = color.colors?.dark?.find(
-            (c) => c.name === colorName,
-          );
+          const lightColor = color.colors?.light?.[colorName];
+          const darkColor = color.colors?.dark?.[colorName];
 
           return (
             <div key={colorName} className={classes.tokenRow}>

--- a/apps/themebuilder/app/_components/sidebar/color-page/color-page.tsx
+++ b/apps/themebuilder/app/_components/sidebar/color-page/color-page.tsx
@@ -116,7 +116,7 @@ export const ColorPage = () => {
     index: number,
     type: 'color' | 'neutral',
   ) => {
-    const hexColor = colorTheme.colors.light[11].hex;
+    const hexColor = colorTheme.colors.light['base-default'].hex;
 
     setColor(ColorService.convert('hex', hexColor));
 
@@ -209,7 +209,7 @@ export const ColorPage = () => {
                 colorTheme.name === 'neutral' ? null : (
                   <ColorInput
                     key={index}
-                    color={colorTheme.colors.light[11].hex}
+                    color={colorTheme.colors.light['base-default'].hex}
                     name={colorTheme.name}
                     onClick={() => openColorEditor(colorTheme, index, 'color')}
                   />
@@ -231,7 +231,7 @@ export const ColorPage = () => {
             <div className={classes.group}>
               <div className={classes.colors}>
                 <ColorInput
-                  color={neutralColor.colors.light[11].hex}
+                  color={neutralColor.colors.light['base-default'].hex}
                   name={neutralColor.name}
                   onClick={() =>
                     openColorEditor(neutralColor, neutralIndex, 'neutral')

--- a/apps/themebuilder/app/_components/token-modal/use-token-modal.ts
+++ b/apps/themebuilder/app/_components/token-modal/use-token-modal.ts
@@ -1,11 +1,8 @@
-import type { Color, CssColor } from '@digdir/designsystemet/color';
+import type { CssColor } from '@digdir/designsystemet/color';
 import type { CreateTokensOptions } from '@digdir/designsystemet/tokens';
 import { useState } from 'react';
 import { useLoaderData } from 'react-router';
 import { useThemebuilder } from '~/routes/themebuilder/_utils/use-themebuilder';
-
-const getBaseDefault = (colorTheme: Color[]) =>
-  colorTheme.find((color) => color.name === 'base-default');
 
 export const useTokenModal = () => {
   const { isProduction } = useLoaderData();
@@ -39,7 +36,7 @@ export const useTokenModal = () => {
     name,
     colors: colors.reduce(
       (acc, color) => {
-        acc[color.name] = getBaseDefault(color.colors.light)?.hex || '#';
+        acc[color.name] = color.colors.light['base-default']?.hex || '#';
         return acc;
       },
       {} as Record<string, CssColor>,

--- a/apps/themebuilder/app/_utils/generate-color-vars.ts
+++ b/apps/themebuilder/app/_utils/generate-color-vars.ts
@@ -12,7 +12,7 @@ export const generateColorVars = (
 ) => {
   const style = {} as Record<string, string>;
 
-  for (const color of colors[colorScheme]) {
+  for (const color of Object.values(colors[colorScheme])) {
     style[`--ds-color-${prefix ? `${prefix}-` : ''}${color.name}`] = color.hex;
   }
 

--- a/apps/themebuilder/app/routes/themebuilder/_utils/use-themebuilder.tsx
+++ b/apps/themebuilder/app/routes/themebuilder/_utils/use-themebuilder.tsx
@@ -3,7 +3,10 @@ import {
   generateColorSchemes,
   type ThemeInfo,
 } from '@digdir/designsystemet';
-import type { SeverityColorNames } from '@digdir/designsystemet/color';
+import type {
+  SemanticColorNames,
+  SeverityColorNames,
+} from '@digdir/designsystemet/color';
 import { severityColors } from '@digdir/designsystemet/schemas/defaults.js';
 import { useLoaderData } from 'react-router';
 import { generateColorVars } from '~/_utils/generate-color-vars';
@@ -203,19 +206,13 @@ export function applyOverridesToColors(
       }
 
       for (const [tokenName, override] of Object.entries(colorOverrides)) {
-        if (override.light) {
-          const lightColor = color.colors.light.find(
-            (c) => c.name === tokenName,
-          );
-          if (lightColor) {
-            lightColor.hex = override.light;
-          }
+        const lightColor = color.colors.light[tokenName as SemanticColorNames];
+        if (override.light && lightColor) {
+          lightColor.hex = override.light;
         }
-        if (override.dark) {
-          const darkColor = color.colors.dark.find((c) => c.name === tokenName);
-          if (darkColor) {
-            darkColor.hex = override.dark;
-          }
+        const darkColor = color.colors.dark[tokenName as SemanticColorNames];
+        if (override.dark && darkColor) {
+          darkColor.hex = override.dark;
         }
       }
 

--- a/packages/cli/src/colors/scale.ts
+++ b/packages/cli/src/colors/scale.ts
@@ -1,7 +1,7 @@
 import chroma from 'chroma-js';
 import * as R from 'ramda';
 import { getSemanticColorByNumber, semanticColorSpec } from './specs.ts';
-import type { Color, ColorNumber, ColorScheme, CssColor, SemanticColorSpec, ThemeInfo } from './types.ts';
+import type { ColorNumber, ColorScale, ColorScheme, CssColor, SemanticColorSpec, ThemeInfo } from './types.ts';
 import { getLightnessFromHex, getLuminanceFromLightness } from './utils.ts';
 
 export const RESERVED_COLORS = ['neutral', 'success', 'warning', 'danger', 'info'];
@@ -19,7 +19,7 @@ export const generateColorScale = (
   color: CssColor,
   colorScheme: ColorScheme,
   colorScaleSpec: ColorScaleSpec = semanticColorSpec,
-): Color[] => {
+): ColorScale => {
   let interpolationColor = color;
 
   // Reduce saturation in dark mode for the interpolation colors
@@ -53,7 +53,7 @@ export const generateColorScale = (
     };
   }
 
-  return Object.values(colors);
+  return colors;
 };
 
 /**

--- a/packages/cli/src/colors/types.ts
+++ b/packages/cli/src/colors/types.ts
@@ -55,9 +55,11 @@ export type Color = ColorScaleStep<SemanticColorNames> & {
   hex: CssColor;
 };
 
+export type ColorScale = Record<SemanticColorNames, Color>;
+
 export type ThemeInfo = {
-  light: Color[];
-  dark: Color[];
+  light: ColorScale;
+  dark: ColorScale;
 };
 
 /**

--- a/packages/cli/src/tokens/create/generators/primitives/color-scheme.ts
+++ b/packages/cli/src/tokens/create/generators/primitives/color-scheme.ts
@@ -1,19 +1,17 @@
 import * as R from 'ramda';
-import type { Color, ColorScheme, CssColor } from '../../../../colors/index.ts';
+import type { ColorScale, ColorScheme, CssColor } from '../../../../colors/index.ts';
 import { generateColorScale, semanticColorSpec } from '../../../../colors/index.ts';
 import { severityColors, visitedLinkColor } from '../../../../schemas/defaults.ts';
 import type { ColorOverrideSchema } from '../../../../schemas/v1.1/schema.ts';
 import type { Token, TokenSet } from '../../../types.ts';
 
-const generateColor = (colorArray: Color[], overrides?: Record<number, string>): TokenSet => {
+const generateColor = (colorScale: ColorScale, overrides?: Record<number, string>): TokenSet => {
   const obj: TokenSet = {};
   const $type = 'color';
-  for (const index in colorArray) {
-    const position = Number(index) + 1;
-    const overrideValue = overrides?.[position];
-    obj[position] = {
+  for (const color of Object.values(colorScale)) {
+    obj[color.number] = {
       $type,
-      $value: overrideValue || colorArray[index].hex,
+      $value: overrides?.[color.number] || color.hex,
     };
   }
   return obj;


### PR DESCRIPTION
When looking at how to fix the bug for severity colors in #5239. I was reminded of a weakness we had in `generateColorScale` where the scales are returned as array. This leads to unsafe code with index lookups and uncessary find/filter for looking up color steps in the scale. 


Refactored `generateColorScale` to return record with semantic color names as key. This leads to much safer and better lookup for color steps.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>