### PR TITLE
fix(Suggestion): prevent rejected selection replay

### DIFF
--- a/.changeset/fresh-suggestions-rest.md
+++ b/.changeset/fresh-suggestions-rest.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-react": patch
+---
+
+**Suggestion:** Prevents a rejected controlled selection from being proposed again when the input loses focus.

--- a/packages/react/src/components/suggestion/suggestion.test.tsx
+++ b/packages/react/src/components/suggestion/suggestion.test.tsx
@@ -1,3 +1,4 @@
+import type { DSSuggestionElement } from '@digdir/designsystemet-web';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { useState } from 'react';
 import { Suggestion, type SuggestionItem } from './suggestion';
@@ -41,7 +42,10 @@ describe('Suggestion', () => {
     });
     await waitFor(() => expect(input).toHaveValue(norway.label));
 
-    const suggestion = document.querySelector('ds-suggestion');
+    const suggestion =
+      document.querySelector<DSSuggestionElement>('ds-suggestion');
+    await waitFor(() => expect(suggestion?.control).toBe(input));
+    const dispatchInput = vi.spyOn(input, 'dispatchEvent');
     const proposedItem = document.createElement('data');
     proposedItem.value = sweden.value;
     proposedItem.textContent = sweden.label;
@@ -58,6 +62,9 @@ describe('Suggestion', () => {
 
     expect(onSelectedChange).toHaveBeenCalledWith(sweden);
     expect(input).toHaveValue(norway.label);
+    expect(dispatchInput).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'input', bubbles: true }),
+    );
   });
 
   it('synchronizes the input when the selected prop changes', async () => {

--- a/packages/react/src/components/suggestion/suggestion.tsx
+++ b/packages/react/src/components/suggestion/suggestion.tsx
@@ -215,7 +215,15 @@ export const Suggestion = forwardRef<DSSuggestionElement, SuggestionProps>(
           (nextItem as SuggestionItem & SuggestionItem[]) || null,
         );
 
-        if (!isControlled) setDefaultItems(sanitizeItems(nextItem));
+        if (!isControlled) {
+          setDefaultItems(sanitizeItems(nextItem));
+        } else if (!multiple && combobox?.control) {
+          // u-combobox caches the proposed match before this cancellable event. Restore the
+          // controlled selection and refresh that cache so losing focus does not propose it again.
+          const selectedItem = selectedItemsRef.current[0];
+          combobox.control.value = selectedItem?.label ?? '';
+          combobox.control.dispatchEvent(new Event('input', { bubbles: true }));
+        }
       };
 
       combobox?.addEventListener('comboboxbeforeselect', beforeChange);


### PR DESCRIPTION
<!--
	Thanks for submitting a Pull Request! We appreciate you spending the time to work on these changes.
	Read about contributing: https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md
	Read our code of conduct: https://github.com/digdir/designsystemet/blob/main/CODE_OF_CONDUCT.md
-->

## Summary

Prevent a controlled single-select Suggestion from proposing a rejected selection again when focus leaves the input.

This follows up #5200. That change keeps the visible input synchronized with the accepted `selected` prop, but `u-combobox` has already cached the proposed option as its internal match before emitting `comboboxbeforeselect`. When a consumer defers the change—for example, while asking for confirmation—moving focus to the confirmation UI causes the stale match to be selected again on blur.

We discovered this while validating the Designsystemet upgrade in [Altinn/altinn-studio#19766](https://github.com/Altinn/altinn-studio/pull/19766). Cancelling an `alertOnChange` confirmation for Altinn's Dropdown immediately reopened the confirmation popover. Adding a delay hid the race but did not address the stale match.

For controlled single-select Suggestions, this restores the currently accepted item after notifying `onSelectedChange` and dispatches an input event so `u-combobox` refreshes its match. Multiple selections and uncontrolled Suggestions keep their existing behavior.

The controlled-proposal browser test now asserts that this reconciliation occurs. The new assertion fails in both React 18 and React 19 test projects when the fix is removed.

## Verification

- React Suggestion browser tests: 6 passed across the React 18 and React 19 Chromium projects.
- `pnpm types:react`
- `pnpm exec biome check packages/react/src/components/suggestion/suggestion.tsx packages/react/src/components/suggestion/suggestion.test.tsx`
- `pnpm build:react`

## Checks

- [x] I have read the [contribution guidelines](https://github.com/digdir/designsystemet/blob/main/CONTRIBUTING.md)
- [x] I have added a changeset (run `pnpm changeset` if relevant)
