### PR TITLE
fix(css): make sure `icon-size` follows `data-size` by default

### DIFF
--- a/.changeset/happy-bikes-sneeze.md
+++ b/.changeset/happy-bikes-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@digdir/designsystemet-css": patch
+---
+
+fix default icon scaling not following sizing defined by `data-size`. (Thanks @Svish)

--- a/packages/css/src/base.css
+++ b/packages/css/src/base.css
@@ -252,5 +252,7 @@ body {
 
 /* Recalculate font-size variable when changing size mode */
 [data-size] {
+  --ds-icon-size: var(--ds-size-6);
+
   font-size: var(--ds-body-md-font-size);
 }


### PR DESCRIPTION
Reported in by slack: https://designsystemet.slack.com/archives/C05RK9VEGJ0/p1787818362255529

Since `--ds-icon-size` is declared on `:root` it does not change depending on `data-size` (variables on `:root` are immutable).

Re-declare `--ds-icon-size` so that it follows new `--ds-size` values mutated by `data-size`.