### PR TITLE
ci: new aggregated release script and use only one tag for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,7 @@ jobs:
           TAG: v${{ steps.release_version.outputs.value }}
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.published-packages }}
         run: |
-          node scripts/aggregate-changelogs.js "$PUBLISHED_PACKAGES" > release-notes.md
+          pnpm node scripts/aggregate-changelogs.js "$PUBLISHED_PACKAGES" > release-notes.md
           gh release create "$TAG" \
             --title "$TAG" \
             --notes-file release-notes.md \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,20 +139,29 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        # Forked version of the changesets action that supports aggregated releases
-        uses: dotansimha/changesets-action@069996e9be15531bd598272996fa23853d61590e # v1.5.2
+        uses: changesets/action@8488615a623b1b9c987934bb89eae8af6a946ac1 # v2.1.1
         with:
-          publish: pnpm publish-packages
-          version: pnpm version-packages
-          commit: "chore: new release"
-          title: "chore: new release"
-          createGithubReleases: aggregate
-          githubReleaseName: v${{ steps.release_version.outputs.value }}
-          githubTagName: v${{ steps.release_version.outputs.value }}
-
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          publish-script: pnpm publish-packages
+          version-script: pnpm version-packages
+          commit-message: "chore: new release"
+          pr-title: "chore: new release"
+          # We create one aggregated release + tag (vX.Y.Z) ourselves below
+          # instead of one release/tag per package.
+          create-github-releases: false
+          push-git-tags: false
+      - name: Create aggregated GitHub release
+        if: ${{ steps.changesets.outputs.published == 'true' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: "" # https://github.com/changesets/changesets/issues/1152#issuecomment-3190884868
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: v${{ steps.release_version.outputs.value }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.published-packages }}
+        run: |
+          node scripts/aggregate-release-notes.js "$PUBLISHED_PACKAGES" > release-notes.md
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes-file release-notes.md \
+            --target "$GITHUB_SHA"
 
   deploy-www:
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,7 @@ jobs:
           TAG: v${{ steps.release_version.outputs.value }}
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.published-packages }}
         run: |
-          node scripts/aggregate-release-notes.js "$PUBLISHED_PACKAGES" > release-notes.md
+          node scripts/aggregate-changelogs.js "$PUBLISHED_PACKAGES" > release-notes.md
           gh release create "$TAG" \
             --title "$TAG" \
             --notes-file release-notes.md \

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "watch:plugin": "pnpm --filter @plugin/designsystemet watch",
     "types": "pnpm -r types",
     "types:react": "pnpm --filter @digdir/designsystemet-react types",
-    "version-packages": "changeset version && node scripts/sync-changelogs.js && pnpm build:types && pnpm build:cli && node scripts/sync-cli-schema.js && pnpm update:theme && pnpm update:theme-digdir && git add . && git commit -m \"sync www changelogs, schema and tokens\" || true",
+    "version-packages": "changeset version && pnpm node scripts/sync-changelogs.js && pnpm build:types && pnpm build:cli && pnpm node scripts/sync-cli-schema.js && pnpm update:theme && pnpm update:theme-digdir && git add . && git commit -m \"sync www changelogs, schema and tokens\" || true",
     "publish-packages": "pnpm build && changeset publish",
     "chromatic": "pnpm --filter @web/storybook chromatic",
     "update:theme-digdir": "pnpm --filter @internal/digdir update:theme-digdir",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -547,7 +547,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(jsdom@30.0.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.0)(less@4.3.0)(sass@1.87.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.7.1))
+        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(jsdom@30.0.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.0)(less@4.3.0)(sass@1.87.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/css:
     dependencies:
@@ -4757,10 +4757,6 @@ packages:
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
@@ -10146,8 +10142,6 @@ snapshots:
 
   picomatch@2.3.2: {}
 
-  picomatch@4.0.4: {}
-
   picomatch@4.0.5: {}
 
   pify@2.3.0: {}
@@ -11470,7 +11464,7 @@ snapshots:
       picomatch: 4.0.5
       std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.0)(less@4.3.0)(sass@1.87.0)(stylus@0.62.0)(tsx@4.22.4)(yaml@2.9.0)

--- a/scripts/aggregate-changelogs.js
+++ b/scripts/aggregate-changelogs.js
@@ -5,7 +5,7 @@
  * dotansimha/changesets-action.
  *
  * Usage:
- *   node scripts/aggregate-release-notes.js '<published-packages JSON>' > notes.md
+ *   node scripts/aggregate-changelogs.js '<published-packages JSON>' > notes.md
  *
  * `published-packages` is the output of changesets/action:
  *   [{ "name": "@digdir/designsystemet-react", "version": "1.20.1" }, ...]

--- a/scripts/aggregate-release-notes.js
+++ b/scripts/aggregate-release-notes.js
@@ -1,21 +1,30 @@
 /**
- * Builds the body for an aggregated GitHub release from the CHANGELOG.md of
- * every package that was just published, mirroring the output of the old
- * `createGithubReleases: aggregate` mode from dotansimha/changesets-action.
+ * Aggregates the CHANGELOG.md of every package into a single structure, and
+ * (when run as a CLI) builds the body for an aggregated GitHub release,
+ * mirroring the output of the old `createGithubReleases: aggregate` mode from
+ * dotansimha/changesets-action.
  *
  * Usage:
- *   node scripts/aggregate-release-notes.mjs '<published-packages JSON>' > notes.md
+ *   node scripts/aggregate-release-notes.js '<published-packages JSON>' > notes.md
  *
  * `published-packages` is the output of changesets/action:
  *   [{ "name": "@digdir/designsystemet-react", "version": "1.20.1" }, ...]
+ *
+ * The exported helpers are also used by scripts/sync-changelogs.js to build the
+ * consolidated changelog for www.
  */
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const ROOT = process.cwd();
 const PACKAGE_DIRS = ['packages'];
 
-async function findPackageDirs() {
+/**
+ * Finds every package under PACKAGE_DIRS.
+ * @returns {Promise<Map<string, { name: string, dir: string, version: string }>>} keyed by package name
+ */
+export async function findPackages() {
   const byName = new Map();
   for (const base of PACKAGE_DIRS) {
     let entries = [];
@@ -28,29 +37,71 @@ async function findPackageDirs() {
         const pkg = JSON.parse(
           await fs.readFile(path.join(dir, 'package.json'), 'utf8'),
         );
-        if (pkg.name) byName.set(pkg.name, dir);
+        if (pkg.name)
+          byName.set(pkg.name, { name: pkg.name, dir, version: pkg.version });
       } catch {}
     }
   }
   return byName;
 }
 
-/** Returns the markdown under the `## <version>` heading, without the heading itself. */
-function extractVersionSection(changelog, version) {
+/**
+ * Parses a CHANGELOG.md into its `## <version>` sections, in file order.
+ * @param {string} changelog
+ * @param {{ until?: string }} [options] stop before this version (exclusive) when given
+ * @returns {Map<string, string>} version → markdown body (heading removed, trimmed)
+ */
+export function parseChangelog(changelog, { until } = {}) {
+  const versions = new Map();
   const lines = changelog.split('\n');
-  const start = lines.findIndex((line) => line.trim() === `## ${version}`);
-  if (start === -1) return null;
-  let end = lines.length;
-  for (let i = start + 1; i < lines.length; i++) {
-    if (/^## /.test(lines[i])) {
-      end = i;
-      break;
+  let current = null;
+  let buffer = [];
+
+  const flush = () => {
+    if (current !== null) versions.set(current, buffer.join('\n').trim());
+    buffer = [];
+  };
+
+  for (const line of lines) {
+    const match = /^##\s+(\d+\.\d+\.\d+)\s*$/.exec(line);
+    if (match) {
+      flush();
+      if (until && match[1] === until) return versions;
+      current = match[1];
+      continue;
+    }
+    if (current !== null) buffer.push(line);
+  }
+  flush();
+  return versions;
+}
+
+/** Returns the markdown under the `## <version>` heading, or null if missing. */
+export function extractVersionSection(changelog, version) {
+  return parseChangelog(changelog).get(version) ?? null;
+}
+
+/**
+ * Reads and parses the CHANGELOG.md of every given package and merges them.
+ * @param {Iterable<{ name: string, dir: string }>} pkgs
+ * @param {{ until?: string }} [options] passed on to parseChangelog
+ * @returns {Promise<Map<string, Map<string, string>>>} version → (package name → body)
+ */
+export async function aggregateChangelogs(pkgs, options) {
+  const allVersions = new Map();
+  for (const pkg of pkgs) {
+    let md;
+    try {
+      md = await fs.readFile(path.join(pkg.dir, 'CHANGELOG.md'), 'utf8');
+    } catch {
+      continue;
+    }
+    for (const [version, body] of parseChangelog(md, options)) {
+      if (!allVersions.has(version)) allVersions.set(version, new Map());
+      allVersions.get(version).set(pkg.name, body);
     }
   }
-  return lines
-    .slice(start + 1, end)
-    .join('\n')
-    .trim();
+  return allVersions;
 }
 
 async function main() {
@@ -67,18 +118,18 @@ async function main() {
     process.exit(1);
   }
 
-  const dirs = await findPackageDirs();
+  const pkgs = await findPackages();
   const sections = [];
 
   for (const { name, version } of [...published].sort((a, b) =>
     a.name.localeCompare(b.name),
   )) {
-    const dir = dirs.get(name);
+    const pkg = pkgs.get(name);
     let body = null;
-    if (dir) {
+    if (pkg) {
       try {
         body = extractVersionSection(
-          await fs.readFile(path.join(dir, 'CHANGELOG.md'), 'utf8'),
+          await fs.readFile(path.join(pkg.dir, 'CHANGELOG.md'), 'utf8'),
           version,
         );
       } catch {}
@@ -93,7 +144,12 @@ async function main() {
   process.stdout.write(`${sections.join('\n\n')}\n`);
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/scripts/aggregate-release-notes.js
+++ b/scripts/aggregate-release-notes.js
@@ -1,0 +1,99 @@
+/**
+ * Builds the body for an aggregated GitHub release from the CHANGELOG.md of
+ * every package that was just published, mirroring the output of the old
+ * `createGithubReleases: aggregate` mode from dotansimha/changesets-action.
+ *
+ * Usage:
+ *   node scripts/aggregate-release-notes.mjs '<published-packages JSON>' > notes.md
+ *
+ * `published-packages` is the output of changesets/action:
+ *   [{ "name": "@digdir/designsystemet-react", "version": "1.20.1" }, ...]
+ */
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const PACKAGE_DIRS = ['packages'];
+
+async function findPackageDirs() {
+  const byName = new Map();
+  for (const base of PACKAGE_DIRS) {
+    let entries = [];
+    try {
+      entries = await fs.readdir(path.join(ROOT, base));
+    } catch {}
+    for (const entry of entries) {
+      const dir = path.join(ROOT, base, entry);
+      try {
+        const pkg = JSON.parse(
+          await fs.readFile(path.join(dir, 'package.json'), 'utf8'),
+        );
+        if (pkg.name) byName.set(pkg.name, dir);
+      } catch {}
+    }
+  }
+  return byName;
+}
+
+/** Returns the markdown under the `## <version>` heading, without the heading itself. */
+function extractVersionSection(changelog, version) {
+  const lines = changelog.split('\n');
+  const start = lines.findIndex((line) => line.trim() === `## ${version}`);
+  if (start === -1) return null;
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^## /.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  return lines
+    .slice(start + 1, end)
+    .join('\n')
+    .trim();
+}
+
+async function main() {
+  const raw = process.argv[2] ?? '';
+  let published = [];
+  try {
+    published = JSON.parse(raw || '[]');
+  } catch {
+    console.error('Could not parse published packages JSON:', raw);
+    process.exit(1);
+  }
+  if (!Array.isArray(published) || published.length === 0) {
+    console.error('No published packages given.');
+    process.exit(1);
+  }
+
+  const dirs = await findPackageDirs();
+  const sections = [];
+
+  for (const { name, version } of [...published].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  )) {
+    const dir = dirs.get(name);
+    let body = null;
+    if (dir) {
+      try {
+        body = extractVersionSection(
+          await fs.readFile(path.join(dir, 'CHANGELOG.md'), 'utf8'),
+          version,
+        );
+      } catch {}
+    }
+    if (body === null) {
+      console.error(`Warning: no changelog entry found for ${name}@${version}`);
+      body = '_No changelog entry found._';
+    }
+    sections.push(`## ${name}@${version}\n\n${body}`);
+  }
+
+  process.stdout.write(`${sections.join('\n\n')}\n`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/sync-changelogs.js
+++ b/scripts/sync-changelogs.js
@@ -1,6 +1,6 @@
 /**
  * Builds the consolidated changelog for www from the CHANGELOG.md of every
- * package. Aggregation lives in scripts/aggregate-release-notes.js; this file
+ * package. Aggregation lives in scripts/aggregate-changelogs.js; this file
  * only formats the result as MDX and writes it.
  */
 import { promises as fs } from 'node:fs';
@@ -8,7 +8,7 @@ import path from 'node:path';
 import {
   aggregateChangelogs,
   findPackages,
-} from './aggregate-release-notes.js';
+} from './aggregate-changelogs.js';
 
 const ROOT = process.cwd();
 const WWW = path.join(ROOT, 'apps/www/app/content/components-docs');

--- a/scripts/sync-changelogs.js
+++ b/scripts/sync-changelogs.js
@@ -1,126 +1,54 @@
+/**
+ * Builds the consolidated changelog for www from the CHANGELOG.md of every
+ * package. Aggregation lives in scripts/aggregate-release-notes.js; this file
+ * only formats the result as MDX and writes it.
+ */
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import {
+  aggregateChangelogs,
+  findPackages,
+} from './aggregate-release-notes.js';
 
 const ROOT = process.cwd();
 const WWW = path.join(ROOT, 'apps/www/app/content/components-docs');
 
-async function findPackages() {
-  const dirs = ['packages'].map((p) => path.join(ROOT, p));
-  const out = [];
-  for (const d of dirs) {
-    let entries = [];
-    try {
-      entries = await fs.readdir(d);
-    } catch {}
-    for (const name of entries) {
-      const dir = path.join(d, name);
-      try {
-        const pkg = JSON.parse(
-          await fs.readFile(path.join(dir, 'package.json'), 'utf8'),
-        );
-        out.push({ name: pkg.name, dir, version: pkg.version });
-      } catch {}
-    }
-  }
-  return out;
-}
+// Stop at "## 0.101.0" - this is the first entry before version 1
+const CUTOFF_VERSION = '0.101.0';
 
-function parseChangelog(content, packageName) {
-  // Truncate content at "## 0.101.0" - This is the first entry after version 1
-  const cutoffIndex = content.indexOf('## 0.101.0');
-  if (cutoffIndex !== -1) {
-    content = content.substring(0, cutoffIndex);
-  }
-
-  // Remove "# Change Log" header
-  const cleaned = content.replace(/^#\s+Change Log\s*\n*/i, '');
-
-  // Split by version headers (## X.Y.Z)
-  const versionRegex = /^##\s+(\d+\.\d+\.\d+)/gm;
-  const versions = new Map();
-
-  const matches = [];
-  let match = versionRegex.exec(cleaned);
-  while (match !== null) {
-    matches.push({ version: match[1], index: match.index });
-    match = versionRegex.exec(cleaned);
-  }
-
-  // Extract content for each version
-  for (let i = 0; i < matches.length; i++) {
-    const { version, index } = matches[i];
-    const nextIndex =
-      i < matches.length - 1 ? matches[i + 1].index : cleaned.length;
-    let content = cleaned
-      .substring(index, nextIndex)
-      .replace(/^##\s+\d+\.\d+\.\d+\s*\n*/, '')
-      .trim();
-
-    // Adjust heading levels: ### (h3) -> #### (h4)
-    content = content.replace(/^###\s+/gm, '#### ');
-
-    if (!versions.has(version)) {
-      versions.set(version, new Map());
-    }
-    versions.get(version).set(packageName, content);
-  }
-
-  return versions;
-}
-
-async function main() {
-  await fs.mkdir(WWW, { recursive: true });
-  const pkgs = await findPackages();
-
-  // Collect all changelogs and parse them
-  const allVersions = new Map();
-
-  for (const pkg of pkgs) {
-    const src = path.join(pkg.dir, 'CHANGELOG.md');
-    try {
-      const md = await fs.readFile(src, 'utf8');
-      const versions = parseChangelog(md, pkg.name);
-
-      // Merge versions into allVersions
-      for (const [version, packages] of versions) {
-        if (!allVersions.has(version)) {
-          allVersions.set(version, new Map());
-        }
-        for (const [pkgName, content] of packages) {
-          allVersions.get(version).set(pkgName, content);
-        }
-      }
-    } catch {
-      // skip
-    }
-  }
-
-  // Build consolidated changelog
-  let consolidatedContent = '';
-  for (const version of Array.from(allVersions.keys())) {
-    consolidatedContent += `<div style={{
+function formatVersion(version, packages) {
+  let out = `<div style={{
   border: "1px solid var(--ds-color-neutral-border-subtle)",
   borderRadius: "var(--ds-border-radius-md)",
   padding: "var(--ds-size-5)",
   marginBottom: "var(--ds-size-4)"
   }}
 >\n\n## ${version}\n\n`;
-    const packages = allVersions.get(version);
 
-    for (const [pkgName, content] of packages) {
-      if (content) {
-        consolidatedContent += `<Divider/>\n\n### ${pkgName}\n\n${content}\n\n`;
-      }
-    }
-
-    consolidatedContent += `</div>\n\n`;
+  for (const [pkgName, body] of packages) {
+    if (!body) continue;
+    // Adjust heading levels: ### (h3) -> #### (h4)
+    const content = body.replace(/^###\s+/gm, '#### ');
+    out += `<Divider/>\n\n### ${pkgName}\n\n${content}\n\n`;
   }
 
-  // Get latest version
+  return `${out}</div>\n\n`;
+}
+
+async function main() {
+  await fs.mkdir(WWW, { recursive: true });
+  const pkgs = [...(await findPackages()).values()];
+  const allVersions = await aggregateChangelogs(pkgs, {
+    until: CUTOFF_VERSION,
+  });
+
+  let consolidatedContent = '';
+  for (const [version, packages] of allVersions) {
+    consolidatedContent += formatVersion(version, packages);
+  }
+
   const latestVersion = pkgs[0]?.version;
 
-  // Write consolidated changelog
-  const dst = path.join(WWW, 'changelog.mdx');
   const content = `---
 title: "Changelog"
 latestVersion: ${latestVersion}
@@ -128,8 +56,9 @@ latestVersion: ${latestVersion}
 
 ${consolidatedContent}`;
 
-  await fs.writeFile(dst, content, 'utf8');
+  await fs.writeFile(path.join(WWW, 'changelog.mdx'), content, 'utf8');
 }
+
 main().catch((e) => {
   console.error(e);
   process.exit(1);


### PR DESCRIPTION
Due to updated `@changesets/cli` in #5243 the forked `changesets-action` that created an aggregated release would probably fail due to api changes in v3.

- Replaced forked `changesets-action`(not updated for 3 years+) with official version.
- New script for generating our own aggregated release notes and create a github release (+ tag) with said notes.
- Disabled tags for individual packages and only set one for the repo as a whole, which is linked to our release notes (like today).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>