### PR TITLE
chore: use "type": "module" in root

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "root",
   "version": "0.0.0",
+  "type": "module",
   "private": true,
   "packageManager": "pnpm@10.34.5+sha512.a4ee05f2f73658255bd6a89859c065a45c28a57daefae2c893a168ee2b73168c37b91e83e57ea67654ad03f03031746430e8bce38e362e042605fb8abc80192e",
   "engines": {


### PR DESCRIPTION
when working with `scripts`or other js files not in packages/apps, tooling gets confused sometimes (or want to make mjs files).

Set it so all tools use esm modules and we don't have to use `.mjs`. Also making sure `scripts` files are treated as esm modules