### PR TITLE
ci: replace conventional-pr action

### DIFF
--- a/.github/actions/conventional-pr/action.yml
+++ b/.github/actions/conventional-pr/action.yml
@@ -24,4 +24,6 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         COMMIT_TITLE_MATCH: ${{ inputs.commit-title-match }}
         IGNORE_COMMITS: ${{ inputs.ignore-commits }}
+        # Empty unless the workflow was triggered by a pull_request event.
+        PR_NUMBER: ${{ github.event.pull_request.number }}
       run: node "${{ github.action_path }}/lint-pr.mjs"

--- a/.github/actions/conventional-pr/action.yml
+++ b/.github/actions/conventional-pr/action.yml
@@ -1,0 +1,27 @@
+name: Conventional pull request
+description: >
+  Checks that the pull request title (and, for single-commit PRs, the commit message)
+  follows the Conventional Commits spec, using the rules of @commitlint/config-conventional.
+inputs:
+  github-token:
+    description: Token used to read the pull request and its commits
+    required: false
+    default: ${{ github.token }}
+  commit-title-match:
+    description: For PRs with a single commit, require the commit subject to equal the PR title
+    required: false
+    default: 'true'
+  ignore-commits:
+    description: Only lint the PR title, never the commits (use when squash merging with the PR title)
+    required: false
+    default: 'false'
+runs:
+  using: composite
+  steps:
+    - name: Lint pull request
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        COMMIT_TITLE_MATCH: ${{ inputs.commit-title-match }}
+        IGNORE_COMMITS: ${{ inputs.ignore-commits }}
+      run: node "${{ github.action_path }}/lint-pr.mjs"

--- a/.github/actions/conventional-pr/lint-header.mjs
+++ b/.github/actions/conventional-pr/lint-header.mjs
@@ -1,0 +1,117 @@
+// Lints a commit header (or PR title) against the header rules of
+// @commitlint/config-conventional. Dependency-free so the action needs no install step.
+//
+// Rules replicated (all errors): type-empty, type-enum, type-case, subject-empty,
+// subject-full-stop, subject-case (never sentence/start/pascal/upper), header-max-length,
+// header-trim. Body and footer rules do not apply to a single header line.
+
+export const TYPES = [
+  'build',
+  'chore',
+  'ci',
+  'docs',
+  'feat',
+  'fix',
+  'perf',
+  'refactor',
+  'revert',
+  'style',
+  'test',
+];
+
+export const HEADER_MAX_LENGTH = 100;
+
+// Same pattern as conventional-changelog-conventionalcommits.
+const HEADER_PATTERN = /^(\w*)(?:\((.*)\))?!?: (.*)$/;
+
+export function parseHeader(header) {
+  const match = HEADER_PATTERN.exec(header);
+  if (!match) {
+    return { type: null, scope: null, subject: null };
+  }
+  const [, type, scope, subject] = match;
+  return { type: type || null, scope: scope ?? null, subject: subject || null };
+}
+
+/** Returns a list of error messages; empty when the header is valid. */
+export function lintHeader(header) {
+  const errors = [];
+  const { type, subject } = parseHeader(header);
+
+  if (header !== header.trim()) {
+    errors.push('header must not have initial and / or trailing whitespaces');
+  }
+  if (header.length > HEADER_MAX_LENGTH) {
+    errors.push(
+      `header must not be longer than ${HEADER_MAX_LENGTH} characters, current length is ${header.length}`,
+    );
+  }
+
+  if (!type) {
+    errors.push('type may not be empty');
+  } else {
+    if (type !== type.toLowerCase()) {
+      errors.push('type must be lower-case');
+    }
+    if (!TYPES.includes(type.toLowerCase())) {
+      errors.push(`type must be one of [${TYPES.join(', ')}]`);
+    }
+  }
+
+  if (!subject) {
+    errors.push('subject may not be empty');
+  } else {
+    if (subject.endsWith('.')) {
+      errors.push('subject may not end with full stop');
+    }
+    const cases = matchedSubjectCases(subject);
+    if (cases.length > 0) {
+      errors.push(`subject must not be ${cases.join(', ')}`);
+    }
+  }
+
+  return errors;
+}
+
+// Mirrors commitlint's subject-case rule with `never` for the four cases below.
+// Like commitlint it only applies when the subject starts with a letter, ignores
+// quoted content (proper names), and skips subjects that then start with a digit.
+export function matchedSubjectCases(subject) {
+  if (!/^[\p{Ll}\p{Lu}\p{Lt}]/u.test(subject)) {
+    return [];
+  }
+  const input = subject.replace(/`.*?`|".*?"|'.*?'/g, '').trim();
+  if (input === '' || /^\d/.test(input)) {
+    return [];
+  }
+
+  const matched = [];
+  if (upperFirst(input) === input) matched.push('sentence-case');
+  if (startCase(input) === input) matched.push('start-case');
+  if (upperFirst(camelCase(input)) === input) matched.push('pascal-case');
+  if (input.toUpperCase() === input) matched.push('upper-case');
+  return matched;
+}
+
+function upperFirst(text) {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+// Word splitting close to lodash's, which commitlint uses via es-toolkit/compat.
+function words(text) {
+  return (
+    text.match(/[A-Z]{2,}(?=[A-Z][a-z]+\d*|\b)|[A-Z]?[a-z]+\d*|[A-Z]|\d+/g) ?? []
+  );
+}
+
+function startCase(text) {
+  return words(text).map(upperFirst).join(' ');
+}
+
+function camelCase(text) {
+  return words(text)
+    .map((word, index) =>
+      index === 0 ? word.toLowerCase() : upperFirst(word.toLowerCase()),
+    )
+    .join('');
+}

--- a/.github/actions/conventional-pr/lint-header.test.mjs
+++ b/.github/actions/conventional-pr/lint-header.test.mjs
@@ -1,0 +1,83 @@
+// Run with: node --test .github/actions/conventional-pr/lint-header.test.mjs
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { lintHeader, matchedSubjectCases, parseHeader } from './lint-header.mjs';
+
+describe('parseHeader', () => {
+  it('extracts type, scope and subject', () => {
+    assert.deepEqual(parseHeader('fix(css): make icon-size follow data-size'), {
+      type: 'fix',
+      scope: 'css',
+      subject: 'make icon-size follow data-size',
+    });
+  });
+
+  it('accepts the breaking-change marker', () => {
+    assert.equal(parseHeader('feat!: drop node 20').type, 'feat');
+  });
+
+  it('returns nulls when the header is not conventional', () => {
+    assert.deepEqual(parseHeader('Update readme'), { type: null, scope: null, subject: null });
+  });
+});
+
+describe('lintHeader', () => {
+  const valid = [
+    'chore: have all Node.js runtime updates in one PR',
+    'chore(deps): update node.js to v24.20.0',
+    'fix(css): make sure `icon-size` follows `data-size` by default',
+    'docs(button): fix type',
+    'feat!: remove deprecated api',
+    'refactor(cli): `Eslint` configuration',
+  ];
+  for (const header of valid) {
+    it(`accepts "${header}"`, () => assert.deepEqual(lintHeader(header), []));
+  }
+
+  it('rejects an unknown type', () => {
+    assert.match(lintHeader('feature: add thing').join(), /type must be one of/);
+  });
+
+  it('rejects an upper-case type', () => {
+    assert.match(lintHeader('Fix: add thing').join(), /type must be lower-case/);
+  });
+
+  it('rejects a missing type and subject', () => {
+    const errors = lintHeader('Update readme');
+    assert.match(errors.join(), /type may not be empty/);
+    assert.match(errors.join(), /subject may not be empty/);
+  });
+
+  it('rejects a subject ending with a full stop', () => {
+    assert.match(lintHeader('fix: add thing.').join(), /full stop/);
+  });
+
+  it('rejects a sentence-case subject', () => {
+    assert.match(lintHeader('fix: Add thing').join(), /subject must not be sentence-case/);
+  });
+
+  it('rejects a header over 100 characters', () => {
+    assert.match(lintHeader(`fix: ${'a'.repeat(100)}`).join(), /longer than 100/);
+  });
+
+  it('rejects surrounding whitespace', () => {
+    assert.match(lintHeader(' fix: add thing').join(), /whitespaces/);
+  });
+});
+
+describe('matchedSubjectCases', () => {
+  it('ignores subjects that start with a non-letter', () => {
+    assert.deepEqual(matchedSubjectCases('`Eslint` config'), []);
+    assert.deepEqual(matchedSubjectCases('123 Things'), []);
+  });
+
+  it('ignores quoted proper names', () => {
+    assert.deepEqual(matchedSubjectCases('use "Inter" as default font'), []);
+  });
+
+  it('reports every case that matches', () => {
+    assert.deepEqual(matchedSubjectCases('Add Thing'), ['sentence-case', 'start-case']);
+    assert.deepEqual(matchedSubjectCases('ADD THING'), ['sentence-case', 'start-case', 'upper-case']);
+    assert.deepEqual(matchedSubjectCases('AddThing'), ['sentence-case', 'pascal-case']);
+  });
+});

--- a/.github/actions/conventional-pr/lint-pr.mjs
+++ b/.github/actions/conventional-pr/lint-pr.mjs
@@ -1,0 +1,80 @@
+// Entry point of the conventional-pr action. Behaviour follows
+// CondeNast/conventional-pull-request-action: with a single commit (and unless
+// IGNORE_COMMITS) the commit subject is linted and must equal the PR title, since GitHub
+// pre-fills the merge message from it. Otherwise the PR title is linted.
+import { readFileSync } from 'node:fs';
+import { lintHeader } from './lint-header.mjs';
+
+const isTrue = (value) => String(value ?? '').toLowerCase() === 'true';
+
+const token = process.env.GITHUB_TOKEN;
+const commitTitleMatch = isTrue(process.env.COMMIT_TITLE_MATCH ?? 'true');
+const ignoreCommits = isTrue(process.env.IGNORE_COMMITS ?? 'false');
+
+const event = JSON.parse(readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
+if (!event.pull_request) {
+  fail('Pull request not found. Use a pull_request event to trigger this action.');
+  process.exit(1);
+}
+
+const repository = process.env.GITHUB_REPOSITORY;
+const number = event.pull_request.number;
+
+const pullRequest = await api(`/repos/${repository}/pulls/${number}`);
+console.log(`Found PR title: ${pullRequest.title}`);
+
+let failed = false;
+
+if (!ignoreCommits && pullRequest.commits <= 1) {
+  const [first] = await api(`/repos/${repository}/pulls/${number}/commits?per_page=1`);
+  const subject = first.commit.message.split('\n')[0];
+  console.log(`Found commit subject: ${subject}`);
+
+  const errors = lintHeader(subject);
+  for (const message of errors) error(`Commit message: ${message}`);
+  if (errors.length > 0) {
+    fail(
+      'COMMIT: PRs with a single commit require the commit message to conform to the conventional commit spec',
+    );
+    failed = true;
+  }
+
+  if (commitTitleMatch && pullRequest.title !== subject) {
+    fail('COMMIT: PRs with a single commit require the PR title and commit message to match');
+    failed = true;
+  }
+} else {
+  const errors = lintHeader(pullRequest.title);
+  for (const message of errors) error(`PR title: ${message}`);
+  if (errors.length > 0) {
+    fail('PULL REQUEST: PR title does not conform to the conventional commit spec');
+    failed = true;
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}
+console.log('Pull request follows the conventional commit spec.');
+
+async function api(path) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`GitHub API ${path} failed: ${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}
+
+// Workflow commands: annotate the run and mark it failed.
+function error(message) {
+  console.log(`::error::${message}`);
+}
+function fail(message) {
+  console.log(`::error::${message}`);
+}

--- a/.github/actions/conventional-pr/lint-pr.mjs
+++ b/.github/actions/conventional-pr/lint-pr.mjs
@@ -2,7 +2,6 @@
 // CondeNast/conventional-pull-request-action: with a single commit (and unless
 // IGNORE_COMMITS) the commit subject is linted and must equal the PR title, since GitHub
 // pre-fills the merge message from it. Otherwise the PR title is linted.
-import { readFileSync } from 'node:fs';
 import { lintHeader } from './lint-header.mjs';
 
 const isTrue = (value) => String(value ?? '').toLowerCase() === 'true';
@@ -11,14 +10,15 @@ const token = process.env.GITHUB_TOKEN;
 const commitTitleMatch = isTrue(process.env.COMMIT_TITLE_MATCH ?? 'true');
 const ignoreCommits = isTrue(process.env.IGNORE_COMMITS ?? 'false');
 
-const event = JSON.parse(readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
-if (!event.pull_request) {
+// The PR number comes from the workflow context via action.yml rather than from the
+// event payload file, and is validated before it is used in a request URL.
+const number = process.env.PR_NUMBER ?? '';
+if (!/^[1-9]\d*$/.test(number)) {
   fail('Pull request not found. Use a pull_request event to trigger this action.');
   process.exit(1);
 }
 
 const repository = process.env.GITHUB_REPOSITORY;
-const number = event.pull_request.number;
 
 const pullRequest = await api(`/repos/${repository}/pulls/${number}`);
 console.log(`Found PR title: ${pullRequest.title}`);

--- a/.github/workflows/check-conventional-pr.yml
+++ b/.github/workflows/check-conventional-pr.yml
@@ -19,7 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # check for the most recent release: https://github.com/CondeNast/conventional-pull-request-action/releases
-      - uses: CondeNast/conventional-pull-request-action@3ce30fdb4d2beef8b941f23a1114dd8188eba082 # v0.2.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/conventional-pr
+        with:
+          ignore-commits: "true"


### PR DESCRIPTION
We use a third part action for checking conventional pr titles. Its nice to have for readability of the commit log. Since its just simple string parsing and checking, I asked claude to make us a simple replacement.